### PR TITLE
make use of ngettext to properly handle plurals

### DIFF
--- a/po/vocal.pot
+++ b/po/vocal.pot
@@ -3,13 +3,13 @@
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
-#: ../src/Widgets/PodcastView.vala:768
+#: ../src/Widgets/PodcastView.vala:806
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-07-08 22:21-0400\n"
+"POT-Creation-Date: 2016-10-09 18:22+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,183 +17,220 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
 
-#: ../src/MainWindow.vala:294 ../src/Widgets/DirectoryView.vala:63
+#: ../src/Library.vala:163
+msgid "Unable to add podcast"
+msgstr ""
+
+#: ../src/Library.vala:762
+msgid "'%s' from '%s' has finished downloading."
+msgstr ""
+
+#: ../src/Library.vala:763
+msgid "Episode Download Complete"
+msgstr ""
+
+#: ../src/Library.vala:769
+msgid "Downloads Complete"
+msgstr ""
+
+#: ../src/Library.vala:769
+msgid "New episodes have been downloaded."
+msgstr ""
+
+#: ../src/Utils/FeedParser.vala:359
+msgid "Selected file doesn't appear to contain podcast subscriptions."
+msgstr ""
+
+#: ../src/Utils/FeedParser.vala:370
+msgid "Selected file seems to be empty."
+msgstr ""
+
+#: ../src/MainWindow.vala:302 ../src/Widgets/DirectoryView.vala:63
 #: ../src/Widgets/DirectoryView.vala:79
 #: ../src/Widgets/SearchResultsView.vala:59
 msgid "Return to Library"
 msgstr ""
 
-#: ../src/MainWindow.vala:624
+#: ../src/MainWindow.vala:632
 msgid "Welcome to Vocal"
 msgstr ""
 
-#: ../src/MainWindow.vala:624
+#: ../src/MainWindow.vala:632
 msgid "Build Your Library By Adding Podcasts"
 msgstr ""
 
-#: ../src/MainWindow.vala:625
+#: ../src/MainWindow.vala:633
 msgid "Browse Podcasts"
 msgstr ""
 
-#: ../src/MainWindow.vala:626
+#: ../src/MainWindow.vala:634
 msgid "Browse through podcasts and choose some to add to your library."
 msgstr ""
 
-#: ../src/MainWindow.vala:627
+#: ../src/MainWindow.vala:635
 msgid "Add a New Feed"
 msgstr ""
 
-#: ../src/MainWindow.vala:627
+#: ../src/MainWindow.vala:635
 msgid "Provide the web address of a podcast feed."
 msgstr ""
 
-#: ../src/MainWindow.vala:628
+#: ../src/MainWindow.vala:636
 msgid "Import Subscriptions"
 msgstr ""
 
-#: ../src/MainWindow.vala:629
+#: ../src/MainWindow.vala:637
 msgid ""
 "If you have exported feeds from another podcast manager, import them here."
 msgstr ""
 
-#: ../src/MainWindow.vala:630
+#: ../src/MainWindow.vala:638
 msgid "Check Out the Vocal Starter Pack…"
 msgstr ""
 
-#: ../src/MainWindow.vala:630
+#: ../src/MainWindow.vala:638
 msgid ""
 "New to podcasting? Check out our starter pack. Select individual podcasts, "
 "or download the entire pack."
 msgstr ""
 
-#: ../src/MainWindow.vala:680
+#: ../src/MainWindow.vala:689
 msgid "Good Stuff is On Its Way"
 msgstr ""
 
-#: ../src/MainWindow.vala:681
+#: ../src/MainWindow.vala:690
 msgid ""
 "If you are importing several podcasts it can take a few minutes. Your "
 "library will be ready shortly."
 msgstr ""
 
-#: ../src/MainWindow.vala:693
+#: ../src/MainWindow.vala:702
 msgid "Welcome"
 msgstr ""
 
-#: ../src/MainWindow.vala:694
+#: ../src/MainWindow.vala:703
 msgid "Importing"
 msgstr ""
 
-#: ../src/MainWindow.vala:695
+#: ../src/MainWindow.vala:704
 msgid "All Podcasts"
 msgstr ""
 
-#: ../src/MainWindow.vala:696 ../src/Widgets/DirectoryArt.vala:69
+#: ../src/MainWindow.vala:705 ../src/Widgets/DirectoryArt.vala:69
 msgid "Details"
 msgstr ""
 
-#: ../src/MainWindow.vala:697
+#: ../src/MainWindow.vala:706
 msgid "Video"
 msgstr ""
 
-#: ../src/MainWindow.vala:711
+#: ../src/MainWindow.vala:720
 msgid "Browse Podcast Directory"
 msgstr ""
 
-#: ../src/MainWindow.vala:712
+#: ../src/MainWindow.vala:721
 msgid "Search Results"
 msgstr ""
 
-#: ../src/MainWindow.vala:973 ../src/MainWindow.vala:977
-#: ../src/Widgets/Toolbar.vala:187 ../src/Widgets/VideoControls.vala:40
-#: ../src/Widgets/EpisodeDetailBox.vala:116
-#: ../src/Widgets/EpisodeDetailBox.vala:294
-msgid "Play"
-msgstr ""
-
-#: ../src/MainWindow.vala:1009 ../src/MainWindow.vala:1013
+#: ../src/MainWindow.vala:1011 ../src/MainWindow.vala:1015
 msgid "Pause"
 msgstr ""
 
-#: ../src/MainWindow.vala:1160 ../src/MainWindow.vala:1199
+#: ../src/MainWindow.vala:1038 ../src/MainWindow.vala:1042
+#: ../src/Widgets/VideoControls.vala:40
+#: ../src/Widgets/EpisodeDetailBox.vala:116
+#: ../src/Widgets/EpisodeDetailBox.vala:295 ../src/Widgets/Toolbar.vala:187
+msgid "Play"
+msgstr ""
+
+#: ../src/MainWindow.vala:1193 ../src/MainWindow.vala:1232
+#: ../src/Widgets/PodcastView.vala:764
 msgid "Cancel"
 msgstr ""
 
-#: ../src/MainWindow.vala:1161
+#: ../src/MainWindow.vala:1194
 msgid "Save"
 msgstr ""
 
-#: ../src/MainWindow.vala:1164 ../src/MainWindow.vala:1203
+#: ../src/MainWindow.vala:1197 ../src/MainWindow.vala:1236
+#: ../src/Widgets/PodcastView.vala:768
 msgid "All files"
 msgstr ""
 
-#: ../src/MainWindow.vala:1168
+#: ../src/MainWindow.vala:1201
 msgid "OPML and XML files"
 msgstr ""
 
-#: ../src/MainWindow.vala:1196
+#: ../src/MainWindow.vala:1229
 msgid "Select Subscription File"
 msgstr ""
 
-#: ../src/MainWindow.vala:1200
+#: ../src/MainWindow.vala:1233 ../src/Widgets/PodcastView.vala:765
 msgid "Open"
 msgstr ""
 
-#: ../src/MainWindow.vala:1207
+#: ../src/MainWindow.vala:1240
 msgid "OPML files"
 msgstr ""
 
-#: ../src/MainWindow.vala:1277
+#: ../src/MainWindow.vala:1315
+msgid ""
+"Please check that you selected the correct file and that it is not corrupted."
+msgstr ""
+
+#: ../src/MainWindow.vala:1317 ../src/MainWindow.vala:1565
+msgid ""
+"There seems to be a problem with your internet connection. Make sure you are "
+"online and then try again."
+msgstr ""
+
+#: ../src/MainWindow.vala:1322
 msgid "Error Importing from File"
 msgstr ""
 
-#: ../src/MainWindow.vala:1278
-msgid ""
-"Please check that you selected the correct file and that you are connected "
-"to the network."
-msgstr ""
-
-#: ../src/MainWindow.vala:1376
+#: ../src/MainWindow.vala:1421
 msgid ""
 "Additional plugins are needed to play media. Would you like for Vocal to "
 "install them for you?"
 msgstr ""
 
-#: ../src/MainWindow.vala:1451 ../src/MainWindow.vala:1453
+#: ../src/MainWindow.vala:1496 ../src/MainWindow.vala:1498
 msgid "Adding new podcast: <b>"
 msgstr ""
 
-#: ../src/MainWindow.vala:1510
+#: ../src/MainWindow.vala:1563
+msgid ""
+"Please make sure you selected the correct feed and that it is still "
+"available."
+msgstr ""
+
+#: ../src/MainWindow.vala:1570
 msgid "Error Adding Podcast"
 msgstr ""
 
-#: ../src/MainWindow.vala:1511
-msgid ""
-"Please check that the feed is correct and that you have a network connection."
-msgstr ""
-
-#: ../src/MainWindow.vala:1641
+#: ../src/MainWindow.vala:1704
 msgid "Are you sure you want to mark all episodes from '%s' as played?"
 msgstr ""
 
-#: ../src/MainWindow.vala:1926
+#: ../src/MainWindow.vala:1989
 msgid "Are you sure you want to remove '%s' from your library?"
 msgstr ""
 
-#: ../src/MainWindow.vala:1929
+#: ../src/MainWindow.vala:1992
 msgid "No"
 msgstr ""
 
-#: ../src/MainWindow.vala:1930
+#: ../src/MainWindow.vala:1993
 msgid "Yes"
 msgstr ""
 
-#: ../src/MainWindow.vala:2207
+#: ../src/MainWindow.vala:2290
 msgid "Fresh content has been added to your library."
 msgstr ""
 
-#: ../src/MainWindow.vala:2316
+#: ../src/MainWindow.vala:2399
 msgid ""
 "Vocal is currently downloading episodes. Exiting will cause the downloads to "
 "be canceled. Are you sure you want to exit?"
@@ -203,23 +240,81 @@ msgstr ""
 msgid "translator-credits"
 msgstr ""
 
-#: ../src/Utils/FeedParser.vala:345
-msgid "Selected file doesn't appear to contain podcast subscriptions."
+#: ../src/Widgets/PlaybackBox.vala:42
+msgid "<b>Select an episode to start playing...</b>"
 msgstr ""
 
-#: ../src/Utils/FeedParser.vala:356
-msgid "Selected file seems to be empty."
+#: ../src/Widgets/DirectoryView.vala:49
+msgid "iTunes Top 100 Podcasts"
+msgstr ""
+
+#: ../src/Widgets/DirectoryView.vala:60
+msgid "Go Back"
+msgstr ""
+
+#: ../src/Widgets/DirectoryView.vala:71
+msgid "Done"
+msgstr ""
+
+#: ../src/Widgets/DirectoryView.vala:105
+msgid "Loading iTunes Store"
+msgstr ""
+
+#: ../src/Widgets/DonateDialog.vala:35
+msgid "Donate to Vocal"
+msgstr ""
+
+#: ../src/Widgets/SearchResultBox.vala:126
+msgid "Summary"
+msgstr ""
+
+#: ../src/Widgets/SearchResultBox.vala:135 ../src/Widgets/DirectoryArt.vala:86
+msgid "No summary available."
+msgstr ""
+
+#: ../src/Widgets/SearchResultBox.vala:156
+msgid "Subscribe to podcast"
+msgstr ""
+
+#: ../src/Widgets/SearchResultsView.vala:69
+msgid "Search Results for <i>%s</i>"
+msgstr ""
+
+#: ../src/Widgets/SearchResultsView.vala:77
+#: ../src/Widgets/SearchResultsPopover.vala:167
+msgid "Episodes from Your Library"
+msgstr ""
+
+#: ../src/Widgets/SearchResultsView.vala:78
+#: ../src/Widgets/SearchResultsPopover.vala:168
+msgid "Podcasts from Your Library"
+msgstr ""
+
+#: ../src/Widgets/SearchResultsView.vala:79
+msgid "iTunes Podcast Results"
+msgstr ""
+
+#: ../src/Widgets/SearchResultsView.vala:124
+msgid "No matching podcasts found."
+msgstr ""
+
+#: ../src/Widgets/SearchResultsView.vala:142
+msgid "No matching episodes found."
+msgstr ""
+
+#: ../src/Widgets/SearchResultsView.vala:161
+msgid "Loading full iTunes results"
 msgstr ""
 
 #: ../src/Widgets/Sidepane.vala:89
 msgid "Mark all episodes as played"
 msgstr ""
 
-#: ../src/Widgets/Sidepane.vala:101 ../src/Widgets/PodcastView.vala:116
+#: ../src/Widgets/Sidepane.vala:101 ../src/Widgets/PodcastView.vala:118
 msgid "Download all episodes"
 msgstr ""
 
-#: ../src/Widgets/Sidepane.vala:109 ../src/Widgets/PodcastView.vala:122
+#: ../src/Widgets/Sidepane.vala:109 ../src/Widgets/PodcastView.vala:124
 msgid "Hide episodes that have already been played"
 msgstr ""
 
@@ -274,183 +369,57 @@ msgid "No episodes available."
 msgstr ""
 
 #: ../src/Widgets/Sidepane.vala:671
-msgid "%d episodes, %d unplayed"
-msgstr ""
+msgid "%d episode, %d unplayed"
+msgid_plural "%d episodes, %d unplayed"
+msgstr[0] ""
+msgstr[1] ""
 
 #: ../src/Widgets/Sidepane.vala:673
-msgid "%d episodes"
-msgstr ""
+msgid "%d episode"
+msgid_plural "%d episodes"
+msgstr[0] ""
+msgstr[1] ""
 
-#: ../src/Widgets/DirectoryArt.vala:89 ../src/Widgets/SearchResultBox.vala:134
-msgid "No summary available."
-msgstr ""
-
-#: ../src/Widgets/DirectoryArt.vala:96
+#: ../src/Widgets/DirectoryArt.vala:95
 msgid "Subscribe"
 msgstr ""
 
-#: ../src/Widgets/Toolbar.vala:83
-msgid "View show notes"
-msgstr ""
-
-#: ../src/Widgets/Toolbar.vala:90
-msgid "Coming up next"
-msgstr ""
-
-#: ../src/Widgets/Toolbar.vala:103
-msgid "Check for Updates"
-msgstr ""
-
-#: ../src/Widgets/Toolbar.vala:108
-msgid "Add Podcast Feed…"
-msgstr ""
-
-#: ../src/Widgets/Toolbar.vala:113
-msgid "Import Subcriptions…"
-msgstr ""
-
-#: ../src/Widgets/Toolbar.vala:118
-msgid "Export Subscriptions…"
-msgstr ""
-
-#: ../src/Widgets/Toolbar.vala:136 ../src/Widgets/SettingsDialog.vala:54
-msgid "Preferences"
-msgstr ""
-
-#: ../src/Widgets/Toolbar.vala:143
-msgid "Check Out The Vocal Starter Pack…"
-msgstr ""
-
-#: ../src/Widgets/Toolbar.vala:149
-msgid "Report a Problem…"
-msgstr ""
-
-#: ../src/Widgets/Toolbar.vala:157
-msgid "Donate…"
-msgstr ""
-
-#: ../src/Widgets/Toolbar.vala:193 ../src/Widgets/Toolbar.vala:205
-msgid "Fast forward %d seconds"
-msgstr ""
-
-#: ../src/Widgets/Toolbar.vala:199 ../src/Widgets/Toolbar.vala:206
-msgid "Rewind %d seconds"
-msgstr ""
-
-#: ../src/Widgets/Toolbar.vala:211
-msgid "Check for new episodes"
-msgstr ""
-
-#: ../src/Widgets/Toolbar.vala:220
-msgid "Search your library or online"
-msgstr ""
-
-#: ../src/Widgets/Toolbar.vala:231
-msgid "View the top podcasts in the iTunes Store"
-msgstr ""
-
-#: ../src/Widgets/Toolbar.vala:264
-msgid "Downloads"
+#: ../src/Widgets/VideoControls.vala:58
+msgid "Exit Fullscreen"
 msgstr ""
 
 #: ../src/Widgets/DownloadsPopover.vala:51
 msgid "No Active Downloads"
 msgstr ""
 
-#: ../src/Widgets/DirectoryView.vala:49
-msgid "iTunes Top 100 Podcasts"
-msgstr ""
-
-#: ../src/Widgets/DirectoryView.vala:60
-msgid "Go Back"
-msgstr ""
-
-#: ../src/Widgets/DirectoryView.vala:71
-msgid "Done"
-msgstr ""
-
-#: ../src/Widgets/DirectoryView.vala:105
-msgid "Loading iTunes Store"
-msgstr ""
-
-#: ../src/Widgets/SearchResultsView.vala:69
-msgid "Search Results for <i>%s</i>"
-msgstr ""
-
-#: ../src/Widgets/SearchResultsView.vala:77
-#: ../src/Widgets/SearchResultsPopover.vala:158
-msgid "Episodes from Your Library"
-msgstr ""
-
-#: ../src/Widgets/SearchResultsView.vala:78
-#: ../src/Widgets/SearchResultsPopover.vala:159
-msgid "Podcasts from Your Library"
-msgstr ""
-
-#: ../src/Widgets/SearchResultsView.vala:79
-msgid "iTunes Podcast Results"
-msgstr ""
-
-#: ../src/Widgets/SearchResultsView.vala:124
-msgid "No matching podcasts found."
-msgstr ""
-
-#: ../src/Widgets/SearchResultsView.vala:142
-msgid "No matching episodes found."
-msgstr ""
-
-#: ../src/Widgets/SearchResultsView.vala:161
-msgid "Loading full iTunes results"
-msgstr ""
-
-#: ../src/Widgets/PodcastView.vala:100
-msgid "Your Podcasts"
-msgstr ""
-
-#: ../src/Widgets/PodcastView.vala:105
-msgid "Mark All Played"
-msgstr ""
-
-#: ../src/Widgets/PodcastView.vala:136
-msgid "Edit podcast details"
-msgstr ""
-
-#: ../src/Widgets/PodcastView.vala:139
-msgid "Select different cover art"
-msgstr ""
-
-#: ../src/Widgets/PodcastView.vala:150
-msgid "Unsubscribe"
-msgstr ""
-
-#: ../src/Widgets/PodcastView.vala:448
-msgid "Are you sure you want to delete the downloaded episode '%s'?"
-msgstr ""
-
-#: ../src/Widgets/PodcastView.vala:581
-msgid "No show notes available."
-msgstr ""
-
-#: ../src/Widgets/PodcastView.vala:698
-msgid "Show more episodes"
-msgstr ""
-
-#: ../src/Widgets/PodcastView.vala:766
-msgid "%d unplayed episodes"
-msgstr ""
-
-#: ../src/Widgets/SearchResultsPopover.vala:160
+#: ../src/Widgets/SearchResultsPopover.vala:169
 msgid "%s Podcast Results"
 msgstr ""
 
-#: ../src/Widgets/SearchResultsPopover.vala:169
+#: ../src/Widgets/SearchResultsPopover.vala:178
 msgid "View All Results"
 msgstr ""
 
-#: ../src/Widgets/SearchResultsPopover.vala:186
-#: ../src/Widgets/SearchResultsPopover.vala:205
-#: ../src/Widgets/SearchResultsPopover.vala:224
+#: ../src/Widgets/SearchResultsPopover.vala:195
+#: ../src/Widgets/SearchResultsPopover.vala:214
+#: ../src/Widgets/SearchResultsPopover.vala:233
 msgid "No matches found."
+msgstr ""
+
+#: ../src/Widgets/AddFeedDialog.vala:42
+msgid "Add New Podcast"
+msgstr ""
+
+#: ../src/Widgets/AddFeedDialog.vala:53
+msgid "<b>Add a new podcast feed to the library</b>"
+msgstr ""
+
+#: ../src/Widgets/AddFeedDialog.vala:58
+msgid "Podcast feed web address"
+msgstr ""
+
+#: ../src/Widgets/SettingsDialog.vala:54 ../src/Widgets/Toolbar.vala:136
+msgid "Preferences"
 msgstr ""
 
 #: ../src/Widgets/SettingsDialog.vala:68
@@ -481,90 +450,6 @@ msgstr ""
 msgid "Close"
 msgstr ""
 
-#: ../src/Widgets/DownloadDetailBox.vala:112
-msgid "Cancel Download"
-msgstr ""
-
-#: ../src/Widgets/DownloadDetailBox.vala:189
-msgid "minute"
-msgstr ""
-
-#: ../src/Widgets/DownloadDetailBox.vala:191
-msgid "minutes"
-msgstr ""
-
-#: ../src/Widgets/DownloadDetailBox.vala:196
-msgid "second"
-msgstr ""
-
-#: ../src/Widgets/DownloadDetailBox.vala:198
-msgid "seconds"
-msgstr ""
-
-#: ../src/Widgets/AddFeedDialog.vala:42
-msgid "Add New Podcast"
-msgstr ""
-
-#: ../src/Widgets/AddFeedDialog.vala:53
-msgid "<b>Add a new podcast feed to the library</b>"
-msgstr ""
-
-#: ../src/Widgets/AddFeedDialog.vala:58
-msgid "Podcast feed web address"
-msgstr ""
-
-#: ../src/Widgets/SearchResultBox.vala:125
-msgid "Summary"
-msgstr ""
-
-#: ../src/Widgets/SearchResultBox.vala:155
-msgid "Subscribe to podcast"
-msgstr ""
-
-#: ../src/Widgets/PlaybackBox.vala:42
-msgid "<b>Select an episode to start playing...</b>"
-msgstr ""
-
-#: ../src/Widgets/DonateDialog.vala:35
-msgid "Donate to Vocal"
-msgstr ""
-
-#: ../src/Widgets/VideoControls.vala:58
-msgid "Exit Fullscreen"
-msgstr ""
-
-#: ../src/Widgets/Shownotes.vala:52
-msgid "Mark this episode as played"
-msgstr ""
-
-#: ../src/Widgets/Shownotes.vala:57
-msgid "Download episode"
-msgstr ""
-
-#: ../src/Widgets/Shownotes.vala:62
-msgid "Share this episode"
-msgstr ""
-
-#: ../src/Widgets/Shownotes.vala:92
-msgid "Add this episode to the up next list"
-msgstr ""
-
-#: ../src/Widgets/Shownotes.vala:100
-msgid "<b>Summary</b>"
-msgstr ""
-
-#: ../src/Widgets/QueueRow.vala:36
-msgid "Move episode up in queue"
-msgstr ""
-
-#: ../src/Widgets/QueueRow.vala:39
-msgid "Move episode down in queue"
-msgstr ""
-
-#: ../src/Widgets/QueueRow.vala:64
-msgid "Remove episode from queue"
-msgstr ""
-
 #: ../src/Widgets/CloudLoginDialog.vala:44
 msgid "Login to gPodder.net"
 msgstr ""
@@ -585,12 +470,44 @@ msgstr ""
 msgid "Register for gPodder.net"
 msgstr ""
 
+#: ../src/Widgets/QueueRow.vala:36
+msgid "Move episode up in queue"
+msgstr ""
+
+#: ../src/Widgets/QueueRow.vala:39
+msgid "Move episode down in queue"
+msgstr ""
+
+#: ../src/Widgets/QueueRow.vala:64
+msgid "Remove episode from queue"
+msgstr ""
+
+#: ../src/Widgets/DownloadDetailBox.vala:112
+msgid "Cancel Download"
+msgstr ""
+
+#: ../src/Widgets/DownloadDetailBox.vala:189
+msgid "minute"
+msgstr ""
+
+#: ../src/Widgets/DownloadDetailBox.vala:191
+msgid "minutes"
+msgstr ""
+
+#: ../src/Widgets/DownloadDetailBox.vala:196
+msgid "second"
+msgstr ""
+
+#: ../src/Widgets/DownloadDetailBox.vala:198
+msgid "seconds"
+msgstr ""
+
 #: ../src/Widgets/EpisodeDetailBox.vala:86
 msgid "This episode is currently being played"
 msgstr ""
 
 #: ../src/Widgets/EpisodeDetailBox.vala:118
-#: ../src/Widgets/EpisodeDetailBox.vala:297
+#: ../src/Widgets/EpisodeDetailBox.vala:298
 msgid "Stream Episode"
 msgstr ""
 
@@ -598,26 +515,136 @@ msgstr ""
 msgid "Download Episode"
 msgstr ""
 
-#: ../src/Widgets/EpisodeDetailBox.vala:169
+#: ../src/Widgets/EpisodeDetailBox.vala:170
 msgid "No description available."
 msgstr ""
 
-#: ../src/Library.vala:163
-msgid "Unable to add podcast"
+#: ../src/Widgets/Shownotes.vala:54
+msgid "Mark this episode as played"
 msgstr ""
 
-#: ../src/Library.vala:756
-msgid "'%s' from '%s' has finished downloading."
+#: ../src/Widgets/Shownotes.vala:59
+msgid "Download episode"
 msgstr ""
 
-#: ../src/Library.vala:757
-msgid "Episode Download Complete"
+#: ../src/Widgets/Shownotes.vala:64
+msgid "Share this episode"
 msgstr ""
 
-#: ../src/Library.vala:763
-msgid "Downloads Complete"
+#: ../src/Widgets/Shownotes.vala:96
+msgid "Add this episode to the up next list"
 msgstr ""
 
-#: ../src/Library.vala:763
-msgid "New episodes have been downloaded."
+#: ../src/Widgets/Shownotes.vala:104
+msgid "<b>Summary</b>"
+msgstr ""
+
+#: ../src/Widgets/PodcastView.vala:102
+msgid "Your Podcasts"
+msgstr ""
+
+#: ../src/Widgets/PodcastView.vala:107
+msgid "Mark All Played"
+msgstr ""
+
+#: ../src/Widgets/PodcastView.vala:138
+msgid "Edit podcast details"
+msgstr ""
+
+#: ../src/Widgets/PodcastView.vala:141
+msgid "Select different cover art"
+msgstr ""
+
+#: ../src/Widgets/PodcastView.vala:150
+msgid "Unsubscribe"
+msgstr ""
+
+#: ../src/Widgets/PodcastView.vala:448
+msgid "Are you sure you want to delete the downloaded episode '%s'?"
+msgstr ""
+
+#: ../src/Widgets/PodcastView.vala:581
+msgid "No show notes available."
+msgstr ""
+
+#: ../src/Widgets/PodcastView.vala:698
+msgid "Show more episodes"
+msgstr ""
+
+#: ../src/Widgets/PodcastView.vala:761
+msgid "Select Album Art"
+msgstr ""
+
+#: ../src/Widgets/PodcastView.vala:772
+msgid "Image Files"
+msgstr ""
+
+#: ../src/Widgets/PodcastView.vala:804
+msgid "%d unplayed episode"
+msgid_plural "%d unplayed episodes"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../src/Widgets/Toolbar.vala:83
+msgid "View show notes"
+msgstr ""
+
+#: ../src/Widgets/Toolbar.vala:90
+msgid "Coming up next"
+msgstr ""
+
+#: ../src/Widgets/Toolbar.vala:103
+msgid "Check for Updates"
+msgstr ""
+
+#: ../src/Widgets/Toolbar.vala:108
+msgid "Add Podcast Feed…"
+msgstr ""
+
+#: ../src/Widgets/Toolbar.vala:113
+msgid "Import Subcriptions…"
+msgstr ""
+
+#: ../src/Widgets/Toolbar.vala:118
+msgid "Export Subscriptions…"
+msgstr ""
+
+#: ../src/Widgets/Toolbar.vala:143
+msgid "Check Out The Vocal Starter Pack…"
+msgstr ""
+
+#: ../src/Widgets/Toolbar.vala:149
+msgid "Report a Problem…"
+msgstr ""
+
+#: ../src/Widgets/Toolbar.vala:157
+msgid "Donate…"
+msgstr ""
+
+#: ../src/Widgets/Toolbar.vala:193 ../src/Widgets/Toolbar.vala:205
+msgid "Fast forward %d second"
+msgid_plural "Fast forward %d seconds"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../src/Widgets/Toolbar.vala:199 ../src/Widgets/Toolbar.vala:206
+msgid "Rewind %d second"
+msgid_plural "Rewind %d seconds"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../src/Widgets/Toolbar.vala:211
+msgid "Check for new episodes"
+msgstr ""
+
+#: ../src/Widgets/Toolbar.vala:220
+msgid "Search your library or online"
+msgstr ""
+
+#: ../src/Widgets/Toolbar.vala:231
+msgid "View the top podcasts in the iTunes Store"
+msgstr ""
+
+#: ../src/Widgets/Toolbar.vala:264
+msgid "Downloads"
 msgstr ""

--- a/src/Widgets/PodcastView.vala
+++ b/src/Widgets/PodcastView.vala
@@ -801,7 +801,7 @@ namespace Vocal {
         public void set_unplayed_text() {
             string count_string = null;
             if(unplayed_count > 0) {
-                count_string = _("%d unplayed episodes".printf(unplayed_count));
+                count_string = ngettext("%d unplayed episode", "%d unplayed episodes", unplayed_count).printf(unplayed_count);
             } else {
                 count_string = _("");
             }

--- a/src/Widgets/Sidepane.vala
+++ b/src/Widgets/Sidepane.vala
@@ -668,9 +668,9 @@ namespace Vocal {
         public void set_unplayed_text() {
             string count_string = null;
             if(unplayed_count > 0) {
-                count_string = _("%d episodes, %d unplayed".printf(podcast.episodes.size, unplayed_count));
+                count_string = ngettext("%d episode, %d unplayed", "%d episodes, %d unplayed", podcast.episodes.size).printf(podcast.episodes.size, unplayed_count));
             } else {
-                count_string = _("%d episodes".printf(podcast.episodes.size));
+                count_string = ngettext("%d episode", "%d episodes", podcast.episodes.size).printf(podcast.episodes.size));
             }
             count_label.set_text(count_string);
         }

--- a/src/Widgets/Toolbar.vala
+++ b/src/Widgets/Toolbar.vala
@@ -190,20 +190,20 @@ namespace Vocal {
             forward = new Gtk.Button();
             forward.image = forward_image;
             forward.has_tooltip = true;
-            forward.tooltip_text = _("Fast forward %d seconds".printf(this.settings.fast_forward_seconds));
+            forward.tooltip_text = ngettext("Fast forward %d second", "Fast forward %d seconds", this.settings.fast_forward_seconds).printf(this.settings.fast_forward_seconds);
 
             var backward_image = new Gtk.Image.from_icon_name("media-seek-backward-symbolic", Gtk.IconSize.LARGE_TOOLBAR);
             backward = new Gtk.Button();
             backward.image = backward_image;
             backward.has_tooltip = true;
-            backward.tooltip_text = _("Rewind %d seconds".printf(this.settings.rewind_seconds));
+            backward.tooltip_text = ngettext("Rewind %d second", "Rewind %d seconds", this.settings.rewind_seconds).printf(this.settings.rewind_seconds);
 
 			play_pause.get_style_context().add_class("vocal-headerbar-button");
 
             // Connect the changed signal for settings to update the tooltips
             this.settings.changed.connect(() => {
-                forward.tooltip_text = _("Fast forward %d seconds".printf(this.settings.fast_forward_seconds));
-                backward.tooltip_text = _("Rewind %d seconds".printf(this.settings.rewind_seconds));
+                forward.tooltip_text = ngettext("Fast forward %d second", "Fast forward %d seconds", this.settings.fast_forward_seconds).printf(this.settings.fast_forward_seconds);
+                backward.tooltip_text = ngettext("Rewind %d second", "Rewind %d seconds", this.settings.rewind_seconds).printf(this.settings.rewind_seconds);
             });
 
             refresh = new Gtk.Button.from_icon_name("view-refresh-symbolic", Gtk.IconSize.LARGE_TOOLBAR);


### PR DESCRIPTION
`ngettext` should be used instead of `gettext` (or `_`) to properly handle plurals. I also refreshed the `vocal.pot` file with a `make pot`.
