### PR TITLE
Use fixed width progress bar for imports. Use GLib for logging.

### DIFF
--- a/src/Library.vala
+++ b/src/Library.vala
@@ -135,10 +135,8 @@ namespace Vocal {
                     }
 
                 } catch (Error e) {
-                    info("Error parsing OPML file.");
-                    info(e.message);
+                    info("Error parsing OPML file. %s\n", e.message);
                     successful = false;
-
                 }
 
 
@@ -199,14 +197,14 @@ namespace Vocal {
                 }
 
             } catch(Error e) {
-                stderr.puts("Unable to save a local copy of the album art.\n");
+                error("Unable to save a local copy of the album art. %s\n", e.message);                
             }
 
 
             // Open the database
             int ec = Sqlite.Database.open (db_location, out db);
 	        if (ec != Sqlite.OK) {
-		        stderr.printf ("Can't open database: %d: %s\n", db.errcode (), db.errmsg ());
+		        error("Can't open database: %d: %s\n", db.errcode (), db.errmsg ());
 		        return false;
 	        }
 
@@ -246,7 +244,7 @@ namespace Vocal {
 
             ec = db.exec (query, null, out errmsg);
 	        if (ec != Sqlite.OK) {
-		        stderr.printf ("Error: %s\n", errmsg);
+		        error("Error: %s\n", errmsg);
 		        return false;
 	        }
 
@@ -281,10 +279,9 @@ namespace Vocal {
 
                 ec = db.exec (query, null, out errmsg);
                 if (ec != Sqlite.OK) {
-                    stderr.printf ("Error: %s\n", errmsg);
+                    error ("Error: %s\n", errmsg);
                 }
             }
-
 
 	        return true;
 
@@ -530,7 +527,7 @@ namespace Vocal {
                         try {
                             local_file.delete();
                         } catch(Error e) {
-                            stderr.puts("Unable to delete file.\n");
+                            error ("Unable to delete file.\n");
                         }
                     }
 
@@ -545,6 +542,7 @@ namespace Vocal {
 
 
             } catch (Error e) {
+                error("Error occurered downloading episode %s\n", e.message);
             }
 
             if(batch_download_count > 0) {
@@ -726,7 +724,7 @@ namespace Vocal {
             ec = db.exec (query, null, out errmsg);
 
             if (ec != Sqlite.OK) {
-                stderr.printf ("Error: %s\n", errmsg);
+                error ("Error: %s\n", errmsg);
             }
         }
 
@@ -845,7 +843,7 @@ namespace Vocal {
             // Open a database:
             int ec = Sqlite.Database.open (db_location, out db);
             if (ec != Sqlite.OK) {
-	            stderr.printf ("Can't open database: %d: %s\n", db.errcode (), db.errmsg ());
+	            error ("Can't open database: %d: %s\n", db.errcode (), db.errmsg ());
 	            return -1;
             }
 
@@ -939,7 +937,7 @@ namespace Vocal {
 	            prepared_query_str = "SELECT * FROM Episode WHERE parent_podcast_name = '%s' ORDER BY rowid ASC".printf(p.name);
 	            ec = db.prepare_v2 (prepared_query_str, prepared_query_str.length, out stmt);
 	            if (ec != Sqlite.OK) {
-		            stderr.printf ("Error: %d: %s\n", db.errcode (), db.errmsg ());
+		            error ("Error: %d: %s\n", db.errcode (), db.errmsg ());
 		            return;
 	            }
 
@@ -1163,7 +1161,7 @@ namespace Vocal {
 
 	        ec = db.exec (query, null, out errmsg);
 	        if (ec != Sqlite.OK) {
-		        stderr.printf ("Error: %d: %s\n", db.errcode (), db.errmsg ());
+		        error ("Error: %d: %s\n", db.errcode (), db.errmsg ());
 		        return;
 	        }
 
@@ -1172,7 +1170,7 @@ namespace Vocal {
             ec = db.exec (query, null, out errmsg);
 
             if (ec != Sqlite.OK) {
-                stderr.printf ("Error: %s\n", errmsg);
+                error ("Error: %s\n", errmsg);
             }
 
             // Remove the local object as well
@@ -1262,7 +1260,7 @@ namespace Vocal {
             ec = db.exec (query, null, out errmsg);
 
             if (ec != Sqlite.OK) {
-                stderr.printf ("Error: %s\n", errmsg);
+                error ("Error: %s\n", errmsg);
             }
         }
 
@@ -1318,7 +1316,7 @@ namespace Vocal {
             ec = db.exec (query, null, out errmsg);
 
             if (ec != Sqlite.OK) {
-                stderr.printf ("Error: %s\n", errmsg);
+                error ("Error: %s\n", errmsg);
             }
             
             // Set the new file location for the podcast object
@@ -1357,7 +1355,7 @@ namespace Vocal {
 
             int ec = Sqlite.Database.open(db_location, out db);
             if(ec != Sqlite.OK) {
-                stderr.printf("Unable to create database at %s\n", db_location);
+                error("Unable to create database at %s\n", db_location);
                 return false;
             } else {
                 string query = """
@@ -1388,7 +1386,7 @@ namespace Vocal {
 		            """;
 	            ec = db.exec (query, null, out error_message);
 	            if(ec != Sqlite.OK) {
-	                stderr.printf("Unable to execute query at %s\n", db_location);
+	                error("Unable to execute query at %s\n", db_location);
                 }
                 return true;
             }
@@ -1435,7 +1433,7 @@ namespace Vocal {
             ec = db.exec (query, null, out errmsg);
 
             if (ec != Sqlite.OK) {
-                stderr.printf ("Error: %s\n", errmsg);
+                error ("Error: %s\n", errmsg);
             }
         }
     }

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -523,7 +523,7 @@ namespace Vocal {
 
             // box is just a generic container that will hold everything else (Gtk.Window can only directly hold a single child)
             box = new Gtk.Box (Gtk.Orientation.VERTICAL, 0);
-
+            
             // Add everything to window
             this.add (box);
             this.set_titlebar(toolbar);
@@ -538,7 +538,7 @@ namespace Vocal {
                     toolbar.hide_downloads_menuitem();
             });
             downloads.all_downloads_complete.connect(toolbar.hide_downloads_menuitem);
-
+            
             // Create the queue popover
             queue_popover = new QueuePopover(toolbar.playlist_button);
             library.queue_changed.connect(() => {
@@ -557,14 +557,14 @@ namespace Vocal {
                 library.update_queue(oldPos, newPos);
                 queue_popover.show_all();
             });
-
+            
             queue_popover.remove_episode.connect((e) => {
                 library.remove_episode_from_queue(e);
                 queue_popover.show_all();
             });
             queue_popover.play_episode_from_queue_immediately.connect(play_episode_from_queue_immediately);
             toolbar.playlist_button.clicked.connect(() => { queue_popover.show_all(); });
-
+            
             // Set up all the toolbar signals
             toolbar.check_for_updates_selected.connect(() => {
                 on_update_request();
@@ -600,7 +600,7 @@ namespace Vocal {
 
             toolbar.export_selected.connect(export_podcasts);
             toolbar.downloads_selected.connect(show_downloads_popover);
-
+            
             setup_library_widgets();
         }
 
@@ -611,7 +611,7 @@ namespace Vocal {
          * that is NOT the first run).
          */
         private void setup_library_widgets() {
-
+            
             // Create a welcome screen and add it to the notebook (no matter if first run or not)
             welcome = new Granite.Widgets.Welcome (_("Welcome to Vocal"), _("Build Your Library By Adding Podcasts"));
             welcome.append(on_elementary ? "preferences-desktop-online-accounts" : "applications-internet", _("Browse Podcasts"),
@@ -697,7 +697,7 @@ namespace Vocal {
                 switch_visible_page(welcome);
             });
             directory_scrolled.add(directory);
-
+            
             // Add the remaining widgets to the notebook. At this point, the gang's all here
             notebook.add_titled(directory_scrolled, "directory", _("Browse Podcast Directory"));
             notebook.add_titled(search_results_scrolled, "search", _("Search Results"));
@@ -709,25 +709,25 @@ namespace Vocal {
             // Add the thinpaned to the box
             box.pack_start(library_box, true, true, 0);
             current_widget = notebook;
-
+            
             // Create the search box
-            search_results_view = new SearchResultsView(library);
+            search_results_view = new SearchResultsView(library);            
             search_results_view.on_new_subscription.connect(on_new_subscription);
             search_results_view.return_to_library.connect(() => {
                 switch_visible_page(previous_widget);
             });
             search_results_view.episode_selected.connect(on_search_popover_episode_selected);
             search_results_view.podcast_selected.connect(on_search_popover_podcast_selected);
-
+            
             search_results_box.add(search_results_view);
 
             show_all();
 
             // Show the welcome widget if it's the first run, or if the library is empty
-            if(first_run || library_empty) {
+            if(first_run || library_empty) {            
                 switch_visible_page(welcome);
                 show_all();
-
+                
             } else {
                 // Populate the IconViews from the library
                 populate_views();
@@ -766,13 +766,12 @@ namespace Vocal {
 
             		currently_repopulating = true;
     	            bool has_video = false;
-
+                    
                     // If it's not the first run or newly launched go ahead and remove all the widgets from the flowboxes
                     if(!first_run && !newly_launched) {
-        	            for(int i = 0; i < all_art.size; i++)
-        	            {
+        	            for(int i = 0; i < all_art.size; i++) {
         	            	all_flowbox.remove(all_flowbox.get_child_at_index(0));
-        	            }
+                        }
 
                         all_art.clear();
                     }
@@ -855,7 +854,7 @@ namespace Vocal {
 	                        has_video = true;
 	                    }
 
-                        CoverArt a = new CoverArt(podcast.coverart_uri.replace("%27", "'"), podcast, true);
+                        CoverArt a = new CoverArt(podcast.coverart_uri, podcast, true);
                         a.get_style_context().add_class("coverart");
                         a.halign = Gtk.Align.START;
 
@@ -893,7 +892,7 @@ namespace Vocal {
             Thread.create<void*>(run, false);
 
             yield;
-
+            
             foreach(CoverArt a in all_art) {
                 all_flowbox.add(a);
             }
@@ -1060,7 +1059,7 @@ namespace Vocal {
             int index = details.current_episode_index;
             current_episode = details.podcast.episodes[index];
 
-            stdout.puts("settings state\n");
+            info("settings state\n");
 
             player.pause();
             play();
@@ -1281,9 +1280,10 @@ namespace Vocal {
                         var add_err_dialog = new Gtk.MessageDialog(add_feed,
                             Gtk.DialogFlags.MODAL,Gtk.MessageType.ERROR,
                             Gtk.ButtonsType.OK, "");
-                            add_err_dialog.response.connect((response_id) => {
-                                add_err_dialog.destroy();
-                            });
+
+                        add_err_dialog.response.connect((response_id) => {
+                            add_err_dialog.destroy();
+                        });
                             
                         // Determine if it was a network issue, or just a problem with the feed
                         
@@ -2300,7 +2300,7 @@ namespace Vocal {
 
             // Save the playback position
             if(player.current_episode != null) {
-                stdout.printf("Setting the last played position to %s\n", player.current_episode.last_played_position.to_string());
+                info("Setting the last played position to %s\n", player.current_episode.last_played_position.to_string());
                 if(player.current_episode.last_played_position != 0)
                     library.set_episode_playback_position(player.current_episode);
             }

--- a/src/Objects/Podcast.vala
+++ b/src/Objects/Podcast.vala
@@ -39,17 +39,14 @@ namespace Vocal {
 
             //the album art is saved locally, return that path. Otherwise, return main album art URI
             get {
-
-                if(local_art_uri != null) {
+                if(local_art_uri != null && local_art_uri != "(null)") {
                     GLib.File local_art = GLib.File.new_for_uri(local_art_uri);
                     if(local_art.query_exists()) {
                         return local_art_uri;
                     }
                 } else if(remote_art_uri != null) {
                     GLib.File remote_art = GLib.File.new_for_path(remote_art_uri);
-                    if(remote_art.query_exists()) {
-                        return remote_art_uri;
-                    }
+                    return remote_art_uri;
                 }
                 // In rare instances where album art is not available at all, provide a "missing art" image to use
                 // in library view
@@ -61,9 +58,9 @@ namespace Vocal {
 		        string[] split = value.split(":");
 		        if(split[0] == "http" || split[0] == "HTTP") {
 		            remote_art_uri = value.replace("%27", "'");
-            } else {
-                local_art_uri = """file://""" + value.replace("%27", "'");
-            }
+                } else {
+                    local_art_uri = """file://""" + value.replace("%27", "'");
+                }
 		    }
 		}
 		

--- a/src/Utils/iTunesProvider.vala
+++ b/src/Utils/iTunesProvider.vala
@@ -49,7 +49,7 @@ namespace Vocal {
                 var root_object = parser.get_root ().get_object ();
 
                 if(root_object == null) {
-                    stdout.puts("Error. Root object was null.");
+                    error("Error. Root object was null.");
                     return null;
                 }
 
@@ -91,7 +91,7 @@ namespace Vocal {
                 var root_object = parser.get_root ().get_object ();
 
                 if(root_object == null) {
-                    stdout.puts("Error. Root object was null.");
+                    error("Error. Root object was null.");
                     return null;
                 }
 
@@ -169,7 +169,7 @@ namespace Vocal {
                 var root_object = parser.get_root ().get_object ();
 
                 if(root_object == null) {
-                    stdout.puts("Error. Root object was null.");
+                    error("Error. Root object was null.");
                     return null;
                 }
 

--- a/src/Vocal.vala
+++ b/src/Vocal.vala
@@ -113,14 +113,14 @@ namespace Vocal {
             // Initialize GtkClutter
             var err = GtkClutter.init (ref args);
             if (err != Clutter.InitError.SUCCESS) {
-                stdout.puts("Could not initialize clutter gtk\n");
+                error ("Could not initialize clutter gtk\n");
                 error ("Could not initalize clutter! "+err.to_string ());
             }
 
             // Initialize Clutter
             err = Clutter.init (ref args);
             if (err != Clutter.InitError.SUCCESS) {
-                stdout.puts("Could not initialize clutter.\n");
+                error ("Could not initialize clutter.\n");
                 error ("Could not initalize clutter! "+err.to_string ());
             }
 

--- a/src/Widgets/CoverArt.vala
+++ b/src/Widgets/CoverArt.vala
@@ -48,32 +48,31 @@ namespace Vocal {
 		 * Constructor for CoverArt given an image path and a podcast
 		 */
 		public CoverArt(string path, Podcast podcast, bool? show_mimetype = false) {
-
+			
 			this.podcast = podcast;
 			this.margin = 10;
 			this.orientation = Gtk.Orientation.VERTICAL;
 
 			try {
-
 				// Load the actual cover art
 				File cover_file = GLib.File.new_for_uri(path.replace("%27", "'"));
 				assert(cover_file != null);
 				bool exists = cover_file.query_exists();
-				if(!exists)
-				{
-					info("Coverart at %s doesn't exist.".printf(path.replace("%27", "'")));
+				if(!exists)	{
+					info("Coverart at %s doesn't exist.", path.replace("%27", "'"));
 				}
-	            InputStream input_stream = cover_file.read();
-	            var coverart_pixbuf = create_cover_image (input_stream);
-	            image = new Gtk.Image.from_pixbuf(coverart_pixbuf);
 
-	            // Load the banner to be drawn on top of the cover art
-                File triangle_file = GLib.File.new_for_path(GLib.Path.build_filename (Constants.PKGDATADIR, "banner.png"));
-	            InputStream triangle_input_stream = triangle_file.read();
-	            var triangle_pixbuf = new Gdk.Pixbuf.from_stream_at_scale(triangle_input_stream, 75, 75, true);
-	            triangle = new Gtk.Image.from_pixbuf(triangle_pixbuf);
+				InputStream input_stream = cover_file.read();
+				var coverart_pixbuf = create_cover_image (input_stream);
+				image = new Gtk.Image.from_pixbuf(coverart_pixbuf);
 
-	            // Align everything to the top right corner
+				// Load the banner to be drawn on top of the cover art
+				File triangle_file = GLib.File.new_for_path(GLib.Path.build_filename (Constants.PKGDATADIR, "banner.png"));
+				InputStream triangle_input_stream = triangle_file.read();
+				var triangle_pixbuf = new Gdk.Pixbuf.from_stream_at_scale(triangle_input_stream, 75, 75, true);
+				triangle = new Gtk.Image.from_pixbuf(triangle_pixbuf);
+
+	      // Align everything to the top right corner
 				triangle.set_alignment(1, 0);
 				image.set_alignment(1,0);
 
@@ -85,7 +84,7 @@ namespace Vocal {
 				triangle_overlay.add(image);
 
 			} catch (Error e) {
-				critical("Unable to load podcast cover art.");
+				critical("Unable to load podcast cover art. %s\n", e.message);
 			}
 
 			if(triangle_overlay == null)

--- a/src/Widgets/DownloadDetailBox.vala
+++ b/src/Widgets/DownloadDetailBox.vala
@@ -32,10 +32,10 @@ namespace Vocal {
 
         public signal void new_percentage_available();		// Fired when a new download percentage is available
 
-        public Gtk.Image	 	image {private get; private set;}
+        public Gtk.Image	 	image;
         public Gdk.Pixbuf		image_pixbuf{ get; set; }
-        public Gtk.Label 	 	title_label {private get; private set;}
-        public Gtk.Label	 	podcast_label {private get; private set;}
+        public Gtk.Label 	 	title_label;
+        public Gtk.Label	 	podcast_label;
         public Gtk.ProgressBar  progress_bar;
         public Gtk.Label 		download_label;
 

--- a/src/Widgets/PlaybackBox.vala
+++ b/src/Widgets/PlaybackBox.vala
@@ -37,14 +37,11 @@ namespace Vocal {
         public PlaybackBox () {
 
             this.get_style_context().add_class("seek-bar");
-            
-            this.width_request  = 300;
             this.info_label = new Gtk.Label(_("<b>Select an episode to start playing…</b>"));
             this.info_label.set_use_markup(true);
             this.info_label.width_chars = 20;
             this.info_label.set_ellipsize(Pango.EllipsizeMode.END);
             this.info_label.margin_top = 12;
-
             this.progress_bar = new Gtk.ProgressBar();
             
             scale = new Gtk.Scale.with_range (Gtk.Orientation.HORIZONTAL, 0, 1, 1000);
@@ -71,6 +68,14 @@ namespace Vocal {
             // Add the components to the box
             this.add(info_label);
             this.add(scale_grid);
+        }
+
+        public override void get_preferred_width (out int minimum_width, out int natural_width) {
+            base.get_preferred_width (out minimum_width, out natural_width);
+            minimum_width = 300;
+            if (natural_width < 600) {
+                natural_width = 600;
+            }
         }
         
         /*

--- a/src/Widgets/QueuePopover.vala
+++ b/src/Widgets/QueuePopover.vala
@@ -53,7 +53,9 @@ namespace Vocal {
 		 * Sets the current queue
 		 */
 		public void set_queue(Gee.ArrayList<Episode> queue) {
-			scrolled_box.remove(episodes);
+			if(episodes != null) {
+				scrolled_box.remove(episodes);
+			}
 
 			if(queue.size > 0) {
 				hide_label();

--- a/src/Widgets/SearchResultsView.vala
+++ b/src/Widgets/SearchResultsView.vala
@@ -123,7 +123,6 @@ namespace Vocal {
             // Create the lists container
             content_box = new Gtk.Box(Gtk.Orientation.VERTICAL, 10);
             var scrolled = new Gtk.ScrolledWindow(null, null);
-            content_box.add(title_label);
             scrolled.add(content_box);
             this.add(scrolled);
 

--- a/src/Widgets/Toolbar.vala
+++ b/src/Widgets/Toolbar.vala
@@ -63,27 +63,18 @@ namespace Vocal {
 
 			this.settings = settings;
 
-			// Create the box that will be used for the title in the headerbar
-            headerbar_box = new Gtk.Box(Gtk.Orientation.HORIZONTAL, 10);
-
-            // Create the box to be shown during playback
-            playback_box = new PlaybackBox();
-
-            // Set the playback box in the middle of the HeaderBar
-	        playback_box.hexpand = true;
-
             // Create the show notes button
-		    if(on_elementary)
+		    if(on_elementary) {
 	            shownotes_button = new Gtk.Button.from_icon_name("help-info-symbolic", Gtk.IconSize.SMALL_TOOLBAR);
-		    else
-	     		shownotes_button = new Gtk.Button.from_icon_name("dialog-information-symbolic", Gtk.IconSize.SMALL_TOOLBAR);
+            } else {
+                 shownotes_button = new Gtk.Button.from_icon_name("dialog-information-symbolic", Gtk.IconSize.SMALL_TOOLBAR);
+            }
             shownotes_button.tooltip_text = _("View show notes");
             shownotes_button.valign = Gtk.Align.CENTER;
             shownotes_button.clicked.connect(() => {
                 shownotes_selected();
             });
             shownotes_button.relief = Gtk.ReliefStyle.NONE;
-
 
             playlist_button = new Gtk.Button.from_icon_name("media-playlist-consecutive-symbolic");
             playlist_button.tooltip_text = _("Coming up next");
@@ -93,11 +84,16 @@ namespace Vocal {
             playlist_button.relief = Gtk.ReliefStyle.NONE;
             playlist_button.valign = Gtk.Align.CENTER;
 
+            // Create the box to be shown during playback
+            playback_box = new PlaybackBox();
+            
+            // Create the box that will be used for the title in the headerbar
+            headerbar_box = new Gtk.Box(Gtk.Orientation.HORIZONTAL, 10);
             headerbar_box.add(shownotes_button);
             headerbar_box.add(playback_box);
             headerbar_box.add(playlist_button);
             headerbar_box.halign = Gtk.Align.CENTER;
-
+            headerbar_box.hexpand = true;
 
             // Create the menus and menuitems
             menu = new Gtk.Menu ();
@@ -146,7 +142,9 @@ namespace Vocal {
             report_problem.activate.connect (() => {
                 try {
                     Gtk.show_uri (null, "https://github.com/needle-and-thread/vocal/issues", 0);
-                } catch (Error error) {}
+                } catch (Error e) {
+                    error("Error occured %s\n", e.message);
+                }
             });
             menu.add(report_problem);
 
@@ -154,7 +152,9 @@ namespace Vocal {
             donate.activate.connect (() => {
                 try {
                     Gtk.show_uri (null, "http://needleandthread.co/apps/vocal", 0);
-                } catch (Error error) {}
+                } catch (Error e) {
+                    error("Error occured %s\n", e.message);
+                }
             });
             //menu.add(donate);
 
@@ -266,9 +266,9 @@ namespace Vocal {
 
 
             Gtk.Image download_image;
-            if(on_elementary)
+            if(on_elementary) {
                 download_image = new Gtk.Image.from_icon_name("browser-download-symbolic", on_elementary ? Gtk.IconSize.LARGE_TOOLBAR : Gtk.IconSize.SMALL_TOOLBAR);
-            else {
+            } else {
                 download_image = new Gtk.Image.from_icon_name("document-save-symbolic", on_elementary ? Gtk.IconSize.LARGE_TOOLBAR : Gtk.IconSize.SMALL_TOOLBAR);
             }
             download = new Gtk.Button();


### PR DESCRIPTION
Fixes #48 and #229. Also use GLib for logging instead of stdout. makes it easier to find where errors are happening. Finally, also gets rid of the warnings in the format `[WARNING 17:19:11.854670] [GLib-GObject] g_object_notify: object class 'VocalDownloadDetailBox' has no property named image`