### PR TITLE
Attempt to fix some libxml and libsoup bugs. Better logging.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -138,6 +138,8 @@ vala_precompile(VALA_C ${EXEC_NAME}
     src/Utils/Utils.vala
     src/Utils/MPRIS.vala
     src/Utils/iTunesProvider.vala
+    src/Utils/SoupClient.vala
+    src/Utils/XmlUtils.vala
     src/Services/ImageCache.vala
 PACKAGES
     ${DEPS_PACKAGES}

--- a/src/Controller.vala
+++ b/src/Controller.vala
@@ -469,114 +469,101 @@ namespace Vocal {
         /*
          * Does the actual adding of podcast feeds
          */
-        public void add_podcast_feed(int response_id, string feed, string? name) {
+        public void add_podcast_feed(string feed) {
+            if(feed.length == 0) {
+                return;
+            }
+            // Destroy the add podcast dialog box
+            //  window.add_feed.destroy();
 
+            info("Adding feed %s", feed);
             currently_importing = true;
 
-            if(response_id == Gtk.ResponseType.OK) {
-                string entered_feed = "";
-                if(feed == null && window.add_feed != null)
-                    entered_feed = window.add_feed.entry.get_text();
-                else
-                    entered_feed = feed;
-
-                // Was the RSS feed an iTunes URL? If so, find the actual RSS feed address
-                if(entered_feed.contains("itunes.apple.com")) {
-                    string actual_rss = itunes.get_rss_from_itunes_url(entered_feed);
-                    if(actual_rss != null) {
-                        info("Original iTunes URL: %s, Vocal found matching RSS address: %s", entered_feed, actual_rss);
-                        entered_feed = actual_rss;
-                    }
-                }
-
-                window.add_feed.destroy();
-
-                // Hide the shownotes button
-                window.toolbar.hide_shownotes_button();
-                window.toolbar.hide_playlist_button();
-
-                if(name == null)
-                    window.toolbar.playback_box.set_message(_("Adding new podcast: <b>" + entered_feed + "</b>"));
-                else
-                    window.toolbar.playback_box.set_message(_("Adding new podcast: <b>" + name + "</b>"));
-                window.toolbar.show_playback_box();
-
-                var loop = new MainLoop();
-                bool success = false;
-
-                library.async_add_podcast_from_file(entered_feed, (obj, res) => {
-                    success = library.async_add_podcast_from_file.end(res);
-                    currently_importing = false;
-                    if(player.playing) {
-                        window.toolbar.playback_box.set_info_title(current_episode.title.replace("%27", "'"), current_episode.parent.name.replace("%27", "'"));
-                        window.video_controls.set_info_title(current_episode.title.replace("%27", "'"), current_episode.parent.name.replace("%27", "'"));
-                    }
-                    loop.quit();
-                });
-
-                loop.run();
-
-                if(success) {
-                    window.toolbar.show_shownotes_button();
-                    window.toolbar.show_playlist_button();
-
-                    if(!player.playing)
-                        window.toolbar.hide_playback_box();
-
-                    // Is there now at least one podcast in the library?
-                    if(library.podcasts.size > 0) {
-
-                        // Make the refresh and export items sensitive now
-                        //refresh_item.sensitive = true;
-                        window.toolbar.export_item.sensitive = true;
-
-                        // Populate views no matter what
-                        window.populate_views();
-
-                        if(window.current_widget == window.welcome) {
-                            window.switch_visible_page(window.all_scrolled);
-                        }
-
-                        library_empty = false;
-
-                        window.show_all();
-                    }
+            // Was the RSS feed an iTunes URL? If so, find the actual RSS feed address
+            if(feed.contains("itunes.apple.com")) {
+                string actual_rss = itunes.get_rss_from_itunes_url(feed);
+                if(actual_rss != null) {
+                    info("Original iTunes URL: %s, Vocal found matching RSS address: %s", feed, actual_rss);
+                    feed = actual_rss;
                 } else {
+                    return;
+                }
+            }
 
-                    if(!player.playing)
-                        window.toolbar.hide_playback_box();
+            // Hide the shownotes button
+            window.toolbar.hide_shownotes_button();
+            window.toolbar.hide_playlist_button();
 
-                    var add_err_dialog = new Gtk.MessageDialog(window.add_feed,
-                    Gtk.DialogFlags.MODAL,Gtk.MessageType.ERROR,
-                    Gtk.ButtonsType.OK, "");
-                    add_err_dialog.response.connect((response_id) => {
-                        add_err_dialog.destroy();
-                    });
-                    
-                    // Determine if it was a network issue, or just a problem with the feed
-                    
-                    bool network_okay = Utils.confirm_internet_functional();
-                    
-                    string error_message;
-                    
-                    if(network_okay) {
-                        error_message = _("Please make sure you selected the correct feed and that it is still available.");
-                    } else {
-                        error_message = _("There seems to be a problem with your internet connection. Make sure you are online and then try again.");
+            window.toolbar.playback_box.set_message(_("Adding new podcast: <b>" + feed + "</b>"));
+            window.toolbar.show_playback_box();
+
+            var loop = new MainLoop();
+            bool success = false;
+
+            library.async_add_podcast_from_file(feed, (obj, res) => {
+                success = library.async_add_podcast_from_file.end(res);
+                currently_importing = false;
+                if(player.playing) {
+                    window.toolbar.playback_box.set_info_title(current_episode.title.replace("%27", "'"), current_episode.parent.name.replace("%27", "'"));
+                    window.video_controls.set_info_title(current_episode.title.replace("%27", "'"), current_episode.parent.name.replace("%27", "'"));
+                }
+                loop.quit();
+            });
+
+            loop.run();
+
+            if(success) {
+                window.toolbar.show_shownotes_button();
+                window.toolbar.show_playlist_button();
+
+                if(!player.playing)
+                    window.toolbar.hide_playback_box();
+
+                // Is there now at least one podcast in the library?
+                if(library.podcasts.size > 0) {
+                    // Make the refresh and export items sensitive now
+                    //refresh_item.sensitive = true;
+                    window.toolbar.export_item.sensitive = true;
+
+                    // Populate views no matter what
+                    window.populate_views();
+
+                    if(window.current_widget == window.welcome) {
+                        window.switch_visible_page(window.all_scrolled);
                     }
 
-                    var error_img = new Gtk.Image.from_icon_name ("dialog-error", Gtk.IconSize.DIALOG);
-                    add_err_dialog.set_transient_for(window);
-                    add_err_dialog.text = _("Error Adding Podcast");
-                    add_err_dialog.secondary_text = error_message;
-                    add_err_dialog.set_image(error_img);
-                    add_err_dialog.show_all();
+                    library_empty = false;
+                    window.show_all();
+                }
+            } else {
+                if(!player.playing) {
+                    window.toolbar.hide_playback_box();
                 }
 
-            }
-            else {
-            	// Destroy the add podcast dialog box
-            	window.add_feed.destroy();
+                var add_err_dialog = new Gtk.MessageDialog(window.add_feed,
+                Gtk.DialogFlags.MODAL,Gtk.MessageType.ERROR,
+                Gtk.ButtonsType.OK, "");
+                add_err_dialog.response.connect((response_id) => {
+                    add_err_dialog.destroy();
+                });
+                
+                // Determine if it was a network issue, or just a problem with the feed
+                bool network_okay = SoupClient.check_connection();
+                
+                string error_message;
+                
+                if(network_okay) {
+                    error_message = _("Please make sure you selected the correct feed and that it is still available.");
+                } else {
+                    error_message = _("There seems to be a problem with your internet connection. Make sure you are online and then try again.");
+                }
+
+                var error_img = new Gtk.Image.from_icon_name ("dialog-error", Gtk.IconSize.DIALOG);
+                add_err_dialog.set_transient_for(window);
+                add_err_dialog.text = _("Error Adding Podcast");
+                add_err_dialog.secondary_text = error_message;
+                add_err_dialog.set_image(error_img);
+                add_err_dialog.show_all();
             }
         }
         

--- a/src/Library.vala
+++ b/src/Library.vala
@@ -58,7 +58,6 @@ namespace Vocal {
         private Unity.LauncherEntry launcher;
 #endif
 
-        private FeedParser parser;				// Parser for parsing feeds
 		private VocalSettings settings;			// Vocal's settings
 
         Episode downloaded_episode = null;
@@ -98,8 +97,6 @@ namespace Vocal {
             // Set the local library path (and replace ~ with the absolute home directory if need be)
             local_library_path = settings.library_location.replace("~", GLib.Environment.get_home_dir());
 
-            parser = new FeedParser();
-
 #if HAVE_LIBUNITY
             launcher = Unity.LauncherEntry.get_for_desktop_id("vocal.desktop");
             launcher.count = new_episode_count;
@@ -110,37 +107,33 @@ namespace Vocal {
         }
 
 
-
         /*
          * Adds podcasts to the library from the provided OPML file path
          */
-        public async bool add_from_OPML(string path) {
-
-            bool successful = true;
-
+        public async Gee.ArrayList<string> add_from_OPML(string path) {
+            Gee.ArrayList<string> failed_feeds = new Gee.ArrayList<string>();
+            
             SourceFunc callback = add_from_OPML.callback;
-
+            
             ThreadFunc<void*> run = () => {
-
                 try {
+                    FeedParser feed_parser = new FeedParser();
+                    string[] feeds = feed_parser.parse_feeds_from_OPML(path);
+                    info("Done parsing feeds.");
 
-                    string[] feeds = parser.parse_feeds_from_OPML(path);
                     int i = 0;
                     foreach (string feed in feeds) {
                         i++;
                         import_status_changed(i, feeds.length, feed);
                         bool temp_status = add_podcast_from_file(feed);
-                        if(temp_status == false)
-                            successful = false;
+                        if(temp_status == false) {
+                            failed_feeds.add(feed);
+                            warning("Failed to add podcast from feed because add_podcast_from_file returned false. for: %s", feed);
+                        }
                     }
-
                 } catch (Error e) {
-                    info("Error parsing OPML file.");
-                    info(e.message);
-                    successful = false;
-
+                    info("Error parsing OPML file. %s", e.message);
                 }
-
 
                 Idle.add((owned) callback);
                 return null;
@@ -149,7 +142,7 @@ namespace Vocal {
 
             yield;
 
-            return successful;
+            return failed_feeds;
         }
 
 
@@ -158,10 +151,7 @@ namespace Vocal {
          * Adds a new podcast to the library
          */
         public bool add_podcast(Podcast podcast) throws VocalLibraryError {
-
-            if(podcast == null){
-                throw new VocalLibraryError.ADD_ERROR(_("Unable to add podcast"));
-            }
+            info("Podcast %s being added to library.", podcast.name);
 
             // Set all but the most recent episode as played on initial add to library
             if(podcast.episodes.size > 0) {
@@ -175,33 +165,27 @@ namespace Vocal {
             // Create a directory for downloads and artwork caching in the local library
             GLib.DirUtils.create_with_parents(podcast_path, 0775);
 
-
             //  Locally cache the album art if necessary
             try {
-
                 // Don't use the default coverart_path getter, we want to make sure we are using the remote URI
                 GLib.File remote_art = GLib.File.new_for_uri(podcast.remote_art_uri);
 
                 // Set the path of the new file and create another object for the local file
-
                 string art_path = podcast_path + """/""" + remote_art.get_basename().replace("%", "_");
 
                 GLib.File local_art = GLib.File.new_for_path(art_path);
 
                 // If the local album art doesn't exist
                 if(!local_art.query_exists()) {
-
                     // Cache the art
                     remote_art.copy(local_art, FileCopyFlags.NONE);
 
                     // Mark the local path on the podcast
                     podcast.local_art_uri = """file://""" + art_path;
                 }
-
             } catch(Error e) {
-                stderr.puts("Unable to save a local copy of the album art.\n");
+                error("Unable to save a local copy of the album art. %s", e.message);
             }
-
 
             // Open the database
             int ec = Sqlite.Database.open (db_location, out db);
@@ -223,7 +207,6 @@ namespace Vocal {
 	            content_type_text = "unknown";
 	        }
 
-
             // Add the podcast
 
             string name, feed_uri, album_art_url, album_art_local_uri, description;
@@ -234,15 +217,11 @@ namespace Vocal {
             album_art_local_uri = podcast.local_art_uri.replace("'", "%27");
             description = podcast.description.replace("'", "%27");
 
-
-
             string query = """INSERT OR REPLACE INTO Podcast (name, feed_uri, album_art_url, album_art_local_uri, description, content_type)
                 VALUES ('%s','%s','%s','%s', '%s', '%s');""".printf(name, feed_uri, album_art_url, album_art_local_uri,
                 description, content_type_text);
 
-
             string errmsg;
-
 
             ec = db.exec (query, null, out errmsg);
 	        if (ec != Sqlite.OK) {
@@ -278,7 +257,6 @@ namespace Vocal {
                 query = """INSERT OR REPLACE INTO Episode (title, parent_podcast_name, uri, local_uri, description, release_date, download_status, play_status) VALUES ('%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s');"""
                     .printf(title, parent_podcast_name, uri, episode.local_uri, episode_description, episode.date_released, download_text, played_text);
 
-
                 ec = db.exec (query, null, out errmsg);
                 if (ec != Sqlite.OK) {
                     stderr.printf ("Error: %s\n", errmsg);
@@ -294,24 +272,23 @@ namespace Vocal {
 		 * Adds a new podcast to the library from a given file path by parsing the file's contents
 		 */
         public bool add_podcast_from_file(string path) {
-
             string uri = path;
             
             // Discover the real URI (avoid redirects)
             if(path.contains("http")) {
                 uri = Utils.get_real_uri(path);
             }
-            info("Adding podcast from: %s".printf(uri));
-            parser = new FeedParser();
+            info("Adding podcast from: %s", uri);
 
-            Podcast new_podcast = parser.get_podcast_from_file(uri);
+            FeedParser feed_parser = new FeedParser();
+            Podcast new_podcast = feed_parser.get_podcast_from_file(uri);
             if(new_podcast == null) {
+                warning("Failed to parse %s", uri);
                 return false;
             } else {
                 add_podcast(new_podcast);
                 return true;
             }
-
         }
 
 
@@ -319,39 +296,36 @@ namespace Vocal {
          * Adds a new podcast from a file, asynchronously
          */
         public async bool async_add_podcast_from_file(string path) {
-
             bool successful = true;
 
             SourceFunc callback = async_add_podcast_from_file.callback;
 
             ThreadFunc<void*> run = () => {
+                info("Adding podcast from file: %s", path);
 
-                info("Adding podcast from file: %s".printf(path));
-                parser = new FeedParser();
-
+                FeedParser parser = new FeedParser();
                 try {
                     Podcast new_podcast = parser.get_podcast_from_file(path);
                     if(new_podcast == null) {
-                        info("New podcast found to be null.");
+                        info("New podcast found to be null. %s", path);
                         successful = false;
                     } else {
+                        info("Async Adding %s", new_podcast.name);
                         add_podcast(new_podcast);
                     }
                 } catch (Error e) {
+                    error("Failed to add podcast: %s", e.message);
                     successful = false;
                 }
 
-
                 Idle.add((owned) callback);
                 return null;
-
             };
             Thread.create<void*>(run, false);
 
             yield;
 
             return successful;
-
         }
 
         /*
@@ -377,8 +351,6 @@ namespace Vocal {
                             // Delete the episode. Skip checking for an existing file, the delete_episode method will do that automatically
                             info("Episode %s is more than a week old. Deleting.".printf(e.title));
                             delete_local_episode(e);
-
-
                         }
                     }
                 }
@@ -403,41 +375,39 @@ namespace Vocal {
         /*
          * Checks each feed in the library to see if new episodes are available
          */
-        public async Gee.ArrayList<Episode> check_for_updates() throws Error{
-
+        public async Gee.ArrayList<Episode> check_for_updates() {
             SourceFunc callback = check_for_updates.callback;
             Gee.ArrayList<Episode> new_episodes = new Gee.ArrayList<Episode>();
 
-            parser = new FeedParser();
+            FeedParser parser = new FeedParser();
 
             ThreadFunc<void*> run = () => {
                 foreach(Podcast podcast in podcasts) {
-                    try {
-                    
-                        int added = -1;
-                        if (podcast.feed_uri != null && podcast.feed_uri.length > 4) {
-                            added = parser.update_feed(podcast);
-                        }
-
-                        while(added > 0) {
-                            int index = podcast.episodes.size - added;
-
-                            // Add the new episode to the arraylist in case it needs to be downloaded later
-
-                            new_episodes.add(podcast.episodes[index]);
-
-                            write_episode_to_database(podcast.episodes[index]);
-                            added--;
-                        }
+                    int added = -1;
+                    if (podcast.feed_uri != null && podcast.feed_uri.length > 4) {
+                        info("updating feed %s", podcast.feed_uri);
                         
-                        if (added == -1) {
-                            critical ("Unable to update podcast due to missing feed URL: " + podcast.name);
+                        try {
+                            added = parser.update_feed(podcast);
+                        } catch(Error e) {
+                            warning("Failed to update feed for podcast: %s. %s", podcast.name, e.message);
+                            continue;
                         }
+                    }
 
-                    } catch(Error e) {
-                        throw e;
+                    while(added > 0) {
+                        int index = podcast.episodes.size - added;
+
+                        // Add the new episode to the arraylist in case it needs to be downloaded later
+                        new_episodes.add(podcast.episodes[index]);
+
+                        write_episode_to_database(podcast.episodes[index]);
+                        added--;
                     }
                     
+                    if (added == -1) {
+                        critical ("Unable to update podcast due to missing feed URL: " + podcast.name);
+                    }
                 }
 
                 Idle.add((owned) callback);
@@ -830,7 +800,8 @@ namespace Vocal {
                     mark_episode_as_downloaded(downloaded_episode);
                 }
 
-            } catch(Error error) {
+            } catch(Error e) {
+                error("%s", e.message);
             } finally {
                 download_finished(downloaded_episode);
             }

--- a/src/Library.vala
+++ b/src/Library.vala
@@ -169,19 +169,18 @@ namespace Vocal {
             try {
                 // Don't use the default coverart_path getter, we want to make sure we are using the remote URI
                 GLib.File remote_art = GLib.File.new_for_uri(podcast.remote_art_uri);
+                if(remote_art.query_exists()) {
+                    // Set the path of the new file and create another object for the local file
+                    string art_path = podcast_path + """/""" + remote_art.get_basename().replace("%", "_");
+                    GLib.File local_art = GLib.File.new_for_path(art_path);
 
-                // Set the path of the new file and create another object for the local file
-                string art_path = podcast_path + """/""" + remote_art.get_basename().replace("%", "_");
-
-                GLib.File local_art = GLib.File.new_for_path(art_path);
-
-                // If the local album art doesn't exist
-                if(!local_art.query_exists()) {
-                    // Cache the art
-                    remote_art.copy(local_art, FileCopyFlags.NONE);
-
-                    // Mark the local path on the podcast
-                    podcast.local_art_uri = """file://""" + art_path;
+                    // If the local album art doesn't exist
+                    if(!local_art.query_exists()) {
+                        // Cache the art
+                        remote_art.copy(local_art, FileCopyFlags.NONE);
+                        // Mark the local path on the podcast
+                        podcast.local_art_uri = """file://""" + art_path;
+                    }
                 }
             } catch(Error e) {
                 error("Unable to save a local copy of the album art. %s", e.message);
@@ -190,7 +189,7 @@ namespace Vocal {
             // Open the database
             int ec = Sqlite.Database.open (db_location, out db);
 	        if (ec != Sqlite.OK) {
-		        stderr.printf ("Can't open database: %d: %s\n", db.errcode (), db.errmsg ());
+		        error ("Can't open database: %d: %s\n", db.errcode (), db.errmsg ());
 		        return false;
 	        }
 

--- a/src/Services/ImageCache.vala
+++ b/src/Services/ImageCache.vala
@@ -32,7 +32,7 @@ namespace Vocal {
 
         private static DiskCacher cacher;
         private static Gee.HashMap<uint, File> cache;
-        private static Soup.Session soup_session;
+        private static SoupClient soup_client = null;
         private static CacheState state;
 
         static construct {
@@ -44,8 +44,7 @@ namespace Vocal {
             var home_dir = GLib.Environment.get_home_dir();
             var cache_directory = Constants.CACHE_DIR.replace("~", home_dir);
 
-            soup_session = new Soup.Session();
-            soup_session.user_agent = Constants.USER_AGENT;
+            soup_client = new SoupClient();            
             cacher = new DiskCacher(cache_directory);
             cacher.get_cached_files.begin((obj, res) => {
                 cache = cacher.get_cached_files.end(res);
@@ -54,7 +53,7 @@ namespace Vocal {
             });
         }
 
-        public ImageCache() { }
+        public ImageCache() {}
 
         // Get image and cache it
         public async Gdk.Pixbuf get_image(string url) {
@@ -84,13 +83,14 @@ namespace Vocal {
 
         private async Gdk.Pixbuf? load_image_async(string url) {
             Gdk.Pixbuf pixbuf = null;
-            Soup.Request req = soup_session.request(url);
-            InputStream image_stream = req.send(null);
+
             try {
-	            pixbuf = yield new Gdk.Pixbuf.from_stream_async(image_stream, null);
+	            pixbuf = yield new Gdk.Pixbuf.from_stream_async(soup_client.request(HttpMethod.GET, url), null);
             } catch (Error e) {
-                warning (e.message);
+                warning ("Failed to load image. %s", e.message);
+                return null;
             }
+
             return pixbuf;
         }
 

--- a/src/Utils/SoupClient.vala
+++ b/src/Utils/SoupClient.vala
@@ -1,0 +1,173 @@
+namespace Vocal {
+public class SoupClient {
+    private Soup.Session soup_session = null;
+
+    public SoupClient () {
+        soup_session = new Soup.Session ();
+        soup_session.user_agent = Constants.USER_AGENT;
+    }
+
+    public InputStream request (HttpMethod method, string url) throws PublishingError {
+        // Soup needs the url to start with http or https or vocal crashes
+        assert (url.index_of("http://") == 0 || url.index_of("https://") == 0);
+
+        var message = new Soup.Message (method.to_string (), url);
+        InputStream stream = soup_session.send (message);
+        check_response_headers(message);
+
+        return stream;
+    }
+
+    public uint8[] send_message (HttpMethod method, string url) throws PublishingError {
+        // Soup needs the url to start with http or https or vocal crashes
+        assert (url.index_of("http://") == 0 || url.index_of("https://") == 0);
+
+        var message = new Soup.Message (method.to_string (), url);
+        soup_session.send_message (message);
+        check_response_headers(message);
+
+        // All valid communication involves body data in the response
+        if (message.response_body.data == null || message.response_body.data.length == 0) {
+            throw new PublishingError.MALFORMED_RESPONSE ("No response data from %s", message.get_uri().to_string (false));
+        }
+
+        return message.response_body.data;
+    }
+
+    public static bool check_connection() {
+        var uri = "http://www.needleandthread.co";
+
+        try {
+            SoupClient soup_client = new SoupClient();
+            soup_client.send_message(HttpMethod.GET, uri);
+        } catch(Error e) {
+            warning(e.message);
+            return false;
+        }
+
+        return true;
+    }
+
+    private void check_response_headers (Soup.Message message) throws PublishingError {
+        switch (message.status_code) {
+            case Soup.Status.OK:
+            case Soup.Status.CREATED: // HTTP code 201 (CREATED) signals that a new
+                // resource was created in response to a PUT or POST
+                break;
+
+            case Soup.Status.CANT_RESOLVE:
+            case Soup.Status.CANT_RESOLVE_PROXY:
+                throw new PublishingError.NO_ANSWER ("Unable to resolve %s (error code %u)", message.get_uri().to_string (false), message.status_code);
+
+            case Soup.Status.CANT_CONNECT:
+            case Soup.Status.CANT_CONNECT_PROXY:
+                throw new PublishingError.NO_ANSWER ("Unable to connect to %s (error code %u)", message.get_uri().to_string (false), message.status_code);
+
+            default:
+                // status codes below 100 are used by Soup, 100 and above are defined HTTP codes
+                if (message.status_code >= 100) {
+                    throw new PublishingError.NO_ANSWER ("Service %s returned HTTP status code %u %s",
+                    message.get_uri().to_string (false), message.status_code, message.reason_phrase);
+                } else {
+                    throw new PublishingError.NO_ANSWER ("Failure communicating with %s (error code %u)", message.get_uri().to_string (false), message.status_code);
+                }
+        }
+
+
+    }
+}
+
+public enum HttpMethod {
+    GET,
+    POST,
+    PUT;
+
+    public string to_string () {
+        switch (this) {
+        case HttpMethod.GET:
+            return "GET";
+
+        case HttpMethod.PUT:
+            return "PUT";
+
+        case HttpMethod.POST:
+            return "POST";
+
+        default:
+            error ("unrecognized HTTP method enumeration value");
+        }
+    }
+
+    public static HttpMethod from_string (string str) {
+        if (str == "GET") {
+            return HttpMethod.GET;
+        } else if (str == "PUT") {
+            return HttpMethod.PUT;
+        } else if (str == "POST") {
+            return HttpMethod.POST;
+        } else {
+            error ("unrecognized HTTP method name: %s", str);
+        }
+    }
+}
+
+public errordomain PublishingError {
+    /**
+     * Indicates that no communications channel could be opened to the remote host.
+     *
+     * This error occurs, for example, when no network connection is available or
+     * when a DNS lookup fails.
+     */
+    NO_ANSWER,
+
+    /**
+     * Indicates that a communications channel to the remote host was previously opened, but
+     * the remote host can no longer be reached.
+     *
+     * This error occurs, for example, when the network is disconnected during a publishing
+     * interaction.
+     */
+    COMMUNICATION_FAILED,
+
+    /**
+     * Indicates that a communications channel to the remote host was opened and
+     * is active, but that messages sent to or from the remote host can't be understood.
+     *
+     * This error occurs, for example, when attempting to interact with a RESTful host
+     * via XML-RPC.
+     */
+    PROTOCOL_ERROR,
+
+    /**
+     * Indicates that the remote host has received a well-formed message that has caused
+     * a server-side error.
+     *
+     * This error occurs, for example, when the remote host receives a message that should
+     * be signed but isn't.
+     */
+    SERVICE_ERROR,
+
+    /**
+     * Indicates that the remote host has sent the local client back a well-formed response,
+     * but the response can't be understood.
+     *
+     * This error occurs, for example, when the remote host sends a response in an XML grammar
+     * different from that expected by the local client.
+     */
+    MALFORMED_RESPONSE,
+
+    /**
+     * Indicates that the local client can't access a file or files in local storage.
+     *
+     * This error occurs, for example, when the local client attempts to read binary data
+     * out of a photo or video file that doesn't exist.
+     */
+    LOCAL_FILE_ERROR,
+
+    /**
+     * Indicates that the remote host has rejected the session identifier used by the local
+     * client as out-of-date. The local client should acquire a new session identifier.
+     */
+    EXPIRED_SESSION
+}
+}

--- a/src/Utils/Utils.vala
+++ b/src/Utils/Utils.vala
@@ -51,50 +51,6 @@ public class Utils
 #endif
     }
     
-    
-    /*
-     * Attempts to load a webpage to confirm that the internet is functional
-     * (called when Vocal fails to parse a podcast and needs to know where
-     * the problem actually exists: the parser or the network)
-     */
-    public static bool confirm_internet_functional() {
-        /*
-            Note: this code is primarily borrowed from the Vala
-            GIONetworkingSample from the GNOME Wiki:
-            https://wiki.gnome.org/Projects/Vala/GIONetworkingSample
-        */
-        var host = "www.needleandthread.co";
-
-        try {
-            // Resolve hostname to IP address
-            var resolver = Resolver.get_default ();
-            var addresses = resolver.lookup_by_name (host, null);
-            var address = addresses.nth_data (0);
-            print ("Test internet connection...\n");
-            print (@"Resolved $host to $address\n");
-
-            // Connect
-            var client = new SocketClient ();
-            var conn = client.connect (new InetSocketAddress (address, 80));
-            print (@"Connected to $host\n");
-
-            // Send HTTP GET request
-            var message = @"GET / HTTP/1.1\r\nHost: $host\r\n\r\n";
-            conn.output_stream.write (message.data);
-            print ("Wrote request\n");
-
-            // Receive response
-            var response = new DataInputStream (conn.input_stream);
-            var status_line = response.read_line (null).strip ();
-            print ("Received status line: %s\n", status_line);
-            return true;
-
-        } catch (Error e) {
-            stderr.printf ("%s\n", e.message);
-            return false;
-        }
-    }
-    
     /*
     * Find the real URI for a resource (locates redirected URIs, etc)
     *

--- a/src/Utils/XmlUtils.vala
+++ b/src/Utils/XmlUtils.vala
@@ -1,0 +1,57 @@
+/***
+  BEGIN LICENSE
+
+  Copyright (C) 2014-2015 Nathan Dyer <mail@nathandyer.me>
+  This program is free software: you can redistribute it and/or modify it
+  under the terms of the GNU Lesser General Public License version 3, as
+  published by the Free Software Foundation.
+
+  This program is distributed in the hope that it will be useful, but
+  WITHOUT ANY WARRANTY; without even the implied warranties of
+  MERCHANTABILITY, SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR
+  PURPOSE.  See the GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License along
+  with this program.  If not, see <http://www.gnu.org/licenses>
+
+  END LICENSE
+***/
+
+namespace Vocal {
+    public class XmlUtils {
+
+        public static string strip_trailing_rss_chars(string rss) {
+            return rss.substring(0, rss.last_index_of("</rss>") + "</rss>".length);
+        }
+    
+        public static unowned Xml.Doc parse_string (string? input_string) throws PublishingError {
+            if (input_string == null || input_string.length == 0) {
+                throw new PublishingError.MALFORMED_RESPONSE ("Empty XML string");
+            }
+
+            var rss = strip_trailing_rss_chars(input_string);
+    
+            // Does this even start and end with the right characters?
+            if (!rss.chug ().chomp ().has_prefix ("<") ||
+            !rss.chug ().chomp ().has_suffix (">")) {
+                // Didn't start or end with a < or > and can't be parsed as XML - treat as malformed.
+                throw new PublishingError.MALFORMED_RESPONSE ("Unable to parse XML document 1");
+            }
+
+            // Don't want blanks to be included as text nodes, and want the XML parser to tolerate
+            // tolerable XML
+            Xml.Doc *doc = Xml.Parser.read_memory (rss, (int) rss.length, null, null,
+            Xml.ParserOption.NOBLANKS | Xml.ParserOption.RECOVER);
+            if (doc == null)
+                throw new PublishingError.MALFORMED_RESPONSE ("Unable to parse XML document 2");
+
+            // Since 'doc' is the top level, if it has no children, something is wrong
+            // with the XML; we cannot continue normally here.
+            if (doc->children == null) {
+                throw new PublishingError.MALFORMED_RESPONSE ("Unable to parse XML document 3");
+            }
+
+            return doc;
+        }
+    }
+}

--- a/src/Utils/iTunesProvider.vala
+++ b/src/Utils/iTunesProvider.vala
@@ -44,7 +44,7 @@ namespace Vocal {
 
             try {
                 var parser = new Json.Parser ();
-                parser.load_from_data ((string) soup_client.send_message(HttpMethod.GET, uri), -1);
+                parser.load_from_stream (soup_client.request(HttpMethod.GET, uri));
 
                 var root_object = parser.get_root ().get_object ();
 

--- a/src/Utils/iTunesProvider.vala
+++ b/src/Utils/iTunesProvider.vala
@@ -82,7 +82,7 @@ namespace Vocal {
             var parser = new Json.Parser ();
 
             try {
-                parser.load_from_data ((string) soup_client.send_message(HttpMethod.GET, uri), -1);
+                parser.load_from_stream (soup_client.request(HttpMethod.GET, uri));
             } catch (Error e) {
                 warning ("An error occured fetching the top podcasts. %s", e.message);
                 return null;
@@ -163,7 +163,7 @@ namespace Vocal {
 
             try {
                 var parser = new Json.Parser ();
-                parser.load_from_data ((string) soup_client.send_message(HttpMethod.GET, uri), -1);
+                parser.load_from_stream (soup_client.request(HttpMethod.GET, uri));
 
                 var root_object = parser.get_root ().get_object ();
 

--- a/src/Utils/iTunesProvider.vala
+++ b/src/Utils/iTunesProvider.vala
@@ -21,7 +21,11 @@ namespace Vocal {
 
     public class iTunesProvider {
 
-        public iTunesProvider() {}
+        private SoupClient soup_client = null;
+
+        public iTunesProvider() {
+            soup_client = new SoupClient();
+        }
 
         /*
          * Finds the public RSS feed address from any given iTunes store URL
@@ -37,14 +41,10 @@ namespace Vocal {
             string id = itunes_url.slice(start_index, stop_index);
 
             var uri =  "https://itunes.apple.com/lookup?id=%s&entity=podcast".printf(id);
-            var session = new Soup.Session ();
-            var message = new Soup.Message ("GET", uri);
-            session.user_agent = Constants.USER_AGENT;
-            session.send_message (message);
 
             try {
                 var parser = new Json.Parser ();
-                parser.load_from_data ((string) message.response_body.flatten ().data, -1);
+                parser.load_from_data ((string) soup_client.send_message(HttpMethod.GET, uri), -1);
 
                 var root_object = parser.get_root ().get_object ();
 
@@ -60,14 +60,11 @@ namespace Vocal {
                     rss = obj.get_string_member("feedUrl");
                     name = obj.get_string_member("trackName");
                 }
-                
-
             } catch (Error e) {
-                warning ("An error occurred while discovering the real RSS feed address");
+                warning ("An error occurred while discovering the real RSS feed address %s\n", e.message);
             }
 
             return rss;
-
         }
 
         /*
@@ -79,17 +76,19 @@ namespace Vocal {
             var settings = VocalSettings.get_default_instance();
 
             var uri =  "https://itunes.apple.com/%s/rss/toppodcasts/limit=%d/json".printf(settings.itunes_store_country, limit);
-            var session = new Soup.Session ();
-            var message = new Soup.Message ("GET", uri);
-            session.send_message (message);
-            
+
             GLib.List<DirectoryEntry> entries = new GLib.List<DirectoryEntry>();
 
             var parser = new Json.Parser ();
-            parser.load_from_data ((string) message.response_body.flatten ().data, -1);
+
+            try {
+                parser.load_from_data ((string) soup_client.send_message(HttpMethod.GET, uri), -1);
+            } catch (Error e) {
+                warning ("An error occured fetching the top podcasts. %s", e.message);
+                return null;
+            }
 
             var root_object = parser.get_root ().get_object ();
-
             if(root_object == null) {
                 error ("Error loading iTunes results. Root object was null.");
                 return null;
@@ -160,15 +159,11 @@ namespace Vocal {
 
             var uri = "https://itunes.apple.com/search?term=%s&entity=podcast&limit=%d".printf(term.replace(" ", "+"), limit);
 
-            var session = new Soup.Session ();
-            var message = new Soup.Message ("GET", uri);
-            session.send_message (message);
-
             Gee.ArrayList<DirectoryEntry> entries = new Gee.ArrayList<DirectoryEntry>();
 
             try {
                 var parser = new Json.Parser ();
-                parser.load_from_data ((string) message.response_body.flatten ().data, -1);
+                parser.load_from_data ((string) soup_client.send_message(HttpMethod.GET, uri), -1);
 
                 var root_object = parser.get_root ().get_object ();
 
@@ -201,7 +196,7 @@ namespace Vocal {
                 }
 
             } catch (Error e) {
-                warning ("An error occurred while loading the iTunes results");
+                warning ("An error occurred while loading the iTunes results. %s", e.message);
             }
 
             return entries;

--- a/src/Widgets/DirectoryArt.vala
+++ b/src/Widgets/DirectoryArt.vala
@@ -82,10 +82,10 @@ namespace Vocal {
 				} else if (url.contains("itunes.apple")) {
 					var itunes = new iTunesProvider();
 					string rss_url = itunes.get_rss_from_itunes_url(url);
-							var fp = new FeedParser();
-					string details_summary =  fp.find_description_from_file(rss_url);
+					var feed_parser = new FeedParser();
+					string details_summary =  feed_parser.find_description_from_file(rss_url);
 					summary_label.set_text(details_summary.length > 0 ? details_summary : _("No summary available."));
-					fp = null;
+					feed_parser = null;
                 }
 				summary_label.max_width_chars = 64;
 				summary_label.margin = 20;

--- a/src/Widgets/DownloadDetailBox.vala
+++ b/src/Widgets/DownloadDetailBox.vala
@@ -32,10 +32,10 @@ namespace Vocal {
 
         public signal void new_percentage_available();		// Fired when a new download percentage is available
 
-        public Gtk.Label 	 	title_label {private get; private set;}
-        public Gtk.Label	 	podcast_label {private get; private set;}
-        public Gtk.ProgressBar  progress_bar;
-        public Gtk.Label 		download_label;
+        public Gtk.Label 	 	title_label = null;
+        public Gtk.Label	 	podcast_label = null;
+        public Gtk.ProgressBar  progress_bar = null;
+        public Gtk.Label 		download_label = null;
 
         public double	percentage;
         public int 		secs_elapsed;

--- a/src/Widgets/SearchResultBox.vala
+++ b/src/Widgets/SearchResultBox.vala
@@ -129,10 +129,10 @@ namespace Vocal {
 
                 details_button.clicked.connect(() => {
                     if(!details_visible) {
-                        var fp = new FeedParser();
-                        string summary =  fp.find_description_from_file(rss_url);
+                        var feed_parser = new FeedParser();
+                        string summary =  feed_parser.find_description_from_file(rss_url);
                         summary_label.set_text(summary.length > 0 ? summary : _("No summary available."));
-                        fp = null;
+                        feed_parser = null;
                         details_box.set_no_show_all(false);
                         details_box.show();
                         show_all();


### PR DESCRIPTION
- Add XmlUtils. For cleaning up xml before parsing it with libxml. eg removing characters that come after closing `</rss>` tag which causes libxml to fail to parse the file when the xml is otherwise valid.
- Add SoupClient. Wrapper for Soup.Session that checks the response code and makes sure vocal doesn't randomly crash because of soup errors. eg if a url string doesn't start with http or https.
- More logging so bugs are easier to find.  eg
`[WARNING 18:34:49.596531] FeedParser.vala:296: Failed to get podcast. Service http://feeds.soundcloud.com/users/soundcloud:users:279952541/sounds.rss returned HTTP status code 404 Not Found`
- Show detailed error when some podcasts fail during import. I've tested this with [this opml file](https://gist.github.com/xpaulnim/6f7567269f7ab8ed62fd3a0d3c2f1830). I modified it from the OPML posted in #207. eg
![list failed podcasts import](https://user-images.githubusercontent.com/8648705/36633787-2c92edee-1993-11e8-96eb-c6fcbfc3cd33.png)
- If only some podcasts fail during import, those that were successful are still imported. Eg, if 1 out of 10 imports fail, the 9 successful ones will still be imported.
- Top 100 podcasts are loaded only when requested. ie clicking that little cloud button in the top left. Still not asynchronously though :disappointed:. This stops vocal freezing "for no reason" at startup. Separate bug can be opened to fix this.
- Also fixes #272 
