### PR TITLE
Fix crash when unsubscribing from feeds with certain format chars in title.

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -1938,10 +1938,9 @@ namespace Vocal {
          */
         private void on_remove_request() {
             if(highlighted_podcast != null) {
-                Gtk.MessageDialog msg = new Gtk.MessageDialog (this, Gtk.DialogFlags.MODAL, Gtk.MessageType.WARNING,
-                                                               Gtk.ButtonsType.NONE, null);
-                msg.set_markup(_("Are you sure you want to remove '%s' from your library?"
-                                 .printf(highlighted_podcast.name.replace("%27", "'"))));
+                Gtk.MessageDialog msg = new Gtk.MessageDialog (this, Gtk.DialogFlags.MODAL, Gtk.MessageType.WARNING, Gtk.ButtonsType.NONE,
+                                                               _("Are you sure you want to remove '%s' from your library?"),
+                                                               highlighted_podcast.name.replace("%27", "'"));
 
 
                 msg.add_button (_("No"), Gtk.ResponseType.NO);

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -1938,8 +1938,10 @@ namespace Vocal {
          */
         private void on_remove_request() {
             if(highlighted_podcast != null) {
-                Gtk.MessageDialog msg = new Gtk.MessageDialog (this, Gtk.DialogFlags.MODAL, Gtk.MessageType.WARNING, Gtk.ButtonsType.NONE,
-                     _("Are you sure you want to remove '%s' from your library?".printf(highlighted_podcast.name.replace("%27", "'"))));
+                Gtk.MessageDialog msg = new Gtk.MessageDialog (this, Gtk.DialogFlags.MODAL, Gtk.MessageType.WARNING,
+                                                               Gtk.ButtonsType.NONE, null);
+                msg.set_markup(_("Are you sure you want to remove '%s' from your library?"
+                                 .printf(highlighted_podcast.name.replace("%27", "'"))));
 
 
                 msg.add_button (_("No"), Gtk.ResponseType.NO);


### PR DESCRIPTION
This commit should fix issue #201 .

When setting the message of a `Gtk.MessageDialog` in the constructor a [`printf`](https://valadoc.org/glib-2.0/GLib.FileStream.printf.html) style format string is expected. If the text contains certain '%' style format escapes with no values an error occurs. 

~~This commit works around this issue by using the `set_markup()` method instead, which expects a "Pango" markup string instead.~~ * see below