### PR TITLE
Fixed missing covers in local library view (Fixes #268)

### DIFF
--- a/src/Objects/Podcast.vala
+++ b/src/Objects/Podcast.vala
@@ -21,16 +21,16 @@ using Gee;
 
 namespace Vocal {
     public class Podcast {
-    
+
         public  ArrayList<Episode> episodes = null;  // the episodes belonging to this podcast
-        
+
         public string       name = "";               // podcast name
         public string       feed_uri = "";           // the uri for the podcast
         public string       remote_art_uri = "";     // the web link to the album art if local is unavailable
         public string       local_art_uri = "";      // where the locally cached album art is located
         public string       description = "";        // the episode's description
         public MediaType    content_type;            // is the podcast an audio or video feed?
-		public License license = License.UNKNOWN; // the type of license
+        public License license = License.UNKNOWN; // the type of license
 
         /*
          * Gets and sets the coverart, whether it's from a remote source
@@ -40,14 +40,13 @@ namespace Vocal {
 
             //the album art is saved locally, return that path. Otherwise, return main album art URI
             get {
-
-                if(local_art_uri != null) {
-                    GLib.File local_art = GLib.File.new_for_uri(local_art_uri);
+                if(local_art_uri != null && local_art_uri != "") {
+                    GLib.File local_art = GLib.File.new_for_path(local_art_uri);
                     if(local_art.query_exists()) {
                         return local_art_uri;
                     }
                 } else if(remote_art_uri != null) {
-                    GLib.File remote_art = GLib.File.new_for_path(remote_art_uri);
+                    GLib.File remote_art = GLib.File.new_for_uri(remote_art_uri);
                     if(remote_art.query_exists()) {
                         return remote_art_uri;
                     }
@@ -57,48 +56,49 @@ namespace Vocal {
                 return "resource:///com/github/needle-and-thread/vocal/missing.png";
             }
 
-		    // If the URI begins with "file://" set local uri, otherwise set the remote uri
-		    set {
-		        string[] split = value.split(":");
-		        if(split[0] == "http" || split[0] == "HTTP") {
-		            remote_art_uri = value.replace("%27", "'");
-            } else {
-                local_art_uri = """file://""" + value.replace("%27", "'");
+            // If the URI begins with "file://" set local uri, otherwise set the remote uri
+            set {
+                string[] split = value.split(":");
+                string proto = split[0].ascii_down();
+                if(proto == "http" || proto == "https") {
+                    remote_art_uri = value.replace("%27", "'");
+                } else {
+                    local_art_uri = """file://""" + value.replace("%27", "'");
+                }
             }
-		    }
-		}
-		
-   
+        }
+
+
         /*
          * Default constructor for an empty podcast
          */
         public Podcast () {
             episodes = new ArrayList<Episode>();
             content_type = MediaType.UNKNOWN;
-  	    }
-        
+        }
+
         public Podcast.with_name(string name) {
             this();
             this.name = name;
         }
-            
+
         /*
          * Add a new episode to the library
          */
         public void add_episode(Episode new_episode) {
             episodes.insert(0, new_episode);
         }
-            
+
     }
-        
-        
+
+
     /*
      * The possible types of media that a podcast might contain, generally either audio or video.
      */
     public enum MediaType {
-          AUDIO, VIDEO, UNKNOWN;
+        AUDIO, VIDEO, UNKNOWN;
     }
-    
+
     /*
      * The legal license that a podcast is listed as (if known)
      */


### PR DESCRIPTION
The following changes were necessary to correctly handle covers in the main library view.

Check local_art_uri against empty string.
Switch around File.new_for_path/File.new_for_uri for local_art and remote_art.
Correctly detect https:// urls as remote_art_uri.