### PR TITLE
Don't show welcome screen unless library is empty. 

### DIFF
--- a/src/Library.vala
+++ b/src/Library.vala
@@ -167,6 +167,14 @@ namespace Vocal {
 
 
         /*
+         * Returns true if the library is empty, false otherwise.
+         */
+        public bool empty () {
+            return podcasts.size == 0;
+        }
+
+
+        /*
          * Adds podcasts to the library from the provided OPML file path
          */
         public async Gee.ArrayList<string> add_from_OPML(string path) {

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -1474,10 +1474,15 @@ namespace Vocal {
             if(current_widget == video_widget && controller.player.playing)
                 controller.pause();
 
-            if(previous_widget == directory_scrolled || previous_widget == search_results_scrolled)
-                previous_widget = all_scrolled;
-            switch_visible_page(previous_widget);
+            // If the library is empty, always return to the welcome screen.
+            if (controller.library.empty ()) {
+                previous_widget = welcome;
+            }
 
+            if (previous_widget == directory_scrolled || previous_widget == search_results_scrolled)
+                previous_widget = all_scrolled;
+
+            switch_visible_page(previous_widget);
 
             // Make sure the cursor is visible again
             this.get_window ().set_cursor (null);

--- a/src/Widgets/DirectoryView.vala
+++ b/src/Widgets/DirectoryView.vala
@@ -58,13 +58,12 @@ namespace Vocal {
 
             itunes_title.get_style_context ().add_class ("h2");
 
-            if(first_run) {
+            if (first_run) {
                 return_button = new Gtk.Button.with_label(_("Go Back"));
-                return_button.clicked.connect(on_first_run_return_clicked);
             } else  {
                 return_button = new Gtk.Button.with_label(_("Return to Library"));
-                return_button.clicked.connect(() => { return_to_library (); });
             }
+            return_button.clicked.connect(() => { return_to_library (); });
             return_button.get_style_context().add_class("back-button");
             return_button.margin = 6;
             return_button.expand = false;
@@ -76,8 +75,6 @@ namespace Vocal {
             first_run_continue_button.expand = false;
             first_run_continue_button.halign = Gtk.Align.END;
             first_run_continue_button.clicked.connect(() => {
-                return_button.clicked.disconnect(on_first_run_return_clicked);
-                return_button.clicked.connect(() => { return_to_library(); });
                 return_button.label = _("Return to Library");
                 hide_first_run_continue_button();
                 return_to_library();
@@ -174,8 +171,5 @@ namespace Vocal {
             first_run_continue_button.hide();
         }
 
-        private void on_first_run_return_clicked() {
-            return_to_welcome();
-        }
     }
 }


### PR DESCRIPTION
This should fix issue #330 where existing podcasts were not shown after visiting the "top 100" screen.

Basically, it let's the `MainWindow` decide whether to show the welcome screen depending on if the Library is empty or not.

The second commit is a minor unrelated change, but I noticed that when creating the database tables on first run the method was opening the database to a local `db` variable which shadowed the object var of the same name. The result was a method that seems to open the database, but where `db` could actually still be null after this method returns.