### PR TITLE
Fix 'string_replace' null error.

### DIFF
--- a/src/Widgets/PodcastView.vala
+++ b/src/Widgets/PodcastView.vala
@@ -527,7 +527,7 @@ namespace Vocal {
             } catch (Error e) {}
 
 			name_label.set_text(podcast.name.replace("%27", "'"));
-            description_label.set_text(GLib.Uri.unescape_string(podcast.description).replace("""\n""",""));
+            description_label.set_text(podcast.description.replace("""\n""",""));
 
             populate_episodes();
 


### PR DESCRIPTION
Remove unnecessary call to `GLib.Uri.escape_string` on podcast description, which may return null for some otherwise valid text.

Fixes the following error:
    [FATAL ...] string_replace: assertion 'self != NULL' failed