### PR TITLE
Fix HTTP User-Agent string format

### DIFF
--- a/src/config.vala
+++ b/src/config.vala
@@ -6,5 +6,5 @@ namespace Constants {
     public const string VERSION = "2.3.0";
     public const string VERSION_INFO = "Release";
     public const string CACHE_DIR = "~/.cache/vocal";
-    public const string USER_AGENT = "vocal 2.3.0";
+    public const string USER_AGENT = "Vocal/2.3.0";
 }


### PR DESCRIPTION
The expected format is `Component/Component-Version`.

Spaces separate multiple components. Current string parsed as `vocal` and `2.3.0` as two distinct components and not Vocal version 2.3.0.