### PR TITLE
Added search entry autofocus to SearchResultsView.vala

### DIFF
--- a/src/Widgets/SearchResultsView.vala
+++ b/src/Widgets/SearchResultsView.vala
@@ -110,6 +110,7 @@ namespace Vocal {
             search_entry.activate.connect (() => {
                 this.search_term = search_entry.text;
                 title_label.label = _("Search Results for <i>%s</i>".printf(search_term));
+		search_entry.grab_focus_without_selecting ();
                 reset ();
                 load_from_itunes ();
                 load_local_results ();

--- a/src/Widgets/SearchResultsView.vala
+++ b/src/Widgets/SearchResultsView.vala
@@ -110,7 +110,7 @@ namespace Vocal {
             search_entry.activate.connect (() => {
                 this.search_term = search_entry.text;
                 title_label.label = _("Search Results for <i>%s</i>".printf(search_term));
-		  search_entry.grab_focus_without_selecting ();
+		search_entry.grab_focus_without_selecting ();
                 reset ();
                 load_from_itunes ();
                 load_local_results ();

--- a/src/Widgets/SearchResultsView.vala
+++ b/src/Widgets/SearchResultsView.vala
@@ -110,7 +110,7 @@ namespace Vocal {
             search_entry.activate.connect (() => {
                 this.search_term = search_entry.text;
                 title_label.label = _("Search Results for <i>%s</i>".printf(search_term));
-		search_entry.grab_focus_without_selecting ();
+		  search_entry.grab_focus_without_selecting ();
                 reset ();
                 load_from_itunes ();
                 load_local_results ();


### PR DESCRIPTION
I'm using  `grab_focus_without_selecting()` to add focus to `search_entry` when search button in the header bar is clicked and the search pane is shown (https://valadoc.org/gtk+-3.0/Gtk.Entry.grab_focus_without_selecting.html). To select existing text in the entry, `grab_focus()` may also be used (if that gives better UX). Read on grab_focus here https://valadoc.org/gtk+-3.0/Gtk.Widget.grab_focus.html