### PR TITLE
Check that parent is not null before creating search results box

### DIFF
--- a/src/Widgets/SearchResultsView.vala
+++ b/src/Widgets/SearchResultsView.vala
@@ -306,9 +306,12 @@ namespace Vocal {
                         parent = p;
                     }
                 }
-                SearchResultBox srb = new SearchResultBox(parent, e);
-                local_episodes_widgets.add(srb);
-                local_episodes_listbox.add(srb);
+
+                if(parent != null) {
+                    SearchResultBox srb = new SearchResultBox(parent, e);
+                    local_episodes_widgets.add(srb);
+                    local_episodes_listbox.add(srb);
+                }
             }
 
             if(e_matches.size == 0) {


### PR DESCRIPTION
This is related to my other PR #290. When vocal finds the episodes matching the query, the parent podcast might not exist. So the parent.coverart_uri cannot be retrieved because parent is null so vocal crashes.

I think when deleting old episodes, episodes with no parent should also be removed. That would make this kind of thing less likely.