### PR TITLE
Sort new episodes view by "released date".

### DIFF
--- a/src/Objects/Episode.vala
+++ b/src/Objects/Episode.vala
@@ -21,7 +21,7 @@ using GLib;
 
 namespace Vocal {
 
-	public class Episode {
+	public class Episode : GLib.Object {
 
 		public string           title = "";              // the title of the episode
 		public string           description = "";        // the description/shownotes


### PR DESCRIPTION
This commit uses a `GLib.ListStore` to keep the episodes for the "new episodes"
view, sorting the episodes as they're added.

Addresses issue #295 