### PR TITLE
Improve episode search in vocal by using using sql wildcards.

### DIFF
--- a/src/Library.vala
+++ b/src/Library.vala
@@ -929,7 +929,7 @@ namespace Vocal {
 
             string prepared_query_str = "SELECT * FROM Episode WHERE title LIKE ? ORDER BY title";
             int ec = db.prepare_v2 (prepared_query_str, prepared_query_str.length, out stmt);
-            ec = stmt.bind_text(1, term, -1, null);
+            ec = stmt.bind_text(1, "%" + term + "%", -1, null);
             if (ec != Sqlite.OK) {
                 warning("%d: %s\n".printf(db.errcode (), db.errmsg ()));
                 return matches;
@@ -944,7 +944,7 @@ namespace Vocal {
 
                 //Add the new episode
                 matches.add(current_ep);
-
+                
             }
 
             stmt.reset();


### PR DESCRIPTION
To find an episode in vocal, currently you have yo search for the exact title of the episode. This PR makes it such that vocal returns all episodes that have the key word searched for in their title. Example follows.


Before this change, if I had a podcast with these episodes:
![vocal episodes](https://user-images.githubusercontent.com/8648705/38518874-0e505edc-3c36-11e8-8b5c-f1bc91d7ad96.png)


When I searched for episodes with the string "LIVE episodes", expecting the two at the top, I got back nothing.
![vocal no episodes](https://user-images.githubusercontent.com/8648705/38518928-3c63abf8-3c36-11e8-9e78-d6fcd4db745d.png)


After this change, I get back the episodes:
![vocal after](https://user-images.githubusercontent.com/8648705/38519099-96ac2248-3c36-11e8-8ce0-1885a691b108.png)

