### PR TITLE
Update new episodes from db

### DIFF
--- a/src/Library.vala
+++ b/src/Library.vala
@@ -1013,7 +1013,6 @@ namespace Vocal {
                 Episode e = episode_from_row (stmt);
                 // Update the episode with podcast data loaded above.
                 if ( podcasts.has_key (e.parent.name) ) {
-                    info ("found cached parent");
                     e.parent = podcasts.get (e.parent.name);
                 }
                 episodes.add (e);

--- a/src/Objects/Episode.vala
+++ b/src/Objects/Episode.vala
@@ -34,6 +34,7 @@ namespace Vocal {
 
 		public Podcast          parent;                  // the parent that the episode belongs to
 		public DateTime         datetime_released;       // the datetime corresponding the when the episode was released
+		public int64            published = 0;           // int (unix timestamp) representation of episode date.
 
 		/*
 		 * Gets the playback uri based on whether the file is local or remote
@@ -114,6 +115,10 @@ namespace Vocal {
                 GLib.Time tm = GLib.Time ();
                 tm.strptime (date_released, "%a, %d %b %Y %H:%M:%S %Z");
                 datetime_released = new DateTime.local(1900 + tm.year, 1 + tm.month, tm.day, tm.hour, tm.minute, tm.second);
+            }
+
+            if (this.published <= 0 && datetime_released != null) {
+                this.published = datetime_released.to_unix ();
             }
         }
 

--- a/src/Widgets/NewEpisodesView.vala
+++ b/src/Widgets/NewEpisodesView.vala
@@ -73,28 +73,22 @@ namespace Vocal {
             this.pack_start (add_all_to_queue_button, false, false, 15);
             new_episodes_listbox.activate_on_single_click = false;
             new_episodes_listbox.row_activated.connect(on_row_activated);
-            
+
         }
 
         public void populate_episodes_list () {
 
-            episodeListModel.remove_all();
+            GLib.ListStore elm = new GLib.ListStore ( typeof (Episode) );
 
-            foreach (Podcast p in controller.library.podcasts) {
-                foreach (Episode e in p.episodes) {
-                    if (e.status == EpisodeStatus.UNPLAYED) {
-                        episodeListModel.insert_sorted (e, (a, b) => {
-                                var e1 = (Episode) a;
-                                var e2 = (Episode) b;
-                                return  e2.datetime_released.compare(e1.datetime_released);
-                        });
-                    }
-                }
+            foreach (Episode e in controller.library.get_new_episodes ()) {
+                elm.append (e);
             }
 
-            new_episodes_listbox.bind_model(episodeListModel, (item) => {
+            this.episodeListModel = elm;
+            new_episodes_listbox.bind_model(this.episodeListModel, (item) => {
                     return  new EpisodeDetailBox( (Episode) item, 0, 0, false, true);
             });
+
             show_all ();
         }
 


### PR DESCRIPTION
This pull request fetches the new episodes directly from the database.

This requires adding a new column to store the episode datetime in the Episode table. When the new column is added an attempt will be made to populate the new column using the existing data. This may take a little while to run when the migration actually occurs depending on how many episodes need to be updated. 

This method should be more efficient than the current method of iterating through all podcasts & episodes and searching for unplayed ones, then sorting them individually as they're added to the new episode view.

Additionally, the new episode list is recreated and re-bound each time the new episodes are refreshed (instead of cleared and reloaded) which I hope will resolve some crashing problems.

Lastly, this change limits the view to 25 unplayed episodes. This number choice was entirely arbitrary. I have noticed that a large number of new episodes will slow the application significantly but would need more feedback on what value of "large" == "slow". The default can easily be change in the `Library#get_new_episodes ()` method definition.



