### PR TITLE
Fix misc. null errors on Episode and Podcast string properties.

### DIFF
--- a/src/Objects/Episode.vala
+++ b/src/Objects/Episode.vala
@@ -21,19 +21,19 @@ using GLib;
 
 namespace Vocal {
 
-    public class Episode {
+	public class Episode {
 
-        public string			title;        			// the title of the episode
-        public string			description;			// the description/shownotes
-        public string			uri;					// the remote location for the media file
-        public string			local_uri;				// the local location for the media file, if any
-        public double 			last_played_position;	// the latest position that has been played
-        public string 			date_released;			// when the episode was released, in string form
-        public EpisodeStatus	status;					// whether the episode is played or unplayed
-        public DownloadStatus	current_download_status;// whether the episode is downloaded or not downloaded
+		public string           title = "";              // the title of the episode
+		public string           description = "";        // the description/shownotes
+		public string           uri = "";                // the remote location for the media file
+		public string           local_uri = "";          // the local location for the media file, if any
+		public double           last_played_position;    // the latest position that has been played
+		public string           date_released;           // when the episode was released, in string form
+		public EpisodeStatus    status;                  // whether the episode is played or unplayed
+		public DownloadStatus	current_download_status; // whether the episode is downloaded or not downloaded
 
-        public Podcast 			parent;					// the parent that the episode belongs to
-        public DateTime 		datetime_released;		// the datetime corresponding the when the episode was released
+		public Podcast          parent;                  // the parent that the episode belongs to
+		public DateTime         datetime_released;       // the datetime corresponding the when the episode was released
 
 		/*
 		 * Gets the playback uri based on whether the file is local or remote

--- a/src/Objects/Podcast.vala
+++ b/src/Objects/Podcast.vala
@@ -22,14 +22,14 @@ using Gee;
 namespace Vocal {
     public class Podcast {
     
-        public  ArrayList<Episode> episodes = null;		  // the episodes belonging to this podcast
+        public  ArrayList<Episode> episodes = null;  // the episodes belonging to this podcast
         
-        public string 		name;                         // podcast name
-        public string 		feed_uri;                     // the uri for the podcast
-        public string 		remote_art_uri;               // the web link to the album art if local is unavailable
-        public string 		local_art_uri;                // where the locally cached album art is located
-        public string 		description;				          // the episode's description
-        public MediaType 	content_type;                 // is the podcast an audio or video feed?
+        public string       name = "";               // podcast name
+        public string       feed_uri = "";           // the uri for the podcast
+        public string       remote_art_uri = "";     // the web link to the album art if local is unavailable
+        public string       local_art_uri = "";      // where the locally cached album art is located
+        public string       description = "";        // the episode's description
+        public MediaType    content_type;            // is the podcast an audio or video feed?
 
         /*
          * Gets and sets the coverart, whether it's from a remote source


### PR DESCRIPTION
If certain string elements were not parsed from the source feed the
properties on the Episode and Podcast object would remain null, sometimes
causing `string_replace: assertion 'self != NULL' failed` errors.

This commit simply initializes these properties as empty strings.