### PR TITLE
Minor Gtk error fixes.

### DIFF
--- a/src/Widgets/PodcastView.vala
+++ b/src/Widgets/PodcastView.vala
@@ -662,7 +662,10 @@ namespace Vocal {
                 remove(scrolled);
             }
 
-            paned.remove(scrolled);
+            if ( scrolled != null ) {
+                paned.remove(scrolled);
+            }
+
             scrolled = new Gtk.ScrolledWindow (null, null);
             listbox = new Gtk.ListBox();
             listbox.activate_on_single_click = false;

--- a/src/Widgets/QueuePopover.vala
+++ b/src/Widgets/QueuePopover.vala
@@ -53,7 +53,10 @@ namespace Vocal {
 		 * Sets the current queue
 		 */
 		public void set_queue(Gee.ArrayList<Episode> queue) {
-			scrolled_box.remove(episodes);
+
+			if (episodes != null) {
+				scrolled_box.remove(episodes);
+			}
 
 			if(queue.size > 0) {
 				hide_label();


### PR DESCRIPTION
These are minor fixes, but very helpful when attempting to debug other issues with `G_DEBUG=fatal-criticals`. Fixes the following error messages:

* `[FATAL 10:20:46.276264] [Gtk] gtk_container_remove: assertion 'GTK_IS_WIDGET (widget)' failed`
Don't attempt to remove the `episodes` queue list in `QueuePopover.vala` when null (during initial creation).

* `[FATAL 10:34:48.041190] [Gtk] gtk_container_remove: assertion 'GTK_IS_WIDGET (widget)' failed`
Don't attempt to remove null `scrolled` from PodcastView
