### PR TITLE
Fix issue where https feed can't be added. Remove custom check for st…

### DIFF
--- a/src/Library.vala
+++ b/src/Library.vala
@@ -237,18 +237,20 @@ namespace Vocal {
             try {
                 // Don't use the default coverart_path getter, we want to make sure we are using the remote URI
                 GLib.File remote_art = GLib.File.new_for_uri(podcast.remote_art_uri);
-                if(remote_art.query_exists()) {
-                    // Set the path of the new file and create another object for the local file
-                    string art_path = podcast_path + """/""" + remote_art.get_basename().replace("%", "_");
-                    GLib.File local_art = GLib.File.new_for_path(art_path);
+                
+                // Set the path of the new file and create another object for the local file
+                string art_path = podcast_path + "/" + remote_art.get_basename().replace("%", "_");
+                GLib.File local_art = GLib.File.new_for_path(art_path);
 
-                    // If the local album art doesn't exist
-                    if(!local_art.query_exists()) {
-                        // Cache the art
-                        remote_art.copy(local_art, FileCopyFlags.NONE);
-                        // Mark the local path on the podcast
-                        podcast.local_art_uri = """file://""" + art_path;
-                    }
+                // If the local album art doesn't exist
+                if(!local_art.query_exists()) {
+                    // Cache the art
+                    remote_art.copy(local_art, FileCopyFlags.NONE);
+                    // Mark the local path on the podcast
+                    podcast.local_art_uri = "file://" + art_path;
+                } else {
+                    // it already exists so don't download again.
+                    podcast.local_art_uri = "file://" + art_path;
                 }
             } catch(Error e) {
                 error("Unable to save a local copy of the album art. %s", e.message);
@@ -302,6 +304,7 @@ namespace Vocal {
 
             FeedParser feed_parser = new FeedParser();
             Podcast new_podcast = feed_parser.get_podcast_from_file(uri);
+
             if(new_podcast == null) {
                 warning("Failed to parse %s", uri);
                 podcasts_being_added.remove (path);
@@ -343,8 +346,10 @@ namespace Vocal {
                 podcasts_being_added.append (path);
 
                 FeedParser parser = new FeedParser();
+
                 try {
                     Podcast new_podcast = parser.get_podcast_from_file(path);
+                    
                     if(new_podcast == null) {
                         info("New podcast found to be null. %s", path);
                         successful = false;

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -682,12 +682,11 @@ namespace Vocal {
             }
             
             new_episodes_view.populate_episodes_list ();
-            
 
             // If the app is supposed to open hidden, don't present the window. Instead, hide it
-            if(!controller.open_hidden && !controller.is_closing)
+            if(!controller.open_hidden && !controller.is_closing) {
                 show_all();
-                
+            }
         }
 
         /*

--- a/src/Utils/SoupClient.vala
+++ b/src/Utils/SoupClient.vala
@@ -7,6 +7,17 @@ public class SoupClient {
         soup_session.user_agent = Constants.USER_AGENT;
     }
 
+    public string request_as_string(HttpMethod method, string url) throws Error {
+        var data_stream = new DataInputStream(request(method, url));
+        var builder = new StringBuilder ();
+
+        for (string line = data_stream.read_line_utf8(); line != null; line = data_stream.read_line_utf8()) {
+            builder.append(line);
+        }
+
+        return builder.str;
+    }
+
     public InputStream request (HttpMethod method, string url) throws Error {
         if (!valid_http_uri(url)) {
             throw new PublishingError.PROTOCOL_ERROR("%s is not a valid URI. Should be http or https", url);
@@ -21,23 +32,6 @@ public class SoupClient {
         return stream;
     }
 
-    public uint8[] send_message (HttpMethod method, string url) throws Error {
-        if (!valid_http_uri(url)) {
-            throw new PublishingError.PROTOCOL_ERROR("%s is not a valid URI. Should be http or https", url);
-        }
-
-        var message = new Soup.Message (method.to_string (), url);
-        soup_session.send_message (message);
-        check_response_headers(message);
-
-        // All valid communication involves body data in the response
-        if (message.response_body.data == null || message.response_body.data.length == 0) {
-            throw new PublishingError.MALFORMED_RESPONSE ("No response data from %s", message.get_uri().to_string (false));
-        }
-
-        return message.response_body.data;
-    }
-
     public static bool valid_http_uri(string url) {
         return url.index_of("http://") == 0 || url.index_of("https://") == 0;
     }
@@ -47,7 +41,7 @@ public class SoupClient {
 
         try {
             SoupClient soup_client = new SoupClient();
-            soup_client.send_message(HttpMethod.GET, uri);
+            soup_client.request_as_string(HttpMethod.GET, uri);
         } catch(Error e) {
             warning(e.message);
             return false;

--- a/src/Utils/XmlUtils.vala
+++ b/src/Utils/XmlUtils.vala
@@ -22,35 +22,27 @@ namespace Vocal {
 
         public static string strip_trailing_rss_chars(string rss) {
             // If there is a feed tag , it is atom file, else a rss one.
-            if (rss.last_index_of("</feed>")>0) {
+            if (rss.last_index_of("</feed>") > 0) {
                 return rss.substring(0, rss.last_index_of("</feed>") + "</feed>".length);
-            }
-            else {
+            } else {
                 return rss.substring(0, rss.last_index_of("</rss>") + "</rss>".length);
             }
         }
     
-        public static unowned Xml.Doc parse_string (string? input_string) throws PublishingError {
+        public static unowned Xml.Doc parse_string (string? input_string) throws Error {
             if (input_string == null || input_string.length == 0) {
                 throw new PublishingError.MALFORMED_RESPONSE ("Empty XML string");
             }
 
             var rss = strip_trailing_rss_chars(input_string);
-    
-            // Does this even start and end with the right characters?
-            if (!rss.chug ().chomp ().has_prefix ("<") ||
-            !rss.chug ().chomp ().has_suffix (">")) {
-                // Didn't start or end with a < or > and can't be parsed as XML - treat as malformed.
-                throw new PublishingError.MALFORMED_RESPONSE ("Unable to parse XML document 1");
-            }
 
             // Don't want blanks to be included as text nodes, and want the XML parser to tolerate
             // tolerable XML
             Xml.Doc *doc = Xml.Parser.read_memory (rss, (int) rss.length, null, null,
             Xml.ParserOption.NOBLANKS | Xml.ParserOption.RECOVER);
-            if (doc == null)
+            if (doc == null) {
                 throw new PublishingError.MALFORMED_RESPONSE ("Unable to parse XML document 2");
-
+            }
             // Since 'doc' is the top level, if it has no children, something is wrong
             // with the XML; we cannot continue normally here.
             if (doc->children == null) {


### PR DESCRIPTION
…art and closing xml brackets since libxml already checks.

Fix #333. It seems the reasons this was happening is because vocal didn't support https feeds. Also vocal doesn't need to check for the starting `'<'` and `'>'` because libxml already does that and gives an error like this if they are missing. 
```
parser error : Start tag expected, '<' not found
?xml version="1.0" encoding="UTF-8"?>
```

Furthermore, this fixes an unreported issue whereby when I unsubscribed to a podcast and re-subscribe, the coverart wan't shown.