### PR TITLE
GResource for vocal-missing.png and banner.png

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,9 @@ configure_file (${CMAKE_SOURCE_DIR}/src/config.vala.cmake ${CMAKE_SOURCE_DIR}/sr
 include(GSettings)
 add_schema("com.github.needle-and-thread.vocal.gschema.xml")
 
+include (GResource)
+glib_compile_resources (GLIB_RESOURCES_VIEW SOURCE data/com.github.needle-and-thread.vocal.gresource.xml)
+
 # Definitions
 add_definitions ("-DGETTEXT_PACKAGE=\"${GETTEXT_PACKAGE}\"")
 
@@ -144,7 +147,7 @@ OPTIONS
 
 add_subdirectory (po)
 
-add_executable(${EXEC_NAME} ${VALA_C})
+add_executable(${EXEC_NAME} ${VALA_C} ${GLIB_RESOURCES_VIEW})
 
 # uninstall target
 configure_file (

--- a/data/com.github.needle-and-thread.vocal.gresource.xml
+++ b/data/com.github.needle-and-thread.vocal.gresource.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gresources>
+  <gresource prefix="/com/github/needle-and-thread/vocal">
+    <file compressed="true" alias="missing.png">../icons/assets/vocal-missing.png</file>
+    <file compressed="true" alias="banner.png">../icons/assets/banner.png</file>    
+  </gresource>
+</gresources>

--- a/src/Objects/Podcast.vala
+++ b/src/Objects/Podcast.vala
@@ -53,7 +53,7 @@ namespace Vocal {
                 }
                 // In rare instances where album art is not available at all, provide a "missing art" image to use
                 // in library view
-                return "file://" + Constants.PKGDATADIR + "/vocal-missing.png";
+                return "resource:///com/github/needle-and-thread/vocal/missing.png";
             }
 
 		    // If the URI begins with "file://" set local uri, otherwise set the remote uri

--- a/src/Utils/FeedParser.vala
+++ b/src/Utils/FeedParser.vala
@@ -331,7 +331,7 @@ namespace Vocal {
             }
             
             if(podcast.coverart_uri == null || podcast.coverart_uri.length < 1) {
-                podcast.coverart_uri = """//usr/share/vocal/vocal-missing.png""";
+                podcast.coverart_uri = """resource:///com/github/needle-and-thread/vocal/banner.png""";
             }
             
             if(podcast.feed_uri == null || podcast.feed_uri.length < 1) {

--- a/src/Widgets/CoverArt.vala
+++ b/src/Widgets/CoverArt.vala
@@ -63,9 +63,7 @@ namespace Vocal {
                 
 
 	            // Load the banner to be drawn on top of the cover art
-                File triangle_file = GLib.File.new_for_path(GLib.Path.build_filename (Constants.PKGDATADIR, "banner.png"));
-	            InputStream triangle_input_stream = triangle_file.read();
-	            var triangle_pixbuf = new Gdk.Pixbuf.from_stream_at_scale(triangle_input_stream, 75, 75, true);
+				var triangle_pixbuf = new Gdk.Pixbuf.from_resource_at_scale("/com/github/needle-and-thread/vocal/banner.png", 75, 75, true);
 	            triangle = new Gtk.Image.from_pixbuf(triangle_pixbuf);
 
 	            // Align everything to the top right corner

--- a/src/Widgets/DirectoryArt.vala
+++ b/src/Widgets/DirectoryArt.vala
@@ -114,21 +114,17 @@ namespace Vocal {
             hor_box.margin_left = 10;
             hor_box.margin_right = 10;
 
-            // Load the album artwork
-            Gtk.Image image = new Gtk.Image();
             
             // By default we're only given the 170px version, but the 600px is available
             var bigartwork = artworkUrl170.replace("170", "600");
 
-            try {
-                var missing = GLib.File.new_for_path(GLib.Path.build_filename (Constants.PKGDATADIR, "vocal-missing.png"));
-                var icon = new GLib.FileIcon(missing);
-                image.gicon = icon;
-                image.pixel_size = 200;
-            } catch (Error e) {
-                warning ("Unable to open missing album art file.");
-            }
+            // Load the album artwork
+            var missing_pixbuf = new Gdk.Pixbuf.from_resource_at_scale("/com/github/needle-and-thread/vocal/missing.png", 32, 32, true);
+            
+            var image = new Gtk.Image.from_pixbuf(missing_pixbuf);
+            image.margin = 0;
             image.expand = false;
+            image.pixel_size = 200;
             image.margin_top = 5;
             image.margin_bottom = 5;
             image.get_style_context().add_class("directory-art-image");

--- a/src/Widgets/SearchResultBox.vala
+++ b/src/Widgets/SearchResultBox.vala
@@ -62,8 +62,7 @@ namespace Vocal {
 
             // Do we only have a podcast?
             if(episode == null) {
-                var missing_pixbuf = new Gdk.Pixbuf.from_file_at_scale("""//usr/share/vocal/vocal-missing.png""",
-                                                                       32, 32, true);
+                var missing_pixbuf = new Gdk.Pixbuf.from_resource_at_scale("/com/github/needle-and-thread/vocal/missing.png", 32, 32, true);
                 var image = new Gtk.Image.from_pixbuf(missing_pixbuf);
                 image.margin = 0;
                 image.expand = false;


### PR DESCRIPTION
If this is accepted, I'm not sure how the existing `//usr/share/vocal/vocal-missing.png` and `//usr/share/vocal/banner.png` will be removed or whether they even need to be removed after an update.

#167 #143 