### PR TITLE
RFC: Enforce elementary code style with vala-lint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,3 +24,5 @@ script:
   - houston ci
     --name-domain com.github.needleandthread.vocal
     --name-human Vocal
+
+  - docker run -v $(pwd)/src:/var/opt/vala-lint elementary/docker:vala-lint

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,4 +25,4 @@ script:
     --name-domain com.github.needleandthread.vocal
     --name-human Vocal
 
-  - docker run -v $(pwd)/src:/var/opt/vala-lint elementary/docker:vala-lint
+  - docker run -v $(pwd)/src:/app valalang/lint

--- a/src/Controller.vala
+++ b/src/Controller.vala
@@ -28,30 +28,29 @@ namespace Vocal {
 
 
     public class Controller : GLib.Object {
-    
+
         public MainWindow window = null;
         public VocalApp app = null;
         public VocalSettings settings = VocalSettings.get_default_instance ();
         public Library library = null;
         public Player player;
         public iTunesProvider itunes = null;
-        
+
         /* Signals */
 
-        public signal void track_changed(string episode_title, string podcast_name, string artwork_uri, uint64 duration);
-        public signal void playback_status_changed(string status);
+        public signal void track_changed (string episode_title, string podcast_name, string artwork_uri, uint64 duration);
+        public signal void playback_status_changed (string status);
         public signal void update_status_changed (bool currently_updating);
 
-    
         /* Runtime flags */
-        
+
         public bool first_run = true;
         public bool newly_launched = true;
         public bool should_quit_immediately = true;
         public bool plugins_are_installing = false;
         public bool checking_for_updates = false;
         public bool is_closing = false;
-        public bool on_elementary = Utils.check_elementary();
+        public bool on_elementary = Utils.check_elementary ();
         public bool open_hidden = false;
         public bool currently_repopulating = false;
         public bool currently_importing = false;
@@ -65,65 +64,65 @@ namespace Vocal {
 
         public Episode current_episode;
         public Podcast highlighted_podcast;
-        
+
         /* Miscellaneous global variables */
 
         public int minutes_elapsed_in_period;
-        
-        
-        
-        
+
+
+
+
         public Controller (VocalApp app) {
-        
+
             info ("Initializing the controller.");
-        
+
             this.app = app;
-            
+
             info ("Initializing the player from GStreamer.");
-        
+
             // Create the Player and Initialize GStreamer
             player = Player.get_default (app.args);
-            
+
             info ("Initializing the iTunes store provider.");
-            
-            itunes = new iTunesProvider();
-            
+
+            itunes = new iTunesProvider ();
+
             info ("Establishing a connection to your podcast library.");
 
             library = new Library (this);
             library.run_database_update_check ();
-            
-            
+
+
             // IMPORTANT NOTE: the player, library, and iTunes provider MUST exist before the MainWindow is created
-            
+
             info ("Initializing the main window.");
-            
+
             window = new MainWindow (this);
-            
+
             // Once the Window exists, connect player signals
             player.eos.connect (window.on_stream_ended);
             player.additional_plugins_required.connect (window.on_additional_plugins_needed);
-            
-            
+
+
             info ("Initializing MPRIS playback.");
-            
+
             // Set up the MPRIS playback functionality
             MPRIS mpris = new MPRIS (this);
             mpris.initialize ();
-            
-            
+
+
             // Connect the new player position available signal from the player
             // to set the new progress on the playback box
-            player.new_position_available.connect(() => {
+            player.new_position_available.connect (() => {
 
-                if(player.progress > 0)
+                if (player.progress > 0)
                     player.current_episode.last_played_position = player.progress;
 
                 int mins_remaining;
                 int secs_remaining;
                 int mins_elapsed;
                 int secs_elapsed;
-                
+
                 // Progress is a percentage of completiong. Multiple by duration to get elapsed.
                 double total_secs_elapsed = player.duration * player.progress;
 
@@ -135,18 +134,18 @@ namespace Vocal {
                 mins_remaining = (int) total_secs_remaining / 60;
                 secs_remaining = (int) total_secs_remaining % 60;
 
-                if(!currently_importing && player.progress != 0) {
-                    window.toolbar.playback_box.set_progress(player.progress, mins_remaining, secs_remaining, mins_elapsed, secs_elapsed);
-                    window.video_controls.set_progress(player.progress, mins_remaining, secs_remaining, mins_elapsed, secs_elapsed);
+                if (!currently_importing && player.progress != 0) {
+                    window.toolbar.playback_box.set_progress (player.progress, mins_remaining, secs_remaining, mins_elapsed, secs_elapsed);
+                    window.video_controls.set_progress (player.progress, mins_remaining, secs_remaining, mins_elapsed, secs_elapsed);
                 }
             });
-            
+
             info ("Initializing notifications.");
-            
+
             //TODO: Replace libnotify with GLib.Notification
             // Initialize notifications (if libnotify is present and enabled)
 #if HAVE_LIBNOTIFY
-            Notify.init("Vocal");
+            Notify.init ("Vocal");
 #endif
 
             info ("Setting up media keys.");
@@ -155,41 +154,41 @@ namespace Vocal {
             try {
                 mediakeys = Bus.get_proxy_sync (BusType.SESSION,
                     "org.gnome.SettingsDaemon", "/org/gnome/SettingsDaemon/MediaKeys");
-                mediakeys.MediaPlayerKeyPressed.connect ( (bus, app, key) => {
+                mediakeys.MediaPlayerKeyPressed.connect ((bus, app, key) => {
                     if (app != "vocal")
                        return;
                     switch (key) {
                         case "Previous":
-                            seek_backward();
+                            seek_backward ();
                             break;
                         case "Next":
-                            seek_forward();
+                            seek_forward ();
                             break;
                         case "Play":
-                            play_pause();
+                            play_pause ();
                             break;
                         default:
                             break;
                     }
                 });
 
-                mediakeys.GrabMediaPlayerKeys("vocal", 0);
+                mediakeys.GrabMediaPlayerKeys ("vocal", 0);
             } catch (Error e) { warning (e.message); }
-        
-        
+
+
             info ("Setting up keyboard shortcuts.");
-            
-            
+
+
             // Set up all the keyboard shortcuts
-            window.key_press_event.connect ( (e) => {
-               
+            window.key_press_event.connect ((e) => {
+
                 bool handled = false;
 
                 // Was the control key pressed?
-                if((e.state & Gdk.ModifierType.CONTROL_MASK) != 0) {
+                if ((e.state & Gdk.ModifierType.CONTROL_MASK) != 0) {
                     switch (e.keyval) {
                         case Gdk.Key.q:
-                            window.destroy();
+                            window.destroy ();
                             handled = true;
                             break;
                         case Gdk.Key.f:
@@ -202,33 +201,33 @@ namespace Vocal {
                 } else {
                     switch (e.keyval) {
                         case Gdk.Key.space:
-                            if(!window.search_results_view.search_entry.has_focus) {
-                                play_pause();
+                            if (!window.search_results_view.search_entry.has_focus) {
+                                play_pause ();
                                 handled = true;
                             }
 
                             break;
                         case Gdk.Key.F11:
-                            window.on_fullscreen_request();
+                            window.on_fullscreen_request ();
                             handled = true;
                             break;
                         case Gdk.Key.Escape:
-                            if(window.fullscreened) {
-                                window.on_fullscreen_request();
+                            if (window.fullscreened) {
+                                window.on_fullscreen_request ();
                                 handled = true;
                             }
 
                             break;
 
                         case Gdk.Key.Left:
-                            if(!window.search_results_view.search_entry.has_focus) {
-                                seek_backward();
+                            if (!window.search_results_view.search_entry.has_focus) {
+                                seek_backward ();
                                 handled = true;
                             }
                             break;
                         case Gdk.Key.Right:
-                            if(!window.search_results_view.search_entry.has_focus) {
-                                seek_forward();
+                            if (!window.search_results_view.search_entry.has_focus) {
+                                seek_forward ();
                                 handled = true;
                             }
                             break;
@@ -236,12 +235,12 @@ namespace Vocal {
                 }
 
                 return handled;
-            });           
+            });
 
             // Connect the library's signals
             library.import_status_changed.connect (window.on_import_status_changed);
             library.download_finished.connect (window.on_download_finished);
-            
+
             // Determine whether or not the local library exists
             first_run = (!library.check_database_exists ());
 
@@ -250,67 +249,67 @@ namespace Vocal {
                 library.refill_library ();
             } else {
                 info ("Setting up library.");
-                library.setup_library();
+                library.setup_library ();
             }
-            
+
             if (first_run || library.empty ()) {
                 window.toolbar.new_episodes_button.set_no_show_all (true);
                 window.toolbar.new_episodes_button.hide ();
             }
-            
+
             // Autoclean the library if necessary
             if (settings.autoclean_library) {
                 info ("Performing library autoclean.");
-                library.autoclean_library();
+                library.autoclean_library ();
             }
 
             // Check for updates after 20 seconds
             GLib.Timeout.add (20000, () => {
-                on_update_request();
+                on_update_request ();
                 return false;
             });
-        
-        
+
+
             // Set minutes elapsed to zero since the app is just now starting up
             minutes_elapsed_in_period = 0;
 
             // Automatically check for new episodes
-            if(settings.update_interval != 0) {
+            if (settings.update_interval != 0) {
 
                 //Increase count and check for match every 5 minutes
-                GLib.Timeout.add(300000, () => {
+                GLib.Timeout.add (300000, () => {
 
                     // The update interval increases/decreases by a step of 5 each time, so eventually
                     // the current count will equal the update interval. When that happens, update.
                     minutes_elapsed_in_period += 5;
-                    if(minutes_elapsed_in_period == settings.update_interval) {
-                        on_update_request();
+                    if (minutes_elapsed_in_period == settings.update_interval) {
+                        on_update_request ();
                     }
 
                     return true;
                 });
             }
-            
+
             info ("Controller initialization finished. Running post-creation sequence.");
-            post_creation_sequence();
+            post_creation_sequence ();
         }
-        
-        private void post_creation_sequence() {
-        
+
+        private void post_creation_sequence () {
+
             // Show the welcome widget if it's the first run, or if the library is empty
-            if(first_run || library.empty ()) {
-                window.show_all();
-                window.switch_visible_page(window.welcome);
+            if (first_run || library.empty ()) {
+                window.show_all ();
+                window.switch_visible_page (window.welcome);
 
             } else {
                 // Populate the IconViews from the library
-                window.populate_views();
-                window.show_all();
-                window.switch_visible_page(window.all_scrolled);
+                window.populate_views ();
+                window.show_all ();
+                window.switch_visible_page (window.all_scrolled);
 
             }
         }
-        
+
         /*
          * Playback related methods
          */
@@ -320,14 +319,14 @@ namespace Vocal {
          * the appropriate function
          */
 
-        public void play_pause() {
+        public void play_pause () {
 
             // If the player is playing, pause. Otherwise, play
-            if(player != null) {
-                if(player.playing) {
-                    pause();
+            if (player != null) {
+                if (player.playing) {
+                    pause ();
                 } else {
-                    play();
+                    play ();
                 }
             }
         }
@@ -336,153 +335,153 @@ namespace Vocal {
         /*
          * Handles play requests and starts media playback using the player
          */
-        public void play() {
+        public void play () {
 
-            if(current_episode != null) {
-                window.toolbar.show_playback_box();
+            if (current_episode != null) {
+                window.toolbar.show_playback_box ();
 
                 //If the current episode is unplayed, subtract one from unplayed total and display
-                if(current_episode.status == EpisodeStatus.UNPLAYED) {
-                    window.current_episode_art.set_count(window.details.unplayed_count);
-                    if(window.details.unplayed_count > 0)
-                        window.current_episode_art.show_count();
+                if (current_episode.status == EpisodeStatus.UNPLAYED) {
+                    window.current_episode_art.set_count (window.details.unplayed_count);
+                    if (window.details.unplayed_count > 0)
+                        window.current_episode_art.show_count ();
                     else
-                        window.current_episode_art.hide_count();
+                        window.current_episode_art.hide_count ();
                     library.new_episode_count--;
-                    library.set_new_badge();
+                    library.set_new_badge ();
                 }
 
                 // Mark the current episode as played
-                library.mark_episode_as_played(current_episode);
+                library.mark_episode_as_played (current_episode);
 
                 // If the currently selected episode isn't set, do so
-                if(player.current_episode != current_episode) {
+                if (player.current_episode != current_episode) {
 
                     // Save the position information from the previous episode
-                    if(player.current_episode != null) {
-                        library.set_episode_playback_position(player.current_episode);
+                    if (player.current_episode != null) {
+                        library.set_episode_playback_position (player.current_episode);
                     }
 
-                    player.set_episode(current_episode);
+                    player.set_episode (current_episode);
                 }
 
 
                 // Are we playing a video? If so, is the video widget already being displayed?
-                if(player.current_episode.parent.content_type == MediaType.VIDEO && window.current_widget != window.video_widget) {
+                if (player.current_episode.parent.content_type == MediaType.VIDEO && window.current_widget != window.video_widget) {
 
                     // If you want to see a pretty animation, you must give the player time to configure everything
                     GLib.Timeout.add (1000, () => {
-                        window.switch_visible_page(window.video_widget);
+                        window.switch_visible_page (window.video_widget);
                         return false;
                     });
                 }
 
-                player.play();
-                playback_status_changed("Playing");
+                player.play ();
+                playback_status_changed ("Playing");
 
                 // Seek if necessary
-                if(current_episode.last_played_position > 0 && current_episode.last_played_position > player.progress) {
+                if (current_episode.last_played_position > 0 && current_episode.last_played_position > player.progress) {
 
                     // If it's a streaming episode, seeking takes longer
                     // Temporarily pause the track and give it some time to seek
-                    if(current_episode.current_download_status == DownloadStatus.NOT_DOWNLOADED) {
-                        player.pause();
+                    if (current_episode.current_download_status == DownloadStatus.NOT_DOWNLOADED) {
+                        player.pause ();
                     }
 
-                    player.set_position(current_episode.last_played_position);
+                    player.set_position (current_episode.last_played_position);
 
                     // Pause for about a second to give time to catch up
-                    if(current_episode.current_download_status == DownloadStatus.NOT_DOWNLOADED) {
-                        player.pause();
-                        Thread.usleep(700000);
-                        player.play();
+                    if (current_episode.current_download_status == DownloadStatus.NOT_DOWNLOADED) {
+                        player.pause ();
+                        Thread.usleep (700000);
+                        player.play ();
                     }
                 }
 
-                var playpause_image = new Gtk.Image.from_icon_name("media-playback-pause-symbolic", Gtk.IconSize.LARGE_TOOLBAR);
-                window.toolbar.set_play_pause_image(playpause_image);
-                window.toolbar.set_play_pause_text(_("Pause"));
+                var playpause_image = new Gtk.Image.from_icon_name ("media-playback-pause-symbolic", Gtk.IconSize.LARGE_TOOLBAR);
+                window.toolbar.set_play_pause_image (playpause_image);
+                window.toolbar.set_play_pause_text (_ ("Pause"));
 
-                var video_playpause_image = new Gtk.Image.from_icon_name("media-playback-pause-symbolic", Gtk.IconSize.LARGE_TOOLBAR);
+                var video_playpause_image = new Gtk.Image.from_icon_name ("media-playback-pause-symbolic", Gtk.IconSize.LARGE_TOOLBAR);
                 window.video_controls.play_button.image = video_playpause_image;
-                window.video_controls.tooltip_text = _("Pause");
-            
+                window.video_controls.tooltip_text = _ ("Pause");
+
 
                 // Set the media information (assuming we're not importing. If we are, the import status is more important
                 // and the media info will be correctly set after it is finished.)
-                if(!currently_importing) {
-                    window.toolbar.playback_box.set_info_title(current_episode.title.replace("%27", "'"), current_episode.parent.name.replace("%27", "'"));
-                    window.video_controls.set_info_title(current_episode.title.replace("%27", "'"), current_episode.parent.name.replace("%27", "'"));
-                    window.shownotes.set_notes_text(current_episode.description);
+                if (!currently_importing) {
+                    window.toolbar.playback_box.set_info_title (current_episode.title.replace ("%27", "'"), current_episode.parent.name.replace ("%27", "'"));
+                    window.video_controls.set_info_title (current_episode.title.replace ("%27", "'"), current_episode.parent.name.replace ("%27", "'"));
+                    window.shownotes.set_notes_text (current_episode.description);
                 }
-                window.show_all();
+                window.show_all ();
             }
         }
 
         /* Pauses playback if it is currently playing */
-        public void pause() {
+        public void pause () {
 
             // If we are playing, switch to paused mode.
-            if(player.playing) {
-                player.pause();
-                playback_status_changed("Paused");
-                var playpause_image = new Gtk.Image.from_icon_name("media-playback-start-symbolic", Gtk.IconSize.LARGE_TOOLBAR);
-                window.toolbar.set_play_pause_image(playpause_image);
-                window.toolbar.set_play_pause_text(_("Play"));
+            if (player.playing) {
+                player.pause ();
+                playback_status_changed ("Paused");
+                var playpause_image = new Gtk.Image.from_icon_name ("media-playback-start-symbolic", Gtk.IconSize.LARGE_TOOLBAR);
+                window.toolbar.set_play_pause_image (playpause_image);
+                window.toolbar.set_play_pause_text (_ ("Play"));
 
-                var video_playpause_image = new Gtk.Image.from_icon_name("media-playback-start-symbolic", Gtk.IconSize.LARGE_TOOLBAR);
+                var video_playpause_image = new Gtk.Image.from_icon_name ("media-playback-start-symbolic", Gtk.IconSize.LARGE_TOOLBAR);
                 window.video_controls.play_button.image = video_playpause_image;
-                window.video_controls.tooltip_text = _("Play");
+                window.video_controls.tooltip_text = _ ("Play");
 
                 // Set last played position
                 current_episode.last_played_position = player.progress;
-                library.set_episode_playback_position(player.current_episode);
+                library.set_episode_playback_position (player.current_episode);
             }
 
             // Set the media information (assuming we're not importing. If we are, the import status is more important
             // and the media info will be correctly set after it is finished.)
-            if(!currently_importing) {
-                window.toolbar.playback_box.set_info_title(current_episode.title.replace("%27", "'"), current_episode.parent.name.replace("%27", "'"));
-                window.video_controls.set_info_title(current_episode.title.replace("%27", "'"), current_episode.parent.name.replace("%27", "'"));
-                window.shownotes.set_notes_text(current_episode.description);
+            if (!currently_importing) {
+                window.toolbar.playback_box.set_info_title (current_episode.title.replace ("%27", "'"), current_episode.parent.name.replace ("%27", "'"));
+                window.video_controls.set_info_title (current_episode.title.replace ("%27", "'"), current_episode.parent.name.replace ("%27", "'"));
+                window.shownotes.set_notes_text (current_episode.description);
             }
 
-            window.show_all();
+            window.show_all ();
         }
-        
+
         /*
          * Seeks backward using the player by the number of settings specified in settings
          */
         public void seek_backward () {
-            player.seek_backward(settings.rewind_seconds);
+            player.seek_backward (settings.rewind_seconds);
         }
 
         /*
          * Seeks forward using the player by the number of settings specified in settings
          */
         public void seek_forward () {
-            player.seek_forward(settings.fast_forward_seconds);
+            player.seek_forward (settings.fast_forward_seconds);
         }
-        
-        
+
+
         /*
          * Does the actual adding of podcast feeds
          */
-        public void add_podcast_feed(string feed) {
-            if(feed.length == 0) {
+        public void add_podcast_feed (string feed) {
+            if (feed.length == 0) {
                 return;
             }
             // Destroy the add podcast dialog box
-            //  window.add_feed.destroy();
+            //  window.add_feed.destroy ();
 
-            info("Adding feed %s", feed);
+            info ("Adding feed %s", feed);
             currently_importing = true;
 
             // Was the RSS feed an iTunes URL? If so, find the actual RSS feed address
-            if(feed.contains("itunes.apple.com")) {
-                string actual_rss = itunes.get_rss_from_itunes_url(feed);
-                if(actual_rss != null) {
-                    info("Original iTunes URL: %s, Vocal found matching RSS address: %s", feed, actual_rss);
+            if (feed.contains ("itunes.apple.com")) {
+                string actual_rss = itunes.get_rss_from_itunes_url (feed);
+                if (actual_rss != null) {
+                    info ("Original iTunes URL: %s, Vocal found matching RSS address: %s", feed, actual_rss);
                     feed = actual_rss;
                 } else {
                     return;
@@ -490,109 +489,109 @@ namespace Vocal {
             }
 
             // Hide the shownotes button
-            window.toolbar.hide_shownotes_button();
+            window.toolbar.hide_shownotes_button ();
             window.toolbar.hide_volume_button ();
-            window.toolbar.hide_playlist_button();
+            window.toolbar.hide_playlist_button ();
 
-            window.toolbar.playback_box.set_message(_("Adding new podcast: <b>" + feed + "</b>"));
-            window.toolbar.show_playback_box();
+            window.toolbar.playback_box.set_message (_ ("Adding new podcast: <b>" + feed + "</b>"));
+            window.toolbar.show_playback_box ();
 
-            var loop = new MainLoop();
+            var loop = new MainLoop ();
             bool success = false;
 
-            library.async_add_podcast_from_file(feed, (obj, res) => {
-                success = library.async_add_podcast_from_file.end(res);
+            library.async_add_podcast_from_file (feed, (obj, res) => {
+                success = library.async_add_podcast_from_file.end (res);
                 currently_importing = false;
-                if(player.playing) {
-                    window.toolbar.playback_box.set_info_title(current_episode.title.replace("%27", "'"), current_episode.parent.name.replace("%27", "'"));
-                    window.video_controls.set_info_title(current_episode.title.replace("%27", "'"), current_episode.parent.name.replace("%27", "'"));
+                if (player.playing) {
+                    window.toolbar.playback_box.set_info_title (current_episode.title.replace ("%27", "'"), current_episode.parent.name.replace ("%27", "'"));
+                    window.video_controls.set_info_title (current_episode.title.replace ("%27", "'"), current_episode.parent.name.replace ("%27", "'"));
                 }
-                loop.quit();
+                loop.quit ();
             });
 
-            loop.run();
+            loop.run ();
 
-            if(success) {
-                window.toolbar.show_shownotes_button();
+            if (success) {
+                window.toolbar.show_shownotes_button ();
                 window.toolbar.show_volume_button ();
-                window.toolbar.show_playlist_button();
+                window.toolbar.show_playlist_button ();
 
-                if(!player.playing)
-                    window.toolbar.hide_playback_box();
+                if (!player.playing)
+                    window.toolbar.hide_playback_box ();
 
                 // Is there now at least one podcast in the library?
-                if(library.podcasts.size > 0) {
+                if (library.podcasts.size > 0) {
                     // Make the refresh and export items sensitive now
                     //refresh_item.sensitive = true;
                     window.toolbar.export_item.sensitive = true;
 
                     // Populate views no matter what
-                    window.populate_views_async();
+                    window.populate_views_async ();
 
-                    if(window.current_widget == window.welcome) {
-                        window.switch_visible_page(window.all_scrolled);
+                    if (window.current_widget == window.welcome) {
+                        window.switch_visible_page (window.all_scrolled);
                     }
 
-                    window.show_all();
+                    window.show_all ();
                 }
             } else {
-                if(!player.playing) {
-                    window.toolbar.hide_playback_box();
+                if (!player.playing) {
+                    window.toolbar.hide_playback_box ();
                 }
 
-                var add_err_dialog = new Gtk.MessageDialog(window.add_feed,
+                var add_err_dialog = new Gtk.MessageDialog (window.add_feed,
                 Gtk.DialogFlags.MODAL,Gtk.MessageType.ERROR,
                 Gtk.ButtonsType.OK, "");
-                add_err_dialog.response.connect((response_id) => {
-                    add_err_dialog.destroy();
+                add_err_dialog.response.connect ((response_id) => {
+                    add_err_dialog.destroy ();
                 });
-                
+
                 // Determine if it was a network issue, or just a problem with the feed
-                bool network_okay = SoupClient.check_connection();
-                
+                bool network_okay = SoupClient.check_connection ();
+
                 string error_message;
-                
-                if(network_okay) {
-                    error_message = _("Please make sure you selected the correct feed and that it is still available.");
+
+                if (network_okay) {
+                    error_message = _ ("Please make sure you selected the correct feed and that it is still available.");
                 } else {
-                    error_message = _("There seems to be a problem with your internet connection. Make sure you are online and then try again.");
+                    error_message = _ ("There seems to be a problem with your internet connection. Make sure you are online and then try again.");
                 }
 
                 var error_img = new Gtk.Image.from_icon_name ("dialog-error", Gtk.IconSize.DIALOG);
-                add_err_dialog.set_transient_for(window);
-                add_err_dialog.text = _("Error Adding Podcast");
+                add_err_dialog.set_transient_for (window);
+                add_err_dialog.text = _ ("Error Adding Podcast");
                 add_err_dialog.secondary_text = error_message;
-                add_err_dialog.set_image(error_img);
-                add_err_dialog.show_all();
+                add_err_dialog.set_image (error_img);
+                add_err_dialog.show_all ();
             }
         }
-        
+
         /*
          * Check for new episodes
          */
-        public void on_update_request() {
+        public void on_update_request () {
 
             // Only check for updates if no other checks are currently under way
-            if(!checking_for_updates) {
+            if (!checking_for_updates) {
 
-                info("Checking for updates.");
+                info ("Checking for updates.");
 
                 checking_for_updates = true;
                 update_status_changed (true);
 
                 // Create an arraylist to store new episodes
-                Gee.ArrayList<Episode> new_episodes = new Gee.ArrayList<Episode>();
+                Gee.ArrayList<Episode> new_episodes = new Gee.ArrayList<Episode> ();
 
-                var loop = new MainLoop();
-                library.check_for_updates.begin((obj, res) => {
+                var loop = new MainLoop ();
+                library.check_for_updates.begin ((obj, res) => {
                     try {
-                        new_episodes = library.check_for_updates.end(res);
+                        new_episodes = library.check_for_updates.end (res);
                     } catch (Error e) {
-                        warning(e.message);
+                        warning (e.message);
                     }
-                    loop.quit();
+                    loop.quit ();
                 });
-                loop.run();
+                loop.run ();
 
                 // Reset the period
                 minutes_elapsed_in_period = 0;
@@ -601,20 +600,19 @@ namespace Vocal {
                 update_status_changed (false);
 
                 // Send a notification if there are new episodes
-                if(new_episodes.size > 0 && !settings.auto_download)
-                {
-                    if(!window.focus_visible)
-                	   Utils.send_generic_notification(_("Fresh content has been added to your library."));
+                if (new_episodes.size > 0 && !settings.auto_download) {
+                    if (!window.focus_visible)
+                       Utils.send_generic_notification (_ ("Fresh content has been added to your library."));
 
-                	// Also update the number of new episodes and set the badge count
-                	library.new_episode_count += new_episodes.size;
-                	library.set_new_badge();
+                    // Also update the number of new episodes and set the badge count
+                    library.new_episode_count += new_episodes.size;
+                    library.set_new_badge ();
                 }
 
                 // Automatically download episodes if set to do so
-                if(settings.auto_download && new_episodes.size > 0) {
-                    foreach(Episode e in new_episodes) {
-                        window.download_episode(e);
+                if (settings.auto_download && new_episodes.size > 0) {
+                    foreach (Episode e in new_episodes) {
+                        window.download_episode (e);
                     }
                 }
 
@@ -624,12 +622,12 @@ namespace Vocal {
                 new_episodes = null;
 
                 // Lastly, if there are new episodes, repopulate the views to obtain new counts
-                if(new_episode_count > 0) {
+                if (new_episode_count > 0) {
                     info ("Repopulating views after the update process has finished.");
-                    window.populate_views_async();
+                    window.populate_views_async ();
                 }
             } else {
-                info("Vocal is already checking for updates.");
+                info ("Vocal is already checking for updates.");
             }
         }
     }

--- a/src/Library.vala
+++ b/src/Library.vala
@@ -33,21 +33,21 @@ namespace Vocal {
 
     public class Library {
 
-		// Fired when a download completes
-        public signal void	download_finished(Episode episode);
+        // Fired when a download completes
+        public signal void download_finished (Episode episode);
 
         // Fired when there is an update during import
-        public signal void 	import_status_changed(int current, int total, string name);
+        public signal void import_status_changed (int current, int total, string name);
 
         // Fired when there is a new, new episode count
-        private signal void new_episode_count_changed();
+        private signal void new_episode_count_changed ();
 
         // Fired when the queue changes
-        public signal void queue_changed();
+        public signal void queue_changed ();
 
-        public ArrayList<Podcast> podcasts;		// Holds all the podcasts in the library
+        public ArrayList<Podcast> podcasts;        // Holds all the podcasts in the library
 
-        private Sqlite.Database db;				// The database
+        private Sqlite.Database db;                // The database
 
         private string db_location = null;
         private string vocal_config_dir = null;
@@ -58,7 +58,7 @@ namespace Vocal {
         private Unity.LauncherEntry launcher;
 #endif
 
-		private VocalSettings settings;			// Vocal's settings
+        private VocalSettings settings;            // Vocal's settings
 
         Episode downloaded_episode = null;
 
@@ -68,89 +68,89 @@ namespace Vocal {
 
             set {
                 _new_episode_count = value;
-                new_episode_count_changed();
+                new_episode_count_changed ();
             }
         }
 
         private int batch_download_count = 0;
         private bool batch_notification_needed = false;
 
-        public Gee.ArrayList<Episode> queue = new Gee.ArrayList<Episode>();
-        private GLib.List<string> podcasts_being_added = new GLib.List<string>();
+        public Gee.ArrayList<Episode> queue = new Gee.ArrayList<Episode> ();
+        private GLib.List<string> podcasts_being_added = new GLib.List<string> ();
 
         private Controller controller;
 
         /*
          * Constructor for the library
          */
-        public Library(Controller controller) {
+        public Library (Controller controller) {
 
             this.controller = controller;
 
-            vocal_config_dir = GLib.Environment.get_user_config_dir() + """/vocal""";
+            vocal_config_dir = GLib.Environment.get_user_config_dir () + """/vocal""";
             this.db_directory = vocal_config_dir + """/database""";
             this.db_location = this.db_directory + """/vocal.db""";
 
-            this.podcasts = new ArrayList<Podcast>();
+            this.podcasts = new ArrayList<Podcast> ();
 
-            settings = VocalSettings.get_default_instance();
+            settings = VocalSettings.get_default_instance ();
 
             // Set the local library path (and replace ~ with the absolute home directory if need be)
-            local_library_path = settings.library_location.replace("~", GLib.Environment.get_home_dir());
+            local_library_path = settings.library_location.replace ("~", GLib.Environment.get_home_dir ());
 
 #if HAVE_LIBUNITY
-            launcher = Unity.LauncherEntry.get_for_desktop_id("vocal.desktop");
+            launcher = Unity.LauncherEntry.get_for_desktop_id ("vocal.desktop");
             launcher.count = new_episode_count;
 #endif
 
-            new_episode_count_changed.connect(set_new_badge);
+            new_episode_count_changed.connect (set_new_badge);
             new_episode_count = 0;
         }
-        
+
         /*
          * As Vocal gets updated,the database must grow to meet new needs.
          * This method is used to test whether certain columns exist,
          * and alters the tables as needed if they don't.
          */
         public void run_database_update_check () {
-        
+
             if (!check_database_exists ()) {
                 return;
             }
-        
+
             info ("Performing database update check.");
-            
+
             // Open the database
             int ec = Sqlite.Database.open (db_location, out db);
-	        if (ec != Sqlite.OK) {
-		        error ("Can't open database: %d: %s\n", db.errcode (), db.errmsg ());
-		        return;
-	        }
-	        
-	        // Temporarily add a dummy podcast
+            if (ec != Sqlite.OK) {
+                error ("Can't open database: %d: %s\n", db.errcode (), db.errmsg ());
+                return;
+            }
+
+            // Temporarily add a dummy podcast
             string query = """INSERT OR REPLACE INTO Podcast (name, feed_uri, album_art_url, album_art_local_uri, description, content_type)
-                VALUES ('%s','%s','%s','%s', '%s', '%s');""".printf("dummy", "dummy", "dummy", "dummy", "dummy", "dummy");
+                VALUES ('%s','%s','%s','%s', '%s', '%s');""".printf ("dummy", "dummy", "dummy", "dummy", "dummy", "dummy");
 
             string errmsg;
 
             ec = db.exec (query, null, out errmsg);
-	        if (ec != Sqlite.OK) {
-		        warning ("Error: %s\n", errmsg);
-		        return;
-	        }
-	        
-	        // Check that license is in the database (added 2018-05-06)
-	        query = """SELECT license FROM Podcast WHERE name = "dummy";""";
-	        errmsg = null;
+            if (ec != Sqlite.OK) {
+                warning ("Error: %s\n", errmsg);
+                return;
+            }
+
+            // Check that license is in the database (added 2018-05-06)
+            query = """SELECT license FROM Podcast WHERE name = "dummy";""";
+            errmsg = null;
 
             ec = db.exec (query, null, out errmsg);
 
             if (ec != Sqlite.OK) {
                 info ("License column does not exist in podcast table. Altering table to update.");
-                
+
                 // Check that license is in the database (added 2018-05-06)
-	            query = """ALTER TABLE Podcast ADD license TEXT;""";
-	            errmsg = null;
+                query = """ALTER TABLE Podcast ADD license TEXT;""";
+                errmsg = null;
 
                 ec = db.exec (query, null, out errmsg);
 
@@ -160,7 +160,7 @@ namespace Vocal {
                     info ("License column successfully added to database.");
                 }
             }
-            
+
             // Clean up by removing the dummy podcast
             query = """DELETE FROM Podcast WHERE name = "dummy";""";
             ec = db.exec (query, null, out errmsg);
@@ -178,35 +178,35 @@ namespace Vocal {
         /*
          * Adds podcasts to the library from the provided OPML file path
          */
-        public async Gee.ArrayList<string> add_from_OPML(string path) {
-            Gee.ArrayList<string> failed_feeds = new Gee.ArrayList<string>();
-            
+        public async Gee.ArrayList<string> add_from_OPML (string path) {
+            Gee.ArrayList<string> failed_feeds = new Gee.ArrayList<string> ();
+
             SourceFunc callback = add_from_OPML.callback;
-            
+
             ThreadFunc<void*> run = () => {
                 try {
-                    FeedParser feed_parser = new FeedParser();
-                    string[] feeds = feed_parser.parse_feeds_from_OPML(path);
-                    info("Done parsing feeds.");
+                    FeedParser feed_parser = new FeedParser ();
+                    string[] feeds = feed_parser.parse_feeds_from_OPML (path);
+                    info ("Done parsing feeds.");
 
                     int i = 0;
                     foreach (string feed in feeds) {
                         i++;
-                        import_status_changed(i, feeds.length, feed);
-                        bool temp_status = add_podcast_from_file(feed);
-                        if(temp_status == false) {
-                            failed_feeds.add(feed);
-                            warning("Failed to add podcast from feed because add_podcast_from_file returned false. for: %s", feed);
+                        import_status_changed (i, feeds.length, feed);
+                        bool temp_status = add_podcast_from_file (feed);
+                        if (temp_status == false) {
+                            failed_feeds.add (feed);
+                            warning ("Failed to add podcast from feed because add_podcast_from_file returned false. for: %s", feed);
                         }
                     }
                 } catch (Error e) {
-                    info("Error parsing OPML file. %s", e.message);
+                    info ("Error parsing OPML file. %s", e.message);
                 }
 
-                Idle.add((owned) callback);
+                Idle.add ((owned) callback);
                 return null;
             };
-            Thread.create<void*>(run, false);
+            Thread.create<void*> (run, false);
 
             yield;
 
@@ -218,34 +218,34 @@ namespace Vocal {
         /*
          * Adds a new podcast to the library
          */
-        public bool add_podcast(Podcast podcast) throws VocalLibraryError {
-            info("Podcast %s being added to library.", podcast.name);
+        public bool add_podcast (Podcast podcast) throws VocalLibraryError {
+            info ("Podcast %s being added to library.", podcast.name);
 
             // Set all but the most recent episode as played on initial add to library
-            if(podcast.episodes.size > 0) {
-                for(int i = 0; i < podcast.episodes.size-1; i++) {
+            if (podcast.episodes.size > 0) {
+                for (int i = 0; i < podcast.episodes.size-1; i++) {
                     podcast.episodes[i].status = EpisodeStatus.PLAYED;
                 }
             }
 
-            string podcast_path = local_library_path + "/%s".printf(podcast.name.replace("%27", "'").replace("%", "_"));
+            string podcast_path = local_library_path + "/%s".printf (podcast.name.replace ("%27", "'").replace ("%", "_"));
 
             // Create a directory for downloads and artwork caching in the local library
-            GLib.DirUtils.create_with_parents(podcast_path, 0775);
+            GLib.DirUtils.create_with_parents (podcast_path, 0775);
 
             //  Locally cache the album art if necessary
             try {
                 // Don't use the default coverart_path getter, we want to make sure we are using the remote URI
-                GLib.File remote_art = GLib.File.new_for_uri(podcast.remote_art_uri);
-                if(remote_art.query_exists()) {
+                GLib.File remote_art = GLib.File.new_for_uri (podcast.remote_art_uri);
+                if (remote_art.query_exists ()) {
                     // If the remote art exists, set the path of the new file and create another object for the local file
-                    string art_path = podcast_path + "/" + remote_art.get_basename().replace("%", "_");
-                    GLib.File local_art = GLib.File.new_for_path(art_path);
+                    string art_path = podcast_path + "/" + remote_art.get_basename ().replace ("%", "_");
+                    GLib.File local_art = GLib.File.new_for_path (art_path);
 
                     // If the local album art doesn't exist
-                    if(!local_art.query_exists()) {
+                    if (!local_art.query_exists ()) {
                         // Cache the art
-                        remote_art.copy(local_art, FileCopyFlags.NONE);
+                        remote_art.copy (local_art, FileCopyFlags.NONE);
                         // Mark the local path on the podcast
                         podcast.local_art_uri = "file://" + art_path;
                     } else {
@@ -253,14 +253,14 @@ namespace Vocal {
                         podcast.local_art_uri = "file://" + art_path;
                     }
                 }
-            } catch(Error e) {
-                error("Unable to save a local copy of the album art. %s", e.message);
+            } catch (Error e) {
+                error ("Unable to save a local copy of the album art. %s", e.message);
             }
 
             // Add the podcast
-            if ( write_podcast_to_database (podcast) ) {
+            if (write_podcast_to_database (podcast)) {
                 // Now that the podcast is in the database, add it to the local arraylist
-                podcasts.add(podcast);
+                podcasts.add (podcast);
 
                 foreach (Episode episode in podcast.episodes) {
                     write_episode_to_database (episode);
@@ -268,50 +268,47 @@ namespace Vocal {
             } else {
                 warning ("failed adding podcast '%s'.", podcast.name);
             }
-
-
-	        return true;
-
+            return true;
         }
 
-		/*
-		 * Adds a new podcast to the library from a given file path by parsing the file's contents
-		 */
-        public bool add_podcast_from_file(string path) {
-        
+        /*
+         * Adds a new podcast to the library from a given file path by parsing the file's contents
+         */
+        public bool add_podcast_from_file (string path) {
+
             foreach (string s in podcasts_being_added) {
                 if (s == path) {
                     info ("Podcast %s already being added.", path);
                     return false;
                 }
             }
-            
+
             foreach (Podcast p in podcasts) {
                 if (p.feed_uri == path) {
                     info ("Podcast %s already in library. If you wish to re-add, remove the original first.", p.name);
                     return false;
                 }
             }
-            
+
             string uri = path;
-            
+
             // Discover the real URI (avoid redirects)
-            if(path.contains("http")) {
-                uri = Utils.get_real_uri(path);
+            if (path.contains ("http")) {
+                uri = Utils.get_real_uri (path);
             }
-            
-            info("Adding podcast from: %s", uri);
+
+            info ("Adding podcast from: %s", uri);
             podcasts_being_added.append (path);
 
-            FeedParser feed_parser = new FeedParser();
-            Podcast new_podcast = feed_parser.get_podcast_from_file(uri);
+            FeedParser feed_parser = new FeedParser ();
+            Podcast new_podcast = feed_parser.get_podcast_from_file (uri);
 
-            if(new_podcast == null) {
-                warning("Failed to parse %s", uri);
+            if (new_podcast == null) {
+                warning ("Failed to parse %s", uri);
                 podcasts_being_added.remove (path);
                 return false;
             } else {
-                add_podcast(new_podcast);
+                add_podcast (new_podcast);
                 podcasts_being_added.remove (path);
                 return true;
             }
@@ -321,54 +318,54 @@ namespace Vocal {
         /*
          * Adds a new podcast from a file, asynchronously
          */
-        public async bool async_add_podcast_from_file(string path) {
-        
+        public async bool async_add_podcast_from_file (string path) {
+
             foreach (string s in podcasts_being_added) {
                 if (s == path) {
                     info ("Podcast %s already being added.", path);
                     return false;
                 }
             }
-            
+
             foreach (Podcast p in podcasts) {
                 if (p.feed_uri == path) {
                     info ("Podcast %s already in library. If you wish to re-add, remove the original first.", p.name);
                     return false;
                 }
             }
-            
+
             bool successful = true;
 
             SourceFunc callback = async_add_podcast_from_file.callback;
 
             ThreadFunc<void*> run = () => {
-            
-                info("Adding podcast from file: %s", path);
+
+                info ("Adding podcast from file: %s", path);
                 podcasts_being_added.append (path);
 
-                FeedParser parser = new FeedParser();
+                FeedParser parser = new FeedParser ();
 
                 try {
-                    Podcast new_podcast = parser.get_podcast_from_file(path);
-                    
-                    if(new_podcast == null) {
-                        info("New podcast found to be null. %s", path);
+                    Podcast new_podcast = parser.get_podcast_from_file (path);
+
+                    if (new_podcast == null) {
+                        info ("New podcast found to be null. %s", path);
                         successful = false;
                     } else {
-                        info("Async Adding %s", new_podcast.name);
-                        add_podcast(new_podcast);
+                        info ("Async Adding %s", new_podcast.name);
+                        add_podcast (new_podcast);
                     }
                 } catch (Error e) {
-                    error("Failed to add podcast: %s", e.message);
+                    error ("Failed to add podcast: %s", e.message);
                     successful = false;
                 }
-                
+
                 podcasts_being_added.remove (path);
 
-                Idle.add((owned) callback);
+                Idle.add ((owned) callback);
                 return null;
             };
-            Thread.create<void*>(run, false);
+            Thread.create<void*> (run, false);
 
             yield;
 
@@ -378,34 +375,34 @@ namespace Vocal {
         /*
          * Checks library for downloaded episodes that are played and over a week old
          */
-        public async void autoclean_library() {
+        public async void autoclean_library () {
 
             SourceFunc callback = autoclean_library.callback;
 
             ThreadFunc<void*> run = () => {
                 // Create a new DateTime that is the current date and then subtract one week
-                GLib.DateTime week_ago = new GLib.DateTime.now_utc();
-                week_ago.add_weeks(-1);
+                GLib.DateTime week_ago = new GLib.DateTime.now_utc ();
+                week_ago.add_weeks (-1);
 
-                foreach(Podcast p in podcasts) {
-                    foreach(Episode e in p.episodes) {
+                foreach (Podcast p in podcasts) {
+                    foreach (Episode e in p.episodes) {
 
                         // If e is downloaded, played, and more than a week old
-                        if(e.current_download_status == DownloadStatus.DOWNLOADED &&
-                            e.status == EpisodeStatus.PLAYED && e.datetime_released.compare(week_ago) == -1) {
+                        if (e.current_download_status == DownloadStatus.DOWNLOADED &&
+                            e.status == EpisodeStatus.PLAYED && e.datetime_released.compare (week_ago) == -1) {
 
                             // Delete the episode. Skip checking for an existing file, the delete_episode method will do that automatically
-                            info("Episode %s is more than a week old. Deleting.".printf(e.title));
-                            delete_local_episode(e);
+                            info ("Episode %s is more than a week old. Deleting.".printf (e.title));
+                            delete_local_episode (e);
                         }
                     }
                 }
 
-                Idle.add((owned) callback);
+                Idle.add ((owned) callback);
                 return null;
 
             };
-            Thread.create<void*>(run, false);
+            Thread.create<void*> (run, false);
 
             yield;
         }
@@ -413,53 +410,53 @@ namespace Vocal {
         /*
          * Checks to see if the local database file exists
          */
-        public bool check_database_exists() {
+        public bool check_database_exists () {
             File file = File.new_for_path (db_location);
-	        return file.query_exists ();
+            return file.query_exists ();
         }
 
         /*
          * Checks each feed in the library to see if new episodes are available
          */
-        public async Gee.ArrayList<Episode> check_for_updates() {
+        public async Gee.ArrayList<Episode> check_for_updates () {
             SourceFunc callback = check_for_updates.callback;
-            Gee.ArrayList<Episode> new_episodes = new Gee.ArrayList<Episode>();
+            Gee.ArrayList<Episode> new_episodes = new Gee.ArrayList<Episode> ();
 
-            FeedParser parser = new FeedParser();
+            FeedParser parser = new FeedParser ();
 
             ThreadFunc<void*> run = () => {
-                foreach(Podcast podcast in podcasts) {
+                foreach (Podcast podcast in podcasts) {
                     int added = -1;
                     if (podcast.feed_uri != null && podcast.feed_uri.length > 4) {
-                        info("updating feed %s", podcast.feed_uri);
-                        
+                        info ("updating feed %s", podcast.feed_uri);
+
                         try {
-                            added = parser.update_feed(podcast);
-                        } catch(Error e) {
-                            warning("Failed to update feed for podcast: %s. %s", podcast.name, e.message);
+                            added = parser.update_feed (podcast);
+                        } catch (Error e) {
+                            warning ("Failed to update feed for podcast: %s. %s", podcast.name, e.message);
                             continue;
                         }
                     }
 
-                    while(added > 0) {
+                    while (added > 0) {
                         int index = podcast.episodes.size - added;
 
                         // Add the new episode to the arraylist in case it needs to be downloaded later
-                        new_episodes.add(podcast.episodes[index]);
+                        new_episodes.add (podcast.episodes[index]);
 
-                        write_episode_to_database(podcast.episodes[index]);
+                        write_episode_to_database (podcast.episodes[index]);
                         added--;
                     }
-                    
+
                     if (added == -1) {
                         critical ("Unable to update podcast due to missing feed URL: " + podcast.name);
                     }
                 }
 
-                Idle.add((owned) callback);
+                Idle.add ((owned) callback);
                 return null;
             };
-            Thread.create<void*>(run, false);
+            Thread.create<void*> (run, false);
 
             yield;
 
@@ -469,14 +466,14 @@ namespace Vocal {
         /*
          * Deletes the local media file for an episode
          */
-        public void delete_local_episode(Episode e) {
+        public void delete_local_episode (Episode e) {
 
             // First check that the file exists
-            GLib.File local = GLib.File.new_for_path(e.local_uri);
-            if(local.query_exists()) {
+            GLib.File local = GLib.File.new_for_path (e.local_uri);
+            if (local.query_exists ()) {
 
                 // Delete the file
-                local.delete();
+                local.delete ();
             }
 
             // Clear the fields in the episode
@@ -484,18 +481,18 @@ namespace Vocal {
             e.local_uri = null;
 
             write_episode_to_database (e);
-            recount_unplayed();
+            recount_unplayed ();
         }
 
         /*
          * Downloads a podcast to the local directory and creates a DownloadDetailBox that is useful
          * for displaying download progress information later
          */
-        public DownloadDetailBox? download_episode(Episode episode) {
+        public DownloadDetailBox? download_episode (Episode episode) {
 
             // Check to see if the episode has already been downloaded
-            if(episode.current_download_status == DownloadStatus.DOWNLOADED) {
-                warning("Error. Episode %s is already downloaded.\n", episode.title);
+            if (episode.current_download_status == DownloadStatus.DOWNLOADED) {
+                warning ("Error. Episode %s is already downloaded.\n", episode.title);
                 return null;
             }
 
@@ -503,55 +500,55 @@ namespace Vocal {
 
 
 
-            if(settings.library_location != null) {
+            if (settings.library_location != null) {
                 library_location = settings.library_location;
             }
             else {
-                library_location = GLib.Environment.get_user_data_dir() + """/vocal""";
+                library_location = GLib.Environment.get_user_data_dir () + """/vocal""";
             }
 
 
             // Create a file object for the remotely hosted file
-            GLib.File remote_file = GLib.File.new_for_uri(episode.uri);
+            GLib.File remote_file = GLib.File.new_for_uri (episode.uri);
 
             DownloadDetailBox detail_box = null;
 
             // Set the path of the new file and create another object for the local file
             try {
-                string path = library_location + "/%s/%s".printf(episode.parent.name.replace("%27", "'").replace("%", "_"), remote_file.get_basename());
-                GLib.File local_file = GLib.File.new_for_path(path);
+                string path = library_location + "/%s/%s".printf (episode.parent.name.replace ("%27", "'").replace ("%", "_"), remote_file.get_basename ());
+                GLib.File local_file = GLib.File.new_for_path (path);
 
-                detail_box = new DownloadDetailBox(episode);
-                detail_box.download_has_completed_successfully.connect(on_successful_download);
+                detail_box = new DownloadDetailBox (episode);
+                detail_box.download_has_completed_successfully.connect (on_successful_download);
                 FileProgressCallback callback = detail_box.download_delegate;
-                GLib.Cancellable cancellable = new GLib.Cancellable();
+                GLib.Cancellable cancellable = new GLib.Cancellable ();
 
-                detail_box.cancel_requested.connect( () => {
+                detail_box.cancel_requested.connect (() => {
 
-                    cancellable.cancel();
-                    bool exists = local_file.query_exists();
-                    if(exists) {
+                    cancellable.cancel ();
+                    bool exists = local_file.query_exists ();
+                    if (exists) {
                         try {
-                            local_file.delete();
-                        } catch(Error e) {
-                            stderr.puts("Unable to delete file.\n");
+                            local_file.delete ();
+                        } catch (Error e) {
+                            stderr.puts ("Unable to delete file.\n");
                         }
                     }
 
                 });
 
-                remote_file.copy_async(local_file, FileCopyFlags.OVERWRITE, Priority.DEFAULT, cancellable, callback);
+                remote_file.copy_async (local_file, FileCopyFlags.OVERWRITE, Priority.DEFAULT, cancellable, callback);
 
 
                 // Set the episode's local uri to the new path
                 episode.local_uri = path;
-                mark_episode_as_downloaded(episode);
+                mark_episode_as_downloaded (episode);
 
 
             } catch (Error e) {
             }
 
-            if(batch_download_count > 0) {
+            if (batch_download_count > 0) {
                 batch_notification_needed = true;
             }
             batch_download_count++;
@@ -562,21 +559,21 @@ namespace Vocal {
         /*
          * Adds an episode to the queue
          */
-        public void enqueue_episode(Episode e) {
-            if(!queue.contains(e)){
-                queue.add(e);
-                queue_changed();
+        public void enqueue_episode (Episode e) {
+            if (!queue.contains (e)) {
+                queue.add (e);
+                queue_changed ();
             }
         }
 
         /*
          * Returns the next episode to be played in the queue
          */
-        public Episode? get_next_episode_in_queue() {
-            if(queue.size > 0) {
-                Episode temp =  queue[0];
-                queue.remove(queue[0]);
-                queue_changed();
+        public Episode? get_next_episode_in_queue () {
+            if (queue.size > 0) {
+                Episode temp = queue[0];
+                queue.remove (queue[0]);
+                queue_changed ();
                 return temp;
             } else {
                 return null;
@@ -586,16 +583,16 @@ namespace Vocal {
         /*
          * Moves an episode higher up in the queue so it will be played quicker
          */
-        public void move_episode_up_in_queue(Episode e) {
+        public void move_episode_up_in_queue (Episode e) {
             int i = 0;
             bool match = false;
-            while(i < queue.size) {
+            while (i < queue.size) {
                 match = (e == queue[i]);
-                if(match && i-1 >= 0) {
+                if (match && i-1 >= 0) {
                     Episode old = queue[i-1];
                     queue[i-1] = queue[i];
                     queue[i] = old;
-                    queue_changed();
+                    queue_changed ();
                     return;
                 }
                 i++;
@@ -606,16 +603,16 @@ namespace Vocal {
         /*
          * Moves an episode down in the queue to give other episodes higher priority
          */
-        public void move_episode_down_in_queue(Episode e) {
+        public void move_episode_down_in_queue (Episode e) {
             int i = 0;
             bool match = false;
-            while(i < queue.size) {
+            while (i < queue.size) {
                 match = (e == queue[i]);
-                if(match && i+1 < queue.size) {
+                if (match && i+1 < queue.size) {
                     Episode old = queue[i+1];
                     queue[i+1] = queue[i];
                     queue[i] = old;
-                    queue_changed();
+                    queue_changed ();
                     return;
                 }
                 i++;
@@ -626,16 +623,16 @@ namespace Vocal {
         /*
          * Updates the queue by moving an episode in the old position to the new position
          */
-        public void update_queue(int oldPos, int newPos) {
+        public void update_queue (int oldPos, int newPos) {
             int i;
 
-            if(oldPos < newPos){
-                for(i = oldPos; i < newPos; i++) {
-                    swap(queue, i, i+1);
+            if (oldPos < newPos) {
+                for (i = oldPos; i < newPos; i++) {
+                    swap (queue, i, i+1);
                 }
             } else {
-                for(i = oldPos; i > newPos; i--) {
-                    swap(queue, i, i-1);
+                for (i = oldPos; i > newPos; i--) {
+                    swap (queue, i, i-1);
                 }
             }
         }
@@ -643,7 +640,7 @@ namespace Vocal {
         /*
          * Used by update_queue to swap episodes in the queue.
          */
-        private void swap(Gee.ArrayList<Episode> q, int a, int b) {
+        private void swap (Gee.ArrayList<Episode> q, int a, int b) {
             Episode tmp = q[a];
             q[a] = q[b];
             q[b] = tmp;
@@ -653,11 +650,11 @@ namespace Vocal {
         /*
          * Removes an episode from the queue altogether
          */
-        public void remove_episode_from_queue(Episode e) {
-            foreach(Episode ep in queue) {
-                if(e == ep) {
-                    queue.remove(e);
-                    queue_changed();
+        public void remove_episode_from_queue (Episode e) {
+            foreach (Episode ep in queue) {
+                if (e == ep) {
+                    queue.remove (e);
+                    queue_changed ();
                     return;
                 }
             }
@@ -667,11 +664,11 @@ namespace Vocal {
         /*
          * Exports the current podcast subscriptions to a file at the provided path
          */
-        public void export_to_OPML(string path) {
+        public void export_to_OPML (string path) {
             File file = File.new_for_path (path);
-	        try {
-	            GLib.DateTime now = new GLib.DateTime.now(new TimeZone.local());
-	            string header = """<?xml version="1.0" encoding="UTF-8"?>
+            try {
+                GLib.DateTime now = new GLib.DateTime.now (new TimeZone.local ());
+                string header = """<?xml version="1.0" encoding="UTF-8"?>
 <opml version="1.0">
 <head>
     <title>Vocal Subscriptions Export</title>
@@ -679,44 +676,44 @@ namespace Vocal {
     <dateModified>%s</dateModified>
 </head>
 <body>
-    """.printf(now.to_string(), now.to_string());
-		        FileIOStream stream = file.create_readwrite (FileCreateFlags.REPLACE_DESTINATION);
-		        stream.output_stream.write (header.data);
+    """.printf (now.to_string (), now.to_string ());
+                FileIOStream stream = file.create_readwrite (FileCreateFlags.REPLACE_DESTINATION);
+                stream.output_stream.write (header.data);
 
-		        string output_line;
+                string output_line;
 
-		        foreach(Podcast p in podcasts) {
+                foreach (Podcast p in podcasts) {
 
-		            output_line =
+                    output_line =
     """<outline text="%s" type="rss" xmlUrl="%s"/>
-    """.printf(p.name.replace("\"", "'").replace("&", "and"), p.feed_uri);
-		            stream.output_stream.write(output_line.data);
-		        }
+    """.printf (p.name.replace ("\"", "'").replace ("&", "and"), p.feed_uri);
+                    stream.output_stream.write (output_line.data);
+                }
 
-		        const string footer = """
+                const string footer = """
 </body>
 </opml>
 """;
 
-		        stream.output_stream.write(footer.data);
-	        } catch (Error e) {
-		        warning ("Error: %s\n", e.message);
-	        }
+                stream.output_stream.write (footer.data);
+            } catch (Error e) {
+                warning ("Error: %s\n", e.message);
+            }
         }
 
         /*
          * Marks all episodes in a given podcast as played
          */
-        public void mark_all_episodes_as_played(Podcast highlighted_podcast) {
-            foreach(Episode episode in highlighted_podcast.episodes) {
-                mark_episode_as_played(episode);
+        public void mark_all_episodes_as_played (Podcast highlighted_podcast) {
+            foreach (Episode episode in highlighted_podcast.episodes) {
+                mark_episode_as_played (episode);
             }
         }
 
         /*
          * Marks an episode as downloaded in the database
          */
-        public void mark_episode_as_downloaded(Episode episode) {
+        public void mark_episode_as_downloaded (Episode episode) {
 
             episode.current_download_status = DownloadStatus.DOWNLOADED;
             write_episode_to_database (episode);
@@ -726,10 +723,10 @@ namespace Vocal {
         /*
          * Marks an episode as played in the database
          */
-        public void mark_episode_as_played(Episode episode) {
+        public void mark_episode_as_played (Episode episode) {
 
-            if(episode == null)
-                error("Episode null!");
+            if (episode == null)
+                error ("Episode null!");
 
             episode.status = EpisodeStatus.PLAYED;
             write_episode_to_database (episode);
@@ -738,7 +735,7 @@ namespace Vocal {
         /*
          * Marks an episode as unplayed in the database
          */
-        public void mark_episode_as_unplayed(Episode episode) {
+        public void mark_episode_as_unplayed (Episode episode) {
 
             episode.status = EpisodeStatus.UNPLAYED;
             write_episode_to_database (episode);
@@ -748,26 +745,26 @@ namespace Vocal {
         /*
          * Notifies the user that a download has completed successfully
          */
-        public void on_successful_download(string episode_title, string parent_podcast_name) {
+        public void on_successful_download (string episode_title, string parent_podcast_name) {
 
             batch_download_count--;
             try {
-                recount_unplayed();
-                set_new_badge();
+                recount_unplayed ();
+                set_new_badge ();
 
 #if HAVE_LIBNOTIFY
 
-            if(!batch_notification_needed) {
-                string message = _("'%s' from '%s' has finished downloading.").printf(episode_title.replace("%27", "'"), parent_podcast_name.replace("%27","'"));
-                var notification = new Notify.Notification(_("Episode Download Complete"), message, null);
-                if(!controller.window.focus_visible)
-                    notification.show();
+            if (!batch_notification_needed) {
+                string message = _ ("'%s' from '%s' has finished downloading.").printf (episode_title.replace ("%27", "'"), parent_podcast_name.replace ("%27","'"));
+                var notification = new Notify.Notification (_ ("Episode Download Complete"), message, null);
+                if (!controller.window.focus_visible)
+                    notification.show ();
             } else {
-                if(batch_download_count == 0) {
-                    var notification = new Notify.Notification(_("Downloads Complete"), _("New episodes have been downloaded."), "vocal");
+                if (batch_download_count == 0) {
+                    var notification = new Notify.Notification (_ ("Downloads Complete"), _ ("New episodes have been downloaded."), "vocal");
                     batch_notification_needed = false;
-                    if(!controller.window.focus_visible)
-                        notification.show();
+                    if (!controller.window.focus_visible)
+                        notification.show ();
                 }
             }
 
@@ -777,11 +774,11 @@ namespace Vocal {
                 downloaded_episode = null;
                 bool found = false;
 
-                foreach(Podcast podcast in podcasts) {
-                    if(!found) {
-                        if(parent_podcast_name == podcast.name) {
-                            foreach(Episode episode in podcast.episodes) {
-                                if(episode_title == episode.title) {
+                foreach (Podcast podcast in podcasts) {
+                    if (!found) {
+                        if (parent_podcast_name == podcast.name) {
+                            foreach (Episode episode in podcast.episodes) {
+                                if (episode_title == episode.title) {
                                     downloaded_episode = episode;
                                     found = true;
                                 }
@@ -792,15 +789,15 @@ namespace Vocal {
                 }
 
                 // If the episode was found (and it should have been), mark as downloaded and write to database
-                if(downloaded_episode != null) {
+                if (downloaded_episode != null) {
                     downloaded_episode.current_download_status = DownloadStatus.DOWNLOADED;
-                    mark_episode_as_downloaded(downloaded_episode);
+                    mark_episode_as_downloaded (downloaded_episode);
                 }
 
-            } catch(Error e) {
-                error("%s", e.message);
+            } catch (Error e) {
+                error ("%s", e.message);
             } finally {
-                download_finished(downloaded_episode);
+                download_finished (downloaded_episode);
             }
 
         }
@@ -808,15 +805,15 @@ namespace Vocal {
         /*
          * Opens the database and prepares for queries
          */
-        private int prepare_database() {
+        private int prepare_database () {
 
-            assert(db_location != null);
+            assert (db_location != null);
 
             // Open a database:
             int ec = Sqlite.Database.open (db_location, out db);
             if (ec != Sqlite.OK) {
-	            stderr.printf ("Can't open database: %d: %s\n", db.errcode (), db.errmsg ());
-	            return -1;
+                stderr.printf ("Can't open database: %d: %s\n", db.errcode (), db.errmsg ());
+                return -1;
             }
 
             return 0;
@@ -826,83 +823,83 @@ namespace Vocal {
         /*
          * Iterates through each episode in the library to count the number of unplayed episodes
          */
-        public void recount_unplayed() {
+        public void recount_unplayed () {
             new_episode_count = 0;
-            foreach(Podcast p in podcasts) {
-                foreach(Episode e in p.episodes) {
-                    if(e.status == EpisodeStatus.UNPLAYED) {
+            foreach (Podcast p in podcasts) {
+                foreach (Episode e in p.episodes) {
+                    if (e.status == EpisodeStatus.UNPLAYED) {
                         new_episode_count++;
                     }
                 }
             }
 
-            set_new_badge();
+            set_new_badge ();
         }
 
         /*
          * Refills the local library from the contents stored in the database
          */
-        public void refill_library() {
-            podcasts.clear();
-            prepare_database();
+        public void refill_library () {
+            podcasts.clear ();
+            prepare_database ();
 
             Sqlite.Statement stmt;
 
-	        string prepared_query_str = "SELECT * FROM Podcast ORDER BY name";
-	        int ec = db.prepare_v2 (prepared_query_str, prepared_query_str.length, out stmt);
-	        if (ec != Sqlite.OK) {
-		        warning("%d: %s\n", db.errcode (), db.errmsg ());
-		        return;
-	        }
-
-	        // Use the prepared statement:
-
-	        while (stmt.step () == Sqlite.ROW) {
-	            Podcast current = podcast_from_row(stmt);
-		        podcasts.add(current);
-	        }
-
-	        stmt.reset();
-
-
-	        // Repeat the process with the episodes
-
-	        foreach(Podcast podcast in podcasts) {
-
-	            prepared_query_str = "SELECT * FROM Episode WHERE parent_podcast_name = '%s' ORDER BY rowid ASC".printf(podcast.name);
-	            ec = db.prepare_v2 (prepared_query_str, prepared_query_str.length, out stmt);
-	            if (ec != Sqlite.OK) {
-		            stderr.printf ("Error: %d: %s\n", db.errcode (), db.errmsg ());
-		            return;
-	            }
-
-	            while (stmt.step () == Sqlite.ROW) {
-                    Episode episode = episode_from_row(stmt);
-                    episode.parent = podcast;
-
-		            podcast.episodes.add(episode);
-	            }
-
-	            stmt.reset();
+            string prepared_query_str = "SELECT * FROM Podcast ORDER BY name";
+            int ec = db.prepare_v2 (prepared_query_str, prepared_query_str.length, out stmt);
+            if (ec != Sqlite.OK) {
+                warning ("%d: %s\n", db.errcode (), db.errmsg ());
+                return;
             }
 
-            recount_unplayed();
-            set_new_badge();
+            // Use the prepared statement:
+
+            while (stmt.step () == Sqlite.ROW) {
+                Podcast current = podcast_from_row (stmt);
+                podcasts.add (current);
+            }
+
+            stmt.reset ();
+
+
+            // Repeat the process with the episodes
+
+            foreach (Podcast podcast in podcasts) {
+
+                prepared_query_str = "SELECT * FROM Episode WHERE parent_podcast_name = '%s' ORDER BY rowid ASC".printf (podcast.name);
+                ec = db.prepare_v2 (prepared_query_str, prepared_query_str.length, out stmt);
+                if (ec != Sqlite.OK) {
+                    stderr.printf ("Error: %d: %s\n", db.errcode (), db.errmsg ());
+                    return;
+                }
+
+                while (stmt.step () == Sqlite.ROW) {
+                    Episode episode = episode_from_row (stmt);
+                    episode.parent = podcast;
+
+                    podcast.episodes.add (episode);
+                }
+
+                stmt.reset ();
+            }
+
+            recount_unplayed ();
+            set_new_badge ();
         }
 
-        public ArrayList<Podcast> find_matching_podcasts(string term) {
+        public ArrayList<Podcast> find_matching_podcasts (string term) {
 
-            ArrayList<Podcast> matches = new ArrayList<Podcast>();
+            ArrayList<Podcast> matches = new ArrayList<Podcast> ();
 
-            prepare_database();
+            prepare_database ();
 
             Sqlite.Statement stmt;
 
             string prepared_query_str = "SELECT * FROM Podcast WHERE name LIKE ? ORDER BY name";
             int ec = db.prepare_v2 (prepared_query_str, prepared_query_str.length, out stmt);
-            ec = stmt.bind_text(1, "%" + term + "%", -1, null);
+            ec = stmt.bind_text (1, "%" + term + "%", -1, null);
             if (ec != Sqlite.OK) {
-                warning("%d: %s\n", db.errcode (), db.errmsg ());
+                warning ("%d: %s\n", db.errcode (), db.errmsg ());
                 return matches;
             }
 
@@ -910,28 +907,28 @@ namespace Vocal {
 
             int cols = stmt.column_count ();
             while (stmt.step () == Sqlite.ROW) {
-                Podcast current = podcast_from_row(stmt);
+                Podcast current = podcast_from_row (stmt);
 
-                matches.add(current);
+                matches.add (current);
             }
 
-            stmt.reset();
+            stmt.reset ();
             return matches;
         }
 
-        public ArrayList<Episode> find_matching_episodes(string term) {
+        public ArrayList<Episode> find_matching_episodes (string term) {
 
-            ArrayList<Episode> matches = new ArrayList<Episode>();
+            ArrayList<Episode> matches = new ArrayList<Episode> ();
 
-            prepare_database();
+            prepare_database ();
 
             Sqlite.Statement stmt;
 
             string prepared_query_str = "SELECT * FROM Episode WHERE title LIKE ? ORDER BY title";
             int ec = db.prepare_v2 (prepared_query_str, prepared_query_str.length, out stmt);
-            ec = stmt.bind_text(1, "%" + term + "%", -1, null);
+            ec = stmt.bind_text (1, "%" + term + "%", -1, null);
             if (ec != Sqlite.OK) {
-                warning("%d: %s\n".printf(db.errcode (), db.errmsg ()));
+                warning ("%d: %s\n".printf (db.errcode (), db.errmsg ()));
                 return matches;
             }
 
@@ -940,14 +937,14 @@ namespace Vocal {
             int cols = stmt.column_count ();
             while (stmt.step () == Sqlite.ROW) {
 
-                Episode current_ep = episode_from_row(stmt);
+                Episode current_ep = episode_from_row (stmt);
 
                 //Add the new episode
-                matches.add(current_ep);
-                
+                matches.add (current_ep);
+
             }
 
-            stmt.reset();
+            stmt.reset ();
             return matches;
         }
 
@@ -955,23 +952,23 @@ namespace Vocal {
         /*
          * Removes a podcast from the library
          */
-        public void remove_podcast(Podcast podcast) {
+        public void remove_podcast (Podcast podcast) {
 
             string query, errmsg;
             int ec;
 
             // Delete the podcast's episodes from the database
-	        query = "DELETE FROM Episode WHERE parent_podcast_name = '%s';".printf(podcast.name.replace("'", "%27"));
+            query = "DELETE FROM Episode WHERE parent_podcast_name = '%s';".printf (podcast.name.replace ("'", "%27"));
 
 
-	        ec = db.exec (query, null, out errmsg);
-	        if (ec != Sqlite.OK) {
-		        stderr.printf ("Error: %d: %s\n", db.errcode (), db.errmsg ());
-		        return;
-	        }
+            ec = db.exec (query, null, out errmsg);
+            if (ec != Sqlite.OK) {
+                stderr.printf ("Error: %d: %s\n", db.errcode (), db.errmsg ());
+                return;
+            }
 
             // Delete the podcast from the database
-            query = "DELETE FROM Podcast WHERE name = '%s';".printf(podcast.name.replace("'", "%27"));
+            query = "DELETE FROM Podcast WHERE name = '%s';".printf (podcast.name.replace ("'", "%27"));
             ec = db.exec (query, null, out errmsg);
 
             if (ec != Sqlite.OK) {
@@ -979,63 +976,63 @@ namespace Vocal {
             }
 
             // Remove the local object as well
-            podcasts.remove(podcast);
+            podcasts.remove (podcast);
         }
 
-        public Gee.ArrayList<Podcast>? search_by_term(string term) {
+        public Gee.ArrayList<Podcast>? search_by_term (string term) {
 
-            prepare_database();
+            prepare_database ();
 
             Sqlite.Statement stmt;
 
-            var search_pods = new Gee.ArrayList<Podcast>();
+            var search_pods = new Gee.ArrayList<Podcast> ();
 
-            string prepared_query_str = "SELECT * FROM Podcast WHERE name='%s' ORDER BY name".printf(term);
+            string prepared_query_str = "SELECT * FROM Podcast WHERE name='%s' ORDER BY name".printf (term);
             int ec = db.prepare_v2 (prepared_query_str, prepared_query_str.length, out stmt);
             if (ec != Sqlite.OK) {
-                warning("%d: %s\n".printf(db.errcode (), db.errmsg ()));
+                warning ("%d: %s\n".printf (db.errcode (), db.errmsg ()));
                 return null;
             }
 
             // Use the prepared statement:
 
             while (stmt.step () == Sqlite.ROW) {
-                Podcast current = podcast_from_row(stmt);
+                Podcast current = podcast_from_row (stmt);
 
-                search_pods.add(current);
+                search_pods.add (current);
             }
 
-            stmt.reset();
+            stmt.reset ();
 
             return search_pods;
         }
 
-        public Episode episode_from_row(Statement stmt) {
-            Episode episode = new Episode();
+        public Episode episode_from_row (Statement stmt) {
+            Episode episode = new Episode ();
 
-            for (int i = 0; i < stmt.column_count(); i++) {
+            for (int i = 0; i < stmt.column_count (); i++) {
                 string col_name = stmt.column_name (i) ?? "<none>";
                 string val = stmt.column_text (i) ?? "<none>";
 
-                if(col_name == "title") {
+                if (col_name == "title") {
                     episode.title = val;
                 }
-                else if(col_name == "description") {
+                else if (col_name == "description") {
                     episode.description = val;
                 }
                 else if (col_name == "uri") {
                     episode.uri = val;
                 }
                 else if (col_name == "local_uri") {
-                    if(val != "(null)")
+                    if (val != " (null)")
                         episode.local_uri = val;
                 }
                 else if (col_name == "release_date") {
                     episode.date_released = val;
-                    episode.set_datetime_from_pubdate();
+                    episode.set_datetime_from_pubdate ();
                 }
-                else if(col_name == "download_status") {
-                    if(val == "downloaded") {
+                else if (col_name == "download_status") {
+                    if (val == "downloaded") {
                         episode.current_download_status = DownloadStatus.DOWNLOADED;
                     }
                     else {
@@ -1043,37 +1040,37 @@ namespace Vocal {
                     }
                 }
                 else if (col_name == "play_status") {
-                    if(val == "played") {
+                    if (val == "played") {
                         episode.status = EpisodeStatus.PLAYED;
-                    }  else {
+                    } else {
                         episode.status = EpisodeStatus.UNPLAYED;
                     }
                 }
                 else if (col_name == "latest_position") {
                     double position = 0;
-                    if(double.try_parse(val, out position)) {
+                    if (double.try_parse (val, out position)) {
                         episode.last_played_position = position;
                     }
                 }
-                else if(col_name == "parent_podcast_name") {
-                    episode.parent = new Podcast.with_name(val);
+                else if (col_name == "parent_podcast_name") {
+                    episode.parent = new Podcast.with_name (val);
                 }
             }
 
             return episode;
         }
 
-        public Podcast podcast_from_row(Statement stmt) {
-            Podcast podcast = new Podcast();
+        public Podcast podcast_from_row (Statement stmt) {
+            Podcast podcast = new Podcast ();
 
-            for (int i = 0; i < stmt.column_count(); i++) {
+            for (int i = 0; i < stmt.column_count (); i++) {
                 string col_name = stmt.column_name (i) ?? "<none>";
                 string val = stmt.column_text (i) ?? "<none>";
 
-                if(col_name == "name") {
+                if (col_name == "name") {
                     podcast.name = val;
                 }
-                else if(col_name == "feed_uri") {
+                else if (col_name == "feed_uri") {
                     podcast.feed_uri = val;
                 }
                 else if (col_name == "album_art_url") {
@@ -1082,14 +1079,14 @@ namespace Vocal {
                 else if (col_name == "album_art_local_uri") {
                     podcast.local_art_uri = val;
                 }
-                else if(col_name == "description") {
+                else if (col_name == "description") {
                     podcast.description = val;
                 }
                 else if (col_name == "content_type") {
-                    if(val == "audio") {
+                    if (val == "audio") {
                         podcast.content_type = MediaType.AUDIO;
                     }
-                    else if(val == "video") {
+                    else if (val == "video") {
                         podcast.content_type = MediaType.VIDEO;
                     }
                     else {
@@ -1115,14 +1112,14 @@ namespace Vocal {
          * Sets the latest playback position in the database for a provided episode
          * The `last_played_position` property must have already been updated in the episode object.
          */
-        public void set_episode_playback_position(Episode episode) {
+        public void set_episode_playback_position (Episode episode) {
             write_episode_to_database (episode);
         }
 
 /*
-        public void set_launcher_progress(double progress) {
+        public void set_launcher_progress (double progress) {
 #if HAVE_LIBUNITY
-            if(progress > 0.0 && progress < 1.0) {
+            if (progress > 0.0 && progress < 1.0) {
                 launcher.progress = progress;
                 launcher.progress_visible = true;
             }
@@ -1137,10 +1134,10 @@ namespace Vocal {
          * Sets the count on the launcher to match the number of unplayed episodes (if there are
          * unplayed episodes) if libunity is enabled.
          */
-        public void set_new_badge() {
+        public void set_new_badge () {
 #if HAVE_LIBUNITY
             launcher.count = new_episode_count;
-            if(new_episode_count > 0) {
+            if (new_episode_count > 0) {
                 launcher.count_visible = true;
             }
             else {
@@ -1149,60 +1146,56 @@ namespace Vocal {
 #endif
 
         }
-        
-        public void set_new_local_album_art(string path_to_local_file, Podcast p) {
-            
+
+        public void set_new_local_album_art (string path_to_local_file, Podcast p) {
+
             // Copy the file
-            GLib.File current_file = GLib.File.new_for_path(path_to_local_file);
+            GLib.File current_file = GLib.File.new_for_path (path_to_local_file);
 
-            InputStream input_stream = current_file.read();
+            InputStream input_stream = current_file.read ();
 
-            string path = settings.library_location + "/%s/cover.jpg".printf(p.name.replace("%27", "'").replace("%", "_"));
-            GLib.File local_file = GLib.File.new_for_path(path);
+            string path = settings.library_location + "/%s/cover.jpg".printf (p.name.replace ("%27", "'").replace ("%", "_"));
+            GLib.File local_file = GLib.File.new_for_path (path);
 
-            current_file.copy_async(local_file, FileCopyFlags.OVERWRITE, Priority.DEFAULT, null, null);
-            
+            current_file.copy_async (local_file, FileCopyFlags.OVERWRITE, Priority.DEFAULT, null, null);
+
             // Set the new file location in the database
             string query, errmsg;
             int ec;
 
-            query = """UPDATE Podcast SET album_art_local_uri = '%s' WHERE name = '%s'""".printf(local_file.get_uri(),p.name);
+            query = """UPDATE Podcast SET album_art_local_uri = '%s' WHERE name = '%s'""".printf (local_file.get_uri (),p.name);
 
             ec = db.exec (query, null, out errmsg);
 
             if (ec != Sqlite.OK) {
                 stderr.printf ("Error: %s\n", errmsg);
             }
-            
+
             // Set the new file location for the podcast object
-            p.local_art_uri = local_file.get_uri();
-            
+            p.local_art_uri = local_file.get_uri ();
+
         }
 
         /*
          * Creates Vocal's config directory, establishes a new SQLite database, and creates
          *  tables for both Podcasts and Episodes
          */
-        public bool setup_library() {
-
-
-            if(settings.library_location == null) {
-                settings.library_location = GLib.Environment.get_user_data_dir() +  """/vocal""";
+        public bool setup_library () {
+            if (settings.library_location == null) {
+                settings.library_location = GLib.Environment.get_user_data_dir () + """/vocal""";
             }
-            local_library_path = settings.library_location.replace("~", GLib.Environment.get_user_data_dir());
+            local_library_path = settings.library_location.replace ("~", GLib.Environment.get_user_data_dir ());
 
             // If the new local_library_path has been modified, update the setting
-            if(settings.library_location != local_library_path)
-            {
+            if (settings.library_location != local_library_path) {
                 settings.library_location = local_library_path;
             }
 
             // Create the local library
-            GLib.DirUtils.create_with_parents(local_library_path, 0775);
+            GLib.DirUtils.create_with_parents (local_library_path, 0775);
 
             // Create the vocal folder if it doesn't exist
-            GLib.DirUtils.create_with_parents(db_directory, 0775);
-
+            GLib.DirUtils.create_with_parents (db_directory, 0775);
 
             prepare_database ();
 
@@ -1244,7 +1237,7 @@ namespace Vocal {
         /*
          * INSERT/REPLACE a Podcast in the database
          */
-        public bool write_podcast_to_database(Podcast podcast) {
+        public bool write_podcast_to_database (Podcast podcast) {
 
             string content_type_text;
             if (podcast.content_type == MediaType.AUDIO) {
@@ -1281,7 +1274,7 @@ namespace Vocal {
             /* This is here for compatibility. Escaping the name should not be necessary
              * but is left to remain consitent with existing db entries since the name
              * is currently used as the key field. */
-            string name = podcast.name.replace("'", "%27");
+            string name = podcast.name.replace ("'", "%27");
 
             stmt.bind_text (1, name);
             stmt.bind_text (2, podcast.feed_uri);
@@ -1306,7 +1299,7 @@ namespace Vocal {
         /*
          * Insert/Replace an episode in the database
          */
-        public bool write_episode_to_database(Episode episode) {
+        public bool write_episode_to_database (Episode episode) {
 
             string query = "INSERT OR REPLACE INTO Episode " +
                            " (title, parent_podcast_name, uri, local_uri, description, release_date, download_status, play_status, latest_position) " +
@@ -1323,8 +1316,8 @@ namespace Vocal {
             /* This is here for compatibility. Escaping these values should not be necessary
              * but is done to remain consitent with existing db entries since the title
              * and podcast name are currently used as key fields. */
-            string title = episode.title.replace("'", "%27");
-            string parent_podcast_name = episode.parent.name.replace("'", "%27");
+            string title = episode.title.replace ("'", "%27");
+            string parent_podcast_name = episode.parent.name.replace ("'", "%27");
 
             // convert enums to text representations.
             string played_text = (episode.status == EpisodeStatus.PLAYED) ? "played" : "unplayed";

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -72,7 +72,7 @@ namespace Vocal {
         public GtkClutter.Actor return_actor;
         public Clutter.Stage stage;
         public GtkClutter.Embed video_widget;
-        
+
         /* Miscellaneous Global Variables */
         public CoverArt current_episode_art;
         public Gtk.Widget current_widget;
@@ -84,16 +84,16 @@ namespace Vocal {
         public bool fullscreened = false;
         private Gtk.Box parent_box = null;
 
-		/*
-		 * Constructor for the main window. Creates the window and gets everything going.
-		 */
+        /*
+         * Constructor for the main window. Creates the window and gets everything going.
+         */
         public MainWindow (Controller controller) {
-        
+
             this.controller = controller;
-            title = _("Vocal");
+            title = _ ("Vocal");
 
             const string HEADERBAR_STYLESHEET = "@define-color colorPrimary #af81d6;";
-            
+
             const string PRIMARY_STYLESHEET = """
 
                 .album-artwork {
@@ -129,7 +129,7 @@ namespace Vocal {
                     color: white;
                     background-color: #af81d6;
                     border-radius: 100%;
-                    padding: 12px; 
+                    padding: 12px;
                 }
 
                 .directory-art-image {
@@ -177,7 +177,7 @@ namespace Vocal {
                 .sidepane-toolbar {
                     background-color: #fff;
                 }
-                
+
                 .video-widgets-background {
                     background-color: #af81d6;
                 }
@@ -187,22 +187,22 @@ namespace Vocal {
             info ("Loading CSS providers.");
             var css_provider = new Gtk.CssProvider ();
             css_provider.load_from_buffer (PRIMARY_STYLESHEET.data);
-            
+
             var headerbar_css_provider = new Gtk.CssProvider ();
             headerbar_css_provider.load_from_buffer (HEADERBAR_STYLESHEET.data);
-            
+
             var screen = Gdk.Screen.get_default ();
             var style_context = this.get_style_context ();
-            
+
             // No matter what, make sure primary CSS provider is added
-            style_context.add_provider_for_screen(screen, css_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
+            style_context.add_provider_for_screen (screen, css_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
 
             this.set_application (controller.app);
 
             if (controller.settings.dark_mode_enabled) {
                 Gtk.Settings.get_default ().set ("gtk-application-prefer-dark-theme", true);
             } else {
-                style_context.add_provider_for_screen(screen, headerbar_css_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
+                style_context.add_provider_for_screen (screen, headerbar_css_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
             }
 
             // Set window properties
@@ -212,7 +212,7 @@ namespace Vocal {
             // Set up the close event
             this.delete_event.connect (on_window_closing);
             this.window_state_event.connect ((e) => {
-                if(!ignore_window_state_change) {
+                if (!ignore_window_state_change) {
                     on_window_state_changed (e.window.get_state ());
                 } else {
                     unmaximize ();
@@ -220,11 +220,11 @@ namespace Vocal {
                 ignore_window_state_change = false;
                 return false;
             });
-            
-            
-            
+
+
+
             info ("Creating video playback widgets.");
-            
+
             // Create the drawing area for the video widget
             video_widget = new GtkClutter.Embed ();
             video_widget.use_layout_size = false;
@@ -235,7 +235,7 @@ namespace Vocal {
             stage.background_color = {0, 0, 0, 0};
             stage.use_alpha = true;
 
-            actor = new Clutter.Actor();
+            actor = new Clutter.Actor ();
             var aspect_ratio = new ClutterGst.Aspectratio ();
             ((ClutterGst.Content) aspect_ratio).player = controller.player;
             actor.content = aspect_ratio;
@@ -255,17 +255,17 @@ namespace Vocal {
             stage.add_child (bottom_actor);
 
             var child1 = video_controls.get_child () as Gtk.Container;
-            foreach(Gtk.Widget child in child1.get_children()) {
+            foreach (Gtk.Widget child in child1.get_children ()) {
                 child.parent.get_style_context ().add_class ("video-toolbar");
                 child.parent.parent.get_style_context ().add_class ("video-toolbar");
             }
 
             video_widget.motion_notify_event.connect (on_motion_event);
 
-            return_to_library = new Gtk.Button.with_label (_("Return to Library"));
+            return_to_library = new Gtk.Button.with_label (_ ("Return to Library"));
             return_to_library.get_style_context ().add_class ("video-widgets-background");
             return_to_library.has_tooltip = true;
-            return_to_library.tooltip_text = _("Return to Library");
+            return_to_library.tooltip_text = _ ("Return to Library");
             return_to_library.relief = Gtk.ReliefStyle.NONE;
             return_to_library.margin = 5;
             return_to_library.set_no_show_all (false);
@@ -279,120 +279,119 @@ namespace Vocal {
 
             return_actor = new GtkClutter.Actor.with_contents (return_revealer);
             stage.add_child (return_actor);
-            
+
             info ("Creating notebook.");
 
-            notebook = new Gtk.Stack();
+            notebook = new Gtk.Stack ();
             notebook.transition_type = Gtk.StackTransitionType.SLIDE_LEFT_RIGHT;
             notebook.transition_duration = 200;
-            
-            info ("Creating podcast view."); 
-            
+
+            info ("Creating podcast view.");
+
             details = new PodcastView (controller);
-            details.go_back.connect(() => {
-                switch_visible_page(all_scrolled);
+            details.go_back.connect (() => {
+                switch_visible_page (all_scrolled);
             });
 
             info ("Creating welcome screen.");
-            
+
             // Create a welcome screen and add it to the notebook (no matter if first run or not)
-            welcome = new Granite.Widgets.Welcome (_("Welcome to Vocal"), _("Build Your Library By Adding Podcasts"));
-            welcome.append(controller.on_elementary ? "preferences-desktop-online-accounts" : "applications-internet", _("Browse Podcasts"),
-                 _("Browse through podcasts and choose some to add to your library."));
-            welcome.append("list-add", _("Add a New Feed"), _("Provide the web address of a podcast feed."));
-            welcome.append("document-open", _("Import Subscriptions"),
-                    _("If you have exported feeds from another podcast manager, import them here."));
+            welcome = new Granite.Widgets.Welcome (_ ("Welcome to Vocal"), _ ("Build Your Library By Adding Podcasts"));
+            welcome.append (controller.on_elementary ? "preferences-desktop-online-accounts" : "applications-internet", _ ("Browse Podcasts"),
+                 _ ("Browse through podcasts and choose some to add to your library."));
+            welcome.append ("list-add", _ ("Add a New Feed"), _ ("Provide the web address of a podcast feed."));
+            welcome.append ("document-open", _ ("Import Subscriptions"),
+                    _ ("If you have exported feeds from another podcast manager, import them here."));
             welcome.activated.connect(on_welcome);
-            
             info ("Creating new episodes view.");
             new_episodes_view = new NewEpisodesView (controller);
             new_episodes_view.go_back.connect (() => {
-                switch_visible_page(all_scrolled);
+                switch_visible_page (all_scrolled);
             });
-            new_episodes_view.play_episode_requested.connect((episode) => {
-                play_different_track(episode);
+            new_episodes_view.play_episode_requested.connect ((episode) => {
+                play_different_track (episode);
             });
             new_episodes_view.add_all_new_to_queue.connect ((episodes) => {
                 foreach (Episode e in episodes) {
                     enqueue_episode (e);
                 }
             });
-                        
+
             info ("Creating scrolled containers and album art views.");
 
             // Set up scrolled windows so that content will scoll instead of causing the window to expand
             all_scrolled = new Gtk.ScrolledWindow (null, null);
             directory_scrolled = new Gtk.ScrolledWindow (null, null);
-            search_results_scrolled = new Gtk.ScrolledWindow(null, null);
-            search_results_box = new Gtk.Box(Gtk.Orientation.VERTICAL, 0);
+            search_results_scrolled = new Gtk.ScrolledWindow (null, null);
+            search_results_box = new Gtk.Box (Gtk.Orientation.VERTICAL, 0);
             search_results_scrolled.add (search_results_box);
 
-		    // Set up the IconView for all podcasts
-		    all_flowbox = new Gtk.FlowBox();
-            all_art = new Gee.ArrayList<CoverArt>();
-            all_flowbox.get_style_context().add_class("notebook-art");
+            // Set up the IconView for all podcasts
+            all_flowbox = new Gtk.FlowBox ();
+            all_art = new Gee.ArrayList<CoverArt> ();
+            all_flowbox.get_style_context ().add_class ("notebook-art");
             all_flowbox.selection_mode = Gtk.SelectionMode.SINGLE;
             all_flowbox.activate_on_single_click = true;
-            all_flowbox.child_activated.connect(on_child_activated);
+            all_flowbox.child_activated.connect (on_child_activated);
             all_flowbox.valign = Gtk.Align.START;
             all_flowbox.homogeneous = true;
 
-		    all_scrolled.add(all_flowbox);
-		    
+            all_scrolled.add (all_flowbox);
+
             // Set up all the signals for the podcast view
-            details.play_episode_requested.connect(play_different_track);
-            details.download_episode_requested.connect(download_episode);
-            details.enqueue_episode.connect(enqueue_episode);
-            details.mark_episode_as_played_requested.connect(on_mark_episode_as_played_request);
-            details.mark_episode_as_unplayed_requested.connect(on_mark_episode_as_unplayed_request);
-            details.delete_local_episode_requested.connect(on_episode_delete_request);
-            details.mark_all_episodes_as_played_requested.connect(on_mark_as_played_request);
-            details.download_all_requested.connect(on_download_all_request);
-            details.delete_podcast_requested.connect(on_remove_request);
-            details.unplayed_count_changed.connect(on_unplayed_count_changed);
-            details.new_cover_art_set.connect(on_new_cover_art_set);
+            details.play_episode_requested.connect (play_different_track);
+            details.download_episode_requested.connect (download_episode);
+            details.enqueue_episode.connect (enqueue_episode);
+            details.mark_episode_as_played_requested.connect (on_mark_episode_as_played_request);
+            details.mark_episode_as_unplayed_requested.connect (on_mark_episode_as_unplayed_request);
+            details.delete_local_episode_requested.connect (on_episode_delete_request);
+            details.mark_all_episodes_as_played_requested.connect (on_mark_as_played_request);
+            details.download_all_requested.connect (on_download_all_request);
+            details.delete_podcast_requested.connect (on_remove_request);
+            details.unplayed_count_changed.connect (on_unplayed_count_changed);
+            details.new_cover_art_set.connect (on_new_cover_art_set);
 
             // Set up the box that gets displayed when importing from .OPML or .XML files during the first launch
-            import_message_box = new Gtk.Box(Gtk.Orientation.VERTICAL, 25);
-            var import_h1_label = new Gtk.Label(_("Good Stuff is On Its Way"));
-            var import_h3_label = new Gtk.Label(_("If you are importing several podcasts it can take a few minutes. Your library will be ready shortly."));
-            import_h1_label.get_style_context ().add_class("h1");
-            import_h3_label.get_style_context ().add_class("h3");
+            import_message_box = new Gtk.Box (Gtk.Orientation.VERTICAL, 25);
+            var import_h1_label = new Gtk.Label (_ ("Good Stuff is On Its Way"));
+            var import_h3_label = new Gtk.Label (_ ("If you are importing several podcasts it can take a few minutes. Your library will be ready shortly."));
+            import_h1_label.get_style_context ().add_class ("h1");
+            import_h3_label.get_style_context ().add_class ("h3");
             import_h1_label.margin_top = 200;
-            import_message_box.add(import_h1_label);
-            import_message_box.add(import_h3_label);
-            var spinner = new Gtk.Spinner();
+            import_message_box.add (import_h1_label);
+            import_message_box.add (import_h3_label);
+            var spinner = new Gtk.Spinner ();
             spinner.active = true;
-            spinner.start();
-            import_message_box.add(spinner);
+            spinner.start ();
+            import_message_box.add (spinner);
 
             // Add everything into the notebook (except for the iTunes store and search view)
-            notebook.add_titled (welcome, "welcome", _("Welcome"));
-            notebook.add_titled (import_message_box, "import", _("Importing"));
-            notebook.add_titled (all_scrolled, "all", _("All Podcasts"));
-            notebook.add_titled (details, "details", _("Details"));
-            notebook.add_titled (new_episodes_view, "new_episodes", _("New Episodes"));
-            notebook.add_titled (video_widget, "video_player", _("Video"));
-            
+            notebook.add_titled (welcome, "welcome", _ ("Welcome"));
+            notebook.add_titled (import_message_box, "import", _ ("Importing"));
+            notebook.add_titled (all_scrolled, "all", _ ("All Podcasts"));
+            notebook.add_titled (details, "details", _ ("Details"));
+            notebook.add_titled (new_episodes_view, "new_episodes", _ ("New Episodes"));
+            notebook.add_titled (video_widget, "video_player", _ ("Video"));
+
             bool show_complete_button = controller.first_run || controller.library.empty ();
-            
+
             info ("Creating directory view.");
-            
-            directory = new DirectoryView(controller.itunes, controller.first_run);
-            directory.load_top_podcasts();
-            directory.on_new_subscription.connect(on_new_subscription);
-            directory.return_to_library.connect(on_return_to_library);
-            directory.return_to_welcome.connect(() => {
-                switch_visible_page(welcome);
+
+            directory = new DirectoryView (controller.itunes, controller.first_run);
+            directory.load_top_podcasts ();
+            directory.on_new_subscription.connect (on_new_subscription);
+            directory.return_to_library.connect (on_return_to_library);
+            directory.return_to_welcome.connect (() => {
+                switch_visible_page (welcome);
             });
-            directory_scrolled.add(directory);
+            directory_scrolled.add (directory);
 
 
             // Add the remaining widgets to the notebook. At this point, the gang's all here
-            notebook.add_titled(directory_scrolled, "directory", _("Browse Podcast Directory"));
-            notebook.add_titled(search_results_scrolled, "search", _("Search Results"));
-            
-            info("Creating toolbar.");
+            notebook.add_titled (directory_scrolled, "directory", _ ("Browse Podcast Directory"));
+            notebook.add_titled (search_results_scrolled, "search", _ ("Search Results"));
+
+            info ("Creating toolbar.");
 
             // Create the toolbar
             toolbar = new Toolbar (controller.settings);
@@ -401,9 +400,9 @@ namespace Vocal {
 
             // Change the player position to match scale changes
             toolbar.playback_box.scale_changed.connect (() => {
-                controller.player.set_position (toolbar.playback_box.get_progress_bar_fill());
+                controller.player.set_position (toolbar.playback_box.get_progress_bar_fill ());
             });
-            
+
             toolbar.check_for_updates_selected.connect (() => {
                 controller.on_update_request ();
             });
@@ -413,20 +412,20 @@ namespace Vocal {
             });
 
             toolbar.import_podcasts_selected.connect (() => {
-                import_podcasts();
+                import_podcasts ();
             });
 
             toolbar.about_selected.connect (() => {
                 controller.app.show_about (this);
             });
-            
+
             toolbar.theme_toggled.connect (() => {
                 if (controller.settings.dark_mode_enabled) {
                     Gtk.Settings.get_default ().set ("gtk-application-prefer-dark-theme", true);
-                    style_context.remove_provider_for_screen(screen, headerbar_css_provider);
+                    style_context.remove_provider_for_screen (screen, headerbar_css_provider);
                 } else {
                     Gtk.Settings.get_default ().set ("gtk-application-prefer-dark-theme", false);
-                    style_context.add_provider_for_screen(screen, headerbar_css_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
+                    style_context.add_provider_for_screen (screen, headerbar_css_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
                 }
             });
 
@@ -435,7 +434,7 @@ namespace Vocal {
                 settings_dialog.show_name_label_toggled.connect (on_show_name_label_toggled);
                 settings_dialog.show_all ();
             });
-            
+
             toolbar.new_episodes_button.clicked.connect (() => {
                 switch_visible_page (new_episodes_view);
             });
@@ -444,7 +443,7 @@ namespace Vocal {
             toolbar.play_pause_selected.connect (controller.play_pause);
             toolbar.seek_forward_selected.connect (controller.seek_forward);
             toolbar.seek_backward_selected.connect (controller.seek_backward);
-            toolbar.playlist_button.clicked.connect(() => { queue_popover.show_all(); });
+            toolbar.playlist_button.clicked.connect (() => { queue_popover.show_all (); });
 
             toolbar.store_selected.connect (() => {
                 details.pane_should_hide ();
@@ -453,9 +452,9 @@ namespace Vocal {
 
             toolbar.export_selected.connect (export_podcasts);
             toolbar.downloads_selected.connect (show_downloads_popover);
-            toolbar.shownotes_button.clicked.connect(() => { shownotes.show_all(); });
-            
-            toolbar.volume_button.clicked.connect(() => {
+            toolbar.shownotes_button.clicked.connect (() => { shownotes.show_all (); });
+
+            toolbar.volume_button.clicked.connect (() => {
                 var popover = new Gtk.Popover (toolbar.volume_button);
                 var scale = new Gtk.Scale.with_range (Gtk.Orientation.VERTICAL, 0, 1, 0.1);
                 scale.inverted = true;
@@ -464,72 +463,72 @@ namespace Vocal {
                 scale.height_request = 120;
                 scale.set_value (controller.player.get_volume ());
                 scale.value_changed.connect (() => {
-			        controller.player.set_volume (scale.get_value ());
-			        if (scale.get_value () > 0.7) {
-			            var vol_image = toolbar.volume_button.image as Gtk.Image;
-			            vol_image.icon_name = "audio-volume-high-symbolic";
-			        } else if (scale.get_value () > 0.4) {
-			            var vol_image = toolbar.volume_button.image as Gtk.Image;
-			            vol_image.icon_name = "audio-volume-medium-symbolic";
-			        } else if  (scale.get_value () > 0.1) {
-			            var vol_image = toolbar.volume_button.image as Gtk.Image;
-			            vol_image.icon_name = "audio-volume-low-symbolic";
-		            } else {
-		                var vol_image = toolbar.volume_button.image as Gtk.Image;
-			            vol_image.icon_name = "audio-volume-muted-symbolic";
-		            }
-		        });
-                popover.add(scale);
+                    controller.player.set_volume (scale.get_value ());
+                    if (scale.get_value () > 0.7) {
+                        var vol_image = toolbar.volume_button.image as Gtk.Image;
+                        vol_image.icon_name = "audio-volume-high-symbolic";
+                    } else if (scale.get_value () > 0.4) {
+                        var vol_image = toolbar.volume_button.image as Gtk.Image;
+                        vol_image.icon_name = "audio-volume-medium-symbolic";
+                    } else if (scale.get_value () > 0.1) {
+                        var vol_image = toolbar.volume_button.image as Gtk.Image;
+                        vol_image.icon_name = "audio-volume-low-symbolic";
+                    } else {
+                        var vol_image = toolbar.volume_button.image as Gtk.Image;
+                        vol_image.icon_name = "audio-volume-muted-symbolic";
+                    }
+                });
+                popover.add (scale);
                 popover.show_all ();
-                
+
             });
 
             // Repeat for the video playback box scale
             video_controls.progress_bar_scale_changed.connect (() => {
                 controller.player.set_position (video_controls.progress_bar_fill);
             });
-            
-            this.set_titlebar(toolbar);
-            
-            
+
+            this.set_titlebar (toolbar);
+
+
             info ("Creating show notes popover.");
-            
+
             // Create the show notes popover
-            shownotes = new ShowNotesPopover(toolbar.shownotes_button);
-            
+            shownotes = new ShowNotesPopover (toolbar.shownotes_button);
+
             info ("Creating downloads popover.");
-            downloads = new DownloadsPopover(toolbar.download);
-            downloads.closed.connect(() => {
-                if(downloads.downloads.size < 1)
-                    toolbar.hide_downloads_menuitem();
+            downloads = new DownloadsPopover (toolbar.download);
+            downloads.closed.connect (() => {
+                if (downloads.downloads.size < 1)
+                    toolbar.hide_downloads_menuitem ();
             });
-            downloads.all_downloads_complete.connect(toolbar.hide_downloads_menuitem);
+            downloads.all_downloads_complete.connect (toolbar.hide_downloads_menuitem);
 
             info ("Creating queue popover.");
             // Create the queue popover
-            queue_popover = new QueuePopover(toolbar.playlist_button);
-            controller.library.queue_changed.connect(() => {
-                queue_popover.set_queue(controller.library.queue);
+            queue_popover = new QueuePopover (toolbar.playlist_button);
+            controller.library.queue_changed.connect (() => {
+                queue_popover.set_queue (controller.library.queue);
             });
-            queue_popover.set_queue(controller.library.queue);
-            queue_popover.move_up.connect((e) => {
-                controller.library.move_episode_up_in_queue(e);
-                queue_popover.show_all();
+            queue_popover.set_queue (controller.library.queue);
+            queue_popover.move_up.connect ((e) => {
+                controller.library.move_episode_up_in_queue (e);
+                queue_popover.show_all ();
             });
-            queue_popover.move_down.connect((e) => {
-                controller.library.move_episode_down_in_queue(e);
-                queue_popover.show_all();
+            queue_popover.move_down.connect ((e) => {
+                controller.library.move_episode_down_in_queue (e);
+                queue_popover.show_all ();
             });
-            queue_popover.update_queue.connect((oldPos, newPos) => {
-                controller.library.update_queue(oldPos, newPos);
-                queue_popover.show_all();
+            queue_popover.update_queue.connect ((oldPos, newPos) => {
+                controller.library.update_queue (oldPos, newPos);
+                queue_popover.show_all ();
             });
 
-            queue_popover.remove_episode.connect((e) => {
-                controller.library.remove_episode_from_queue(e);
-                queue_popover.show_all();
+            queue_popover.remove_episode.connect ((e) => {
+                controller.library.remove_episode_from_queue (e);
+                queue_popover.show_all ();
             });
-            queue_popover.play_episode_from_queue_immediately.connect(play_episode_from_queue_immediately);
+            queue_popover.play_episode_from_queue_immediately.connect (play_episode_from_queue_immediately);
 
             info ("Adding notebook to window.");
             current_widget = notebook;
@@ -551,196 +550,190 @@ namespace Vocal {
             });
 
             // Create the search box
-            search_results_view = new SearchResultsView(controller.library);
-            search_results_view.on_new_subscription.connect(on_new_subscription);
-            search_results_view.return_to_library.connect(() => {
+            search_results_view = new SearchResultsView (controller.library);
+            search_results_view.on_new_subscription.connect (on_new_subscription);
+            search_results_view.return_to_library.connect (() => {
                 if (controller.library.empty ()) {
                     switch_visible_page (welcome);
                 } else {
-                    switch_visible_page(all_scrolled);
+                    switch_visible_page (all_scrolled);
                 }
             });
-            search_results_view.episode_selected.connect(on_search_popover_episode_selected);
-            search_results_view.podcast_selected.connect(on_search_popover_podcast_selected);
+            search_results_view.episode_selected.connect (on_search_popover_episode_selected);
+            search_results_view.podcast_selected.connect (on_search_popover_podcast_selected);
 
-            search_results_box.add(search_results_view);
-            
-             if(controller.open_hidden) {
-                info("The app will open hidden in the background.");
-                this.hide();
+            search_results_box.add (search_results_view);
+
+             if (controller.open_hidden) {
+                info ("The app will open hidden in the background.");
+                this.hide ();
             }
-            info("Window initialization complete.");
+            info ("Window initialization complete.");
         }
-        
+
         /*
          * Populates the three views (all, audio, video) from the contents of the controller.library
          */
-        public void populate_views() {
-        
-    
-        	if(!controller.currently_repopulating)
-        	{
+        public void populate_views () {
+
+
+            if (!controller.currently_repopulating) {
 
                 info ("Populating the main podcast view.");
-        		controller.currently_repopulating = true;
-	            bool has_video = false;
+                controller.currently_repopulating = true;
+                bool has_video = false;
 
                 // If it's not the first run or newly launched go ahead and remove all the widgets from the flowboxes
-                if(!controller.first_run && !controller.newly_launched) {
-    	            for(int i = 0; i < all_art.size; i++)
-    	            {
-    	            	all_flowbox.remove(all_flowbox.get_child_at_index(0));
-    	            }
+                if (!controller.first_run && !controller.newly_launched) {
+                    for (int i = 0; i < all_art.size; i++) {
+                        all_flowbox.remove (all_flowbox.get_child_at_index (0));
+                    }
 
-                    all_art.clear();
+                    all_art.clear ();
                 }
 
                 //TODO: Move this to the controller
-                
-                info("Restoring last played media.");
-	            // If the program was just launched, check to see what the last played media was
-	            if(controller.newly_launched) {
+
+                info ("Restoring last played media.");
+                // If the program was just launched, check to see what the last played media was
+                if (controller.newly_launched) {
 
                     current_widget = all_scrolled;
 
-	                if(controller.settings.last_played_media != null && controller.settings.last_played_media.length > 1) {
+                    if (controller.settings.last_played_media != null && controller.settings.last_played_media.length > 1) {
 
-	                    // Split the media into two different strings
-	                    string[] fields = controller.settings.last_played_media.split(",");
-	                    bool found = false;
-	                    foreach(Podcast podcast in controller.library.podcasts) {
+                        // Split the media into two different strings
+                        string[] fields = controller.settings.last_played_media.split (",");
+                        bool found = false;
+                        foreach (Podcast podcast in controller.library.podcasts) {
 
-	                        if(!found) {
-	                            if(podcast.name == fields[1]) {
-	                                found = true;
+                            if (!found) {
+                                if (podcast.name == fields[1]) {
+                                    found = true;
 
-	                                // Attempt to find the matching episode, set it as the current episode, and display the information in the box
-	                                foreach(Episode episode in podcast.episodes) {
-	                                    if(episode.title == fields[0]){
-	                                        controller.current_episode = episode;
-	                                        toolbar.playback_box.set_info_title(controller.current_episode.title.replace("%27", "'"), controller.current_episode.parent.name.replace("%27", "'"));
-	                                        controller.track_changed(controller.current_episode.title, controller.current_episode.parent.name, controller.current_episode.parent.coverart_uri, (uint64) controller.player.duration);
+                                    // Attempt to find the matching episode, set it as the current episode, and display the information in the box
+                                    foreach (Episode episode in podcast.episodes) {
+                                        if (episode.title == fields[0]) {
+                                            controller.current_episode = episode;
+                                            toolbar.playback_box.set_info_title (controller.current_episode.title.replace ("%27", "'"), controller.current_episode.parent.name.replace ("%27", "'"));
+                                            controller.track_changed (controller.current_episode.title, controller.current_episode.parent.name, controller.current_episode.parent.coverart_uri, (uint64) controller.player.duration);
 
-	                                        try {
+                                            try {
 
-	                                            controller.player.set_episode(controller.current_episode);
-                                                controller.player.set_position(controller.current_episode.last_played_position);
-	                                            shownotes.set_notes_text(episode.description);
+                                                controller.player.set_episode (controller.current_episode);
+                                                controller.player.set_position (controller.current_episode.last_played_position);
+                                                shownotes.set_notes_text (episode.description);
 
-	                                        } catch(Error e) {
-	                                            warning(e.message);
-	                                        }
+                                            } catch (Error e) {
+                                                warning (e.message);
+                                            }
 
-	                                        if(controller.current_episode.last_played_position != 0) {
-	                                            toolbar.show_playback_box();
-	                                        }
-	                                        else {
-	                                            toolbar.hide_playback_box();
-	                                        }
-	                                    }
-	                                }
-	                            }
-	                        }
-	                    }
-	                }
-	            }
+                                            if (controller.current_episode.last_played_position != 0) {
+                                                toolbar.show_playback_box ();
+                                            }
+                                            else {
+                                                toolbar.hide_playback_box ();
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
 
 
-	            // Refill the controller.library based on what is stored in the database (if it's not newly launched, in
-	            // which case it has already been filled)
-	            if(!controller.newly_launched){
-	                info ("Refilling library.");
-	                controller.library.refill_library();
-	            }
+                // Refill the controller.library based on what is stored in the database (if it's not newly launched, in
+                // which case it has already been filled)
+                if (!controller.newly_launched) {
+                    info ("Refilling library.");
+                    controller.library.refill_library ();
+                }
 
-	            // Clear flags since we have an established controller.library at this point
-	            controller.newly_launched = false;
-	            controller.first_run = false;
-	            
-	            info ("Creating coverart for each podcast in library.");
+                // Clear flags since we have an established controller.library at this point
+                controller.newly_launched = false;
+                controller.first_run = false;
 
-                foreach(Podcast podcast in controller.library.podcasts) {
+                info ("Creating coverart for each podcast in library.");
+
+                foreach (Podcast podcast in controller.library.podcasts) {
 
                     // Determine whether or not there are video podcasts
-                    if(podcast.content_type == MediaType.VIDEO) {
+                    if (podcast.content_type == MediaType.VIDEO) {
                         has_video = true;
                     }
-                    
-                    CoverArt a = new CoverArt(podcast.coverart_uri.replace("%27", "'"), podcast, true);
-                    
+
+                    CoverArt a = new CoverArt (podcast.coverart_uri.replace ("%27", "'"), podcast, true);
+
                     if (controller.on_elementary) {
                         a.get_style_context ().add_class ("card");
                     } else {
-                        a.get_style_context().add_class("coverart");
+                        a.get_style_context ().add_class ("coverart");
                     }
                     a.halign = Gtk.Align.START;
-                    
+
                     int currently_unplayed = 0;
-                    foreach(Episode e in podcast.episodes)
-                    {
-                        if (e.status == EpisodeStatus.UNPLAYED)
-                        {
+                    foreach (Episode e in podcast.episodes) {
+                        if (e.status == EpisodeStatus.UNPLAYED) {
                             currently_unplayed++;
                         }
                     }
 
-                    if(currently_unplayed > 0)
-                    {
-                        a.set_count(currently_unplayed);
-                        a.show_count();
+                    if (currently_unplayed > 0) {
+                        a.set_count (currently_unplayed);
+                        a.show_count ();
                     }
 
-                    else
-                    {
-                        a.hide_count();
+                    else {
+                        a.hide_count ();
                     }
 
-                    all_art.add(a);
-                    
+                    all_art.add (a);
+
                 }
 
-	            controller.currently_repopulating = false;
-        	}
-
-            
-            info("Adding coverart to view.");
-
-            foreach(CoverArt a in all_art) {
-                all_flowbox.add(a);
+                controller.currently_repopulating = false;
             }
 
-            var flowbox_children = all_flowbox.get_children();
-            foreach(Gtk.Widget f in flowbox_children) {
+
+            info ("Adding coverart to view.");
+
+            foreach (CoverArt a in all_art) {
+                all_flowbox.add (a);
+            }
+
+            var flowbox_children = all_flowbox.get_children ();
+            foreach (Gtk.Widget f in flowbox_children) {
                 f.halign = Gtk.Align.CENTER;
                 f.valign = Gtk.Align.START;
             }
-            
+
             new_episodes_view.populate_episodes_list ();
 
             // If the app is supposed to open hidden, don't present the window. Instead, hide it
-            if(!controller.open_hidden && !controller.is_closing) {
-                show_all();
+            if (!controller.open_hidden && !controller.is_closing) {
+                show_all ();
             }
         }
 
         /*
          * Populates the three views (all, audio, video) from the contents of the controller.library
          */
-        public async void populate_views_async() {
-        
+        public async void populate_views_async () {
+
 
             SourceFunc callback = populate_views_async.callback;
 
             ThreadFunc<void*> run = () => {
 
-            	populate_views ();
+                populate_views ();
 
-                Idle.add((owned) callback);
+                Idle.add ((owned) callback);
                 return null;
             };
 
 
-            Thread.create<void*>(run, false);
+            Thread.create<void*> (run, false);
 
             yield;
         }
@@ -749,20 +742,20 @@ namespace Vocal {
          * When a user double-clicks and episode in the queue, remove it from the queue and
          * immediately begin playback
          */
-        private void play_episode_from_queue_immediately(Episode e) {
+        private void play_episode_from_queue_immediately (Episode e) {
 
             controller.current_episode = e;
-            queue_popover.hide();
-            controller.library.remove_episode_from_queue(e);
+            queue_popover.hide ();
+            controller.library.remove_episode_from_queue (e);
 
-            controller.play();
+            controller.play ();
 
             // Set the shownotes, the media information, and update the last played media in the settings
-            controller.track_changed(controller.current_episode.title, controller.current_episode.parent.name, controller.current_episode.parent.coverart_uri, (uint64)controller.player.duration);
-            shownotes.set_notes_text(controller.current_episode.description);
-            controller.settings.last_played_media = "%s,%s".printf(controller.current_episode.title, controller.current_episode.parent.name);
+            controller.track_changed (controller.current_episode.title, controller.current_episode.parent.name, controller.current_episode.parent.coverart_uri, (uint64)controller.player.duration);
+            shownotes.set_notes_text (controller.current_episode.description);
+            controller.settings.last_played_media = "%s,%s".printf (controller.current_episode.title, controller.current_episode.parent.name);
         }
-        
+
         /*
          * Switches the current track and requests the newly selected track starts playing
          */
@@ -775,44 +768,42 @@ namespace Vocal {
                 controller.current_episode = episode;
             }
 
-            controller.player.pause();
-            controller.play();
+            controller.player.pause ();
+            controller.play ();
 
             // Set the shownotes, the media information, and update the last played media in the settings
-            controller.track_changed(controller.current_episode.title, controller.current_episode.parent.name, controller.current_episode.parent.coverart_uri, (uint64) controller.player.duration);
-            shownotes.set_notes_text(controller.current_episode.description);
-            controller.settings.last_played_media = "%s,%s".printf(controller.current_episode.title, controller.current_episode.parent.name);
+            controller.track_changed (controller.current_episode.title, controller.current_episode.parent.name, controller.current_episode.parent.coverart_uri, (uint64) controller.player.duration);
+            shownotes.set_notes_text (controller.current_episode.description);
+            controller.settings.last_played_media = "%s,%s".printf (controller.current_episode.title, controller.current_episode.parent.name);
         }
 
         /*
          * Library functions
          */
-         
-        public async void mark_all_as_played_async(Podcast highlighted_podcast) {
+
+        public async void mark_all_as_played_async (Podcast highlighted_podcast) {
 
             SourceFunc callback = mark_all_as_played_async.callback;
 
             ThreadFunc<void*> run = () => {
 
-                controller.library.mark_all_episodes_as_played(highlighted_podcast);
-                controller.library.recount_unplayed();
-                controller.library.set_new_badge();
-                foreach(CoverArt a in all_art)
-                {
-                    if(a.podcast == highlighted_podcast)
-                    {
-                        a.set_count(0);
-                        a.hide_count();
+                controller.library.mark_all_episodes_as_played (highlighted_podcast);
+                controller.library.recount_unplayed ();
+                controller.library.set_new_badge ();
+                foreach (CoverArt a in all_art) {
+                    if (a.podcast == highlighted_podcast) {
+                        a.set_count (0);
+                        a.hide_count ();
                     }
                 }
 
-                details.mark_all_played();
+                details.mark_all_played ();
 
 
-                Idle.add((owned) callback);
+                Idle.add ((owned) callback);
                 return null;
             };
-            Thread.create<void*>(run, false);
+            Thread.create<void*> (run, false);
 
             yield;
         }
@@ -822,67 +813,67 @@ namespace Vocal {
          * Handles request to download an episode, by showing the downloads menuitem and
          * requesting the download from the controller.library
          */
-        public void download_episode(Episode episode) {
+        public void download_episode (Episode episode) {
             //  Show the download menuitem
-            toolbar.show_download_button();
+            toolbar.show_download_button ();
 
             //  Begin the process of downloading the episode (asynchronously)
-            var details_box = controller.library.download_episode(episode);
-            details_box.cancel_requested.connect(on_download_canceled);
+            var details_box = controller.library.download_episode (episode);
+            details_box.cancel_requested.connect (on_download_canceled);
 
             // Every time a new percentage is available re-calculate the overall percentage
-            details_box.new_percentage_available.connect(() => {
+            details_box.new_percentage_available.connect (() => {
                 double overall_percentage = 1.0;
 
-                foreach(DownloadDetailBox d in downloads.downloads) {
-                    if(d.percentage > 0.0) {
+                foreach (DownloadDetailBox d in downloads.downloads) {
+                    if (d.percentage > 0.0) {
                         overall_percentage *= d.percentage;
                     }
                 }
             });
 
             //  Add the download to the downloads popup
-            downloads.add_download(details_box);
+            downloads.add_download (details_box);
         }
 
 
         public void enqueue_episode (Episode episode) {
-            controller.library.enqueue_episode(episode);
+            controller.library.enqueue_episode (episode);
         }
 
 
         /*
          * Show a dialog to add a single feed to the controller.library
          */
-        public void add_new_podcast() {
-            add_feed = new AddFeedDialog(this, controller.on_elementary);
-            add_feed.response.connect(on_add_podcast_feed);
-            add_feed.show_all();
+        public void add_new_podcast () {
+            add_feed = new AddFeedDialog (this, controller.on_elementary);
+            add_feed.response.connect (on_add_podcast_feed);
+            add_feed.show_all ();
         }
 
 
         /*
          * Create a file containing the current controller.library subscription export
          */
-        public void export_podcasts() {
+        public void export_podcasts () {
             //Create a new file chooser dialog and allow the user to import the save configuration
             var file_chooser = new Gtk.FileChooserDialog ("Save Subscriptions to XML File",
                           this,
                           Gtk.FileChooserAction.SAVE,
-                          _("Cancel"), Gtk.ResponseType.CANCEL,
-                          _("Save"), Gtk.ResponseType.ACCEPT);
+                          _ ("Cancel"), Gtk.ResponseType.CANCEL,
+                          _ ("Save"), Gtk.ResponseType.ACCEPT);
 
-            var all_files_filter = new Gtk.FileFilter();
-            all_files_filter.set_filter_name(_("All files"));
-            all_files_filter.add_pattern("*");
+            var all_files_filter = new Gtk.FileFilter ();
+            all_files_filter.set_filter_name (_ ("All files"));
+            all_files_filter.add_pattern ("*");
 
-            var opml_xml_filter = new Gtk.FileFilter();
-            opml_xml_filter.set_filter_name(_("OPML and XML files"));
-            opml_xml_filter.add_mime_type("application/xml");
-            opml_xml_filter.add_mime_type("text/x-opml+xml");
+            var opml_xml_filter = new Gtk.FileFilter ();
+            opml_xml_filter.set_filter_name (_ ("OPML and XML files"));
+            opml_xml_filter.add_mime_type ("application/xml");
+            opml_xml_filter.add_mime_type ("text/x-opml+xml");
 
-            file_chooser.add_filter(opml_xml_filter);
-            file_chooser.add_filter(all_files_filter);
+            file_chooser.add_filter (opml_xml_filter);
+            file_chooser.add_filter (all_files_filter);
 
             //Modal dialogs are sexy :)
             file_chooser.modal = true;
@@ -890,7 +881,7 @@ namespace Vocal {
             //If the user selects a file, get the name and parse it
             if (file_chooser.run () == Gtk.ResponseType.ACCEPT) {
                 string file_name = (file_chooser.get_filename ());
-                controller.library.export_to_OPML(file_name);
+                controller.library.export_to_OPML (file_name);
             }
 
             //If the user didn't select a file, destroy the dialog
@@ -901,107 +892,107 @@ namespace Vocal {
         /*
          * Choose a file to import to the controller.library
          */
-        public void import_podcasts() {
+        public void import_podcasts () {
 
             controller.currently_importing = true;
 
-            var file_chooser = new Gtk.FileChooserDialog (_("Select Subscription File"),
+            var file_chooser = new Gtk.FileChooserDialog (_ ("Select Subscription File"),
                  this,
                  Gtk.FileChooserAction.OPEN,
-                 _("Cancel"), Gtk.ResponseType.CANCEL,
-                 _("Open"), Gtk.ResponseType.ACCEPT);
+                 _ ("Cancel"), Gtk.ResponseType.CANCEL,
+                 _ ("Open"), Gtk.ResponseType.ACCEPT);
 
-            var all_files_filter = new Gtk.FileFilter();
-            all_files_filter.set_filter_name(_("All files"));
-            all_files_filter.add_pattern("*");
+            var all_files_filter = new Gtk.FileFilter ();
+            all_files_filter.set_filter_name (_ ("All files"));
+            all_files_filter.add_pattern ("*");
 
-            var opml_filter = new Gtk.FileFilter();
-            opml_filter.set_filter_name(_("OPML files"));
-            opml_filter.add_mime_type("text/x-opml+xml");
+            var opml_filter = new Gtk.FileFilter ();
+            opml_filter.set_filter_name (_ ("OPML files"));
+            opml_filter.add_mime_type ("text/x-opml+xml");
 
-            file_chooser.add_filter(opml_filter);
-            file_chooser.add_filter(all_files_filter);
+            file_chooser.add_filter (opml_filter);
+            file_chooser.add_filter (all_files_filter);
 
             file_chooser.modal = true;
 
-            int decision = file_chooser.run();
-            string file_name = file_chooser.get_filename();
+            int decision = file_chooser.run ();
+            string file_name = file_chooser.get_filename ();
 
-            file_chooser.destroy();
+            file_chooser.destroy ();
 
             //If the user selects a file, get the name and parse it
             if (decision == Gtk.ResponseType.ACCEPT) {
 
-                toolbar.show_playback_box();
+                toolbar.show_playback_box ();
 
                 // Hide the shownotes button
-                toolbar.hide_shownotes_button();
+                toolbar.hide_shownotes_button ();
                 toolbar.hide_volume_button ();
-                toolbar.hide_playlist_button();
+                toolbar.hide_playlist_button ();
 
-                if(current_widget == welcome) {
-                    switch_visible_page(import_message_box);
+                if (current_widget == welcome) {
+                    switch_visible_page (import_message_box);
                 }
 
-                var loop = new MainLoop();
-                controller.library.add_from_OPML(file_name, (obj, res) => {
+                var loop = new MainLoop ();
+                controller.library.add_from_OPML (file_name, (obj, res) => {
 
-                    Gee.ArrayList<string> failed_feed_list = controller.library.add_from_OPML.end(res);
+                    Gee.ArrayList<string> failed_feed_list = controller.library.add_from_OPML.end (res);
 
-                    if(!controller.player.playing) {
-                        toolbar.hide_playback_box();
+                    if (!controller.player.playing) {
+                        toolbar.hide_playback_box ();
                     }
 
-                    if(failed_feed_list.size == 0) {
-                        info("Successfully imported all podcasts from OPML.");
+                    if (failed_feed_list.size == 0) {
+                        info ("Successfully imported all podcasts from OPML.");
                     } else {
                         string failed_feeds = "";
-                        foreach(string failed_feed in failed_feed_list) {
-                            failed_feeds = "%s\n %s".printf(failed_feeds, failed_feed);
+                        foreach (string failed_feed in failed_feed_list) {
+                            failed_feeds = "%s\n %s".printf (failed_feeds, failed_feed);
                         }
-                        string error_message = "Vocal was unable to import podcasts from the following feeds in the OPML file. \n%s\n".printf(failed_feeds);
-                        warning(error_message);
+                        string error_message = "Vocal was unable to import podcasts from the following feeds in the OPML file. \n%s\n".printf (failed_feeds);
+                        warning (error_message);
 
                         var error_img = new Gtk.Image.from_icon_name ("dialog-error", Gtk.IconSize.DIALOG);
 
-                        var add_err_dialog = new Gtk.MessageDialog(add_feed, Gtk.DialogFlags.MODAL,Gtk.MessageType.ERROR, Gtk.ButtonsType.OK, "");
-                        add_err_dialog.response.connect((response_id) => {
-                            add_err_dialog.destroy();
+                        var add_err_dialog = new Gtk.MessageDialog (add_feed, Gtk.DialogFlags.MODAL,Gtk.MessageType.ERROR, Gtk.ButtonsType.OK, "");
+                        add_err_dialog.response.connect ((response_id) => {
+                            add_err_dialog.destroy ();
                         });
-                        add_err_dialog.set_transient_for(this);
-                        add_err_dialog.text = _("Error Importing from File");
+                        add_err_dialog.set_transient_for (this);
+                        add_err_dialog.text = _ ("Error Importing from File");
                         add_err_dialog.secondary_text = error_message;
-                        add_err_dialog.set_image(error_img);
-                        add_err_dialog.show_all();
+                        add_err_dialog.set_image (error_img);
+                        add_err_dialog.show_all ();
                     }
 
-                    populate_views_async();
+                    populate_views_async ();
 
                     // Make the refresh and export items sensitive now
                     toolbar.export_item.sensitive = true;
 
-                    toolbar.show_shownotes_button();
+                    toolbar.show_shownotes_button ();
                     toolbar.show_volume_button ();
-                    toolbar.show_playlist_button();
+                    toolbar.show_playlist_button ();
 
-                    if(current_widget == import_message_box) {
-                        switch_visible_page(all_scrolled);
+                    if (current_widget == import_message_box) {
+                        switch_visible_page (all_scrolled);
                     }
 
-                    show_all();
+                    show_all ();
 
                     controller.currently_importing = false;
 
-                    if(controller.player.playing) {
-                        toolbar.playback_box.set_info_title(controller.current_episode.title.replace("%27", "'"), controller.current_episode.parent.name.replace("%27", "'"));
-                        video_controls.set_info_title(controller.current_episode.title.replace("%27", "'"), controller.current_episode.parent.name.replace("%27", "'"));
+                    if (controller.player.playing) {
+                        toolbar.playback_box.set_info_title (controller.current_episode.title.replace ("%27", "'"), controller.current_episode.parent.name.replace ("%27", "'"));
+                        video_controls.set_info_title (controller.current_episode.title.replace ("%27", "'"), controller.current_episode.parent.name.replace ("%27", "'"));
                     }
 
-                    loop.quit();
+                    loop.quit ();
                 });
-                loop.run();
+                loop.run ();
 
-                file_chooser.destroy();
+                file_chooser.destroy ();
             }
         }
 
@@ -1015,53 +1006,53 @@ namespace Vocal {
          * the podcast and episode information
          */
         public void show_details (Podcast current_podcast) {
-            details.set_podcast(current_podcast);
-            switch_visible_page(details);
+            details.set_podcast (current_podcast);
+            switch_visible_page (details);
         }
 
 
         /*
          * Shows the downloads popover
          */
-        public void show_downloads_popover() {
-            this.downloads.show_all();
+        public void show_downloads_popover () {
+            this.downloads.show_all ();
         }
 
 
         /*
          * Called when a different widget needs to be displayed in the notebook
          */
-         public void switch_visible_page(Gtk.Widget widget) {
+         public void switch_visible_page (Gtk.Widget widget) {
 
-            if(current_widget != widget)
+            if (current_widget != widget)
                 previous_widget = current_widget;
 
             if (widget == all_scrolled) {
-                notebook.set_visible_child(all_scrolled);
+                notebook.set_visible_child (all_scrolled);
                 current_widget = all_scrolled;
             }
             else if (widget == details) {
-                notebook.set_visible_child(details);
+                notebook.set_visible_child (details);
                 current_widget = details;
             }
             else if (widget == video_widget) {
-                notebook.set_visible_child(video_widget);
+                notebook.set_visible_child (video_widget);
                 current_widget = video_widget;
             }
             else if (widget == import_message_box) {
-                notebook.set_visible_child(import_message_box);
+                notebook.set_visible_child (import_message_box);
                 current_widget = import_message_box;
             }
             else if (widget == search_results_scrolled) {
-                notebook.set_visible_child(search_results_scrolled);
+                notebook.set_visible_child (search_results_scrolled);
                 current_widget = search_results_scrolled;
             }
             else if (widget == directory_scrolled) {
-                notebook.set_visible_child(directory_scrolled);
+                notebook.set_visible_child (directory_scrolled);
                 current_widget = directory_scrolled;
             }
             else if (widget == welcome) {
-                notebook.set_visible_child(welcome);
+                notebook.set_visible_child (welcome);
                 current_widget = welcome;
             }
             else if (widget == new_episodes_view) {
@@ -1069,7 +1060,7 @@ namespace Vocal {
                 current_widget = new_episodes_view;
             }
             else {
-                info("Attempted to switch to a notebook page that didn't exist. This is likely a bug and might cause issues.");
+                info ("Attempted to switch to a notebook page that didn't exist. This is likely a bug and might cause issues.");
             }
          }
 
@@ -1084,15 +1075,15 @@ namespace Vocal {
          * Prompts user to install the plugins and then proceeds to handle the installation. Playback begins
          * once plugins are installed.
          */
-        public void on_additional_plugins_needed(Gst.Message install_message) {
-            warning("Required GStreamer plugins were not found. Prompting to install.");
-            missing_dialog = new Gtk.MessageDialog(this, Gtk.DialogFlags.MODAL, Gtk.MessageType.QUESTION, Gtk.ButtonsType.YES_NO,
-                 _("Additional plugins are needed to play media. Would you like for Vocal to install them for you?"));
+        public void on_additional_plugins_needed (Gst.Message install_message) {
+            warning ("Required GStreamer plugins were not found. Prompting to install.");
+            missing_dialog = new Gtk.MessageDialog (this, Gtk.DialogFlags.MODAL, Gtk.MessageType.QUESTION, Gtk.ButtonsType.YES_NO,
+                 _ ("Additional plugins are needed to play media. Would you like for Vocal to install them for you?"));
 
             missing_dialog.response.connect ((response_id) => {
                 switch (response_id) {
                     case Gtk.ResponseType.YES:
-                        missing_dialog.destroy();
+                        missing_dialog.destroy ();
                         var plugins_are_installing = true;
 
                         var installer = Gst.PbUtils.missing_plugin_message_get_installer_detail (install_message);
@@ -1100,17 +1091,17 @@ namespace Vocal {
 
                          // Since we can't do anything else anyways, go ahead and install the plugins synchronously
                          Gst.PbUtils.InstallPluginsReturn ret = Gst.PbUtils.install_plugins_sync ({ installer }, context);
-                         if(ret == Gst.PbUtils.InstallPluginsReturn.SUCCESS) {
-                            info("Plugins have finished installing. Updating GStreamer registry.");
+                         if (ret == Gst.PbUtils.InstallPluginsReturn.SUCCESS) {
+                            info ("Plugins have finished installing. Updating GStreamer registry.");
                             Gst.update_registry ();
                             plugins_are_installing = false;
 
-                            info("GStreamer registry updated, attempting to start playback using the new plugins...");
+                            info ("GStreamer registry updated, attempting to start playback using the new plugins...");
 
                             // Reset the controller.player
                             controller.player.current_episode = null;
 
-                            controller.play();
+                            controller.play ();
                          }
 
                         break;
@@ -1118,7 +1109,7 @@ namespace Vocal {
                         break;
                 }
 
-                missing_dialog.destroy();
+                missing_dialog.destroy ();
             });
             missing_dialog.show ();
         }
@@ -1128,37 +1119,37 @@ namespace Vocal {
          * Handles requests to add individual podcast feeds (either from welcome screen or
          * the add feed menuitem
          */
-        public void on_add_podcast_feed(int response_id) {
-            if(response_id == Gtk.ResponseType.OK) {
-                controller.add_podcast_feed(add_feed.entry.get_text());
+        public void on_add_podcast_feed (int response_id) {
+            if (response_id == Gtk.ResponseType.OK) {
+                controller.add_podcast_feed (add_feed.entry.get_text ());
             }
 
             // Destroy the add podcast dialog box
-            add_feed.destroy();
+            add_feed.destroy ();
         }
 
 
         /*
          * Called whenever a child is activated (selected) in one of the three flowboxes.
          */
-        public void on_child_activated(FlowBoxChild child) {
+        public void on_child_activated (FlowBoxChild child) {
             Gtk.FlowBox parent = child.parent as Gtk.FlowBox;
-            CoverArt art = parent.get_child_at_index(child.get_index()).get_child() as CoverArt;
-            parent.unselect_all();
+            CoverArt art = parent.get_child_at_index (child.get_index ()).get_child () as CoverArt;
+            parent.unselect_all ();
             this.current_episode_art = art;
             controller.highlighted_podcast = art.podcast;
-            show_details(art.podcast);
+            show_details (art.podcast);
         }
 
 
-		/*
-		 * Called when the user requests to download all episodes from the sidepane
-		 */
-        public void on_download_all_request() {
+        /*
+         * Called when the user requests to download all episodes from the sidepane
+         */
+        public void on_download_all_request () {
             // TODO: Warn user if too many (more than 50?) podcasts will be downloaded.
-            foreach(Episode episode in controller.highlighted_podcast.episodes) {
-                if(episode.current_download_status == DownloadStatus.NOT_DOWNLOADED) {
-                    download_episode(episode);
+            foreach (Episode episode in controller.highlighted_podcast.episodes) {
+                if (episode.current_download_status == DownloadStatus.NOT_DOWNLOADED) {
+                    download_episode (episode);
                 }
             }
         }
@@ -1167,16 +1158,16 @@ namespace Vocal {
         /*
          * Mark the episode as not being downloaded
          */
-         private void on_download_canceled(Episode episode) {
+         private void on_download_canceled (Episode episode) {
 
-            if(details != null && episode.parent == details.podcast) {
+            if (details != null && episode.parent == details.podcast) {
 
                 // Get the index for the episode in the list
-                int index = details.get_box_index_from_episode(episode);
+                int index = details.get_box_index_from_episode (episode);
 
                 // Set the box to show the downloads button
-                if(index != -1) {
-                    details.boxes[index].show_download_button();
+                if (index != -1) {
+                    details.boxes[index].show_download_button ();
                 }
             }
         }
@@ -1185,37 +1176,37 @@ namespace Vocal {
         /*
          * Mark an episode as being downloaded
          */
-        public void on_download_finished(Episode episode) {
+        public void on_download_finished (Episode episode) {
 
             if (details != null && episode.parent == details.podcast) {
-                details.shownotes.hide_download_button();
+                details.shownotes.hide_download_button ();
             }
         }
 
 
         /*
-		 * Called when an episode needs to be deleted (locally)
-		 */
-        private void on_episode_delete_request(Episode episode) {
-            controller.library.delete_local_episode(episode);
-            details.on_single_delete(episode);
+         * Called when an episode needs to be deleted (locally)
+         */
+        private void on_episode_delete_request (Episode episode) {
+            controller.library.delete_local_episode (episode);
+            details.on_single_delete (episode);
         }
 
 
 
-		/*
-		 * Called when the app needs to go fullscreen or unfullscreen
-		 */
-        public void on_fullscreen_request() {
+        /*
+         * Called when the app needs to go fullscreen or unfullscreen
+         */
+        public void on_fullscreen_request () {
 
-            if(fullscreened) {
-                unfullscreen();
-                video_controls.set_reveal_child(false);
+            if (fullscreened) {
+                unfullscreen ();
+                video_controls.set_reveal_child (false);
                 fullscreened = false;
                 ignore_window_state_change = true;
             } else {
 
-                fullscreen();
+                fullscreen ();
                 fullscreened = true;
             }
         }
@@ -1224,135 +1215,131 @@ namespace Vocal {
         /*
          * Called during an import event when the parser has started parsing a new feed
          */
-        public void on_import_status_changed(int current, int total, string title) {
-            show_all();
-            toolbar.playback_box.set_message_and_percentage("Adding feed %d/%d: %s".printf(current, total, title), (double)((double)current/(double)total));
+        public void on_import_status_changed (int current, int total, string title) {
+            show_all ();
+            toolbar.playback_box.set_message_and_percentage ("Adding feed %d/%d: %s".printf (current, total, title), (double) ((double)current/ (double)total));
         }
 
 
         /*
          * Called when the user requests to mark a podcast as played from the controller.library via the right-click menu
          */
-        public void on_mark_as_played_request() {
+        public void on_mark_as_played_request () {
 
-            if(controller.highlighted_podcast != null) {
+            if (controller.highlighted_podcast != null) {
                 Gtk.MessageDialog msg = new Gtk.MessageDialog (this, Gtk.DialogFlags.MODAL, Gtk.MessageType.WARNING, Gtk.ButtonsType.YES_NO,
-                     _("Are you sure you want to mark all episodes from '%s' as played?".printf(GLib.Markup.escape_text(controller.highlighted_podcast.name))));
+                     _ ("Are you sure you want to mark all episodes from '%s' as played?".printf (GLib.Markup.escape_text (controller.highlighted_podcast.name))));
 
-                var image = new Gtk.Image.from_icon_name("dialog-question", Gtk.IconSize.DIALOG);
+                var image = new Gtk.Image.from_icon_name ("dialog-question", Gtk.IconSize.DIALOG);
                 msg.image = image;
-                msg.image.show_all();
+                msg.image.show_all ();
 
-			    msg.response.connect ((response_id) => {
-			        switch (response_id) {
-				        case Gtk.ResponseType.YES:
-                            mark_all_as_played_async(controller.highlighted_podcast);
-					        break;
-				        case Gtk.ResponseType.NO:
-					        break;
-			        }
+                msg.response.connect ((response_id) => {
+                    switch (response_id) {
+                        case Gtk.ResponseType.YES:
+                            mark_all_as_played_async (controller.highlighted_podcast);
+                            break;
+                        case Gtk.ResponseType.NO:
+                            break;
+                    }
 
-			        msg.destroy();
-		        });
-		        msg.show ();
-	        }
+                    msg.destroy ();
+                });
+                msg.show ();
+            }
         }
 
-        
+
 
 
         /*
-		 * Called when an episode needs to be marked as played
-		 */
-        public void on_mark_episode_as_played_request(Episode episode) {
+         * Called when an episode needs to be marked as played
+         */
+        public void on_mark_episode_as_played_request (Episode episode) {
 
             // First check to see the episode is already marked as unplayed
-            if(episode.status != EpisodeStatus.PLAYED) {
-                controller.library.mark_episode_as_played(episode);
+            if (episode.status != EpisodeStatus.PLAYED) {
+                controller.library.mark_episode_as_played (episode);
                 controller.library.new_episode_count--;
-                controller.library.set_new_badge();
-                foreach(CoverArt a in all_art)
-                {
-                    if(a.podcast == details.podcast)
-                    {
-                        a.set_count(details.unplayed_count);
-                        if(details.unplayed_count > 0)
-                            a.show_count();
-                        else
-                            a.hide_count();
+                controller.library.set_new_badge ();
+                foreach (CoverArt a in all_art) {
+                    if (a.podcast == details.podcast) {
+                        a.set_count (details.unplayed_count);
+                        if (details.unplayed_count > 0) {
+                            a.show_count ();
+                        } else {
+                            a.hide_count ();
+                        }
                     }
                 }
-                
+
                 new_episodes_view.populate_episodes_list ();
             }
         }
 
 
-		/*
-		 * Called when an episode needs to be marked as unplayed
-		 */
-        public void on_mark_episode_as_unplayed_request(Episode episode) {
+        /*
+         * Called when an episode needs to be marked as unplayed
+         */
+        public void on_mark_episode_as_unplayed_request (Episode episode) {
 
             // First check to see the episode is already marked as unplayed
-            if(episode.status != EpisodeStatus.UNPLAYED) {
-                controller.library.mark_episode_as_unplayed(episode);
+            if (episode.status != EpisodeStatus.UNPLAYED) {
+                controller.library.mark_episode_as_unplayed (episode);
                 controller.library.new_episode_count++;
-                controller.library.set_new_badge();
+                controller.library.set_new_badge ();
 
-                foreach(CoverArt a in all_art)
-                {
-                    if(a.podcast == details.podcast)
-                    {
-                        a.set_count(details.unplayed_count);
-                        if(details.unplayed_count > 0)
-                            a.show_count();
-                        else
-                            a.hide_count();
+                foreach (CoverArt a in all_art) {
+                    if (a.podcast == details.podcast) {
+                        a.set_count (details.unplayed_count);
+                        if (details.unplayed_count > 0) {
+                            a.show_count ();
+                        } else {
+                            a.hide_count ();
+                        }
                     }
                 }
-                if(controller.highlighted_podcast.content_type == MediaType.AUDIO) {
-                    foreach(CoverArt audio in all_art)
-                    {
-                        if(audio.podcast == details.podcast)
-                        {
-                            audio.set_count(details.unplayed_count);
-                            if(details.unplayed_count > 0)
-                                audio.show_count();
-                            else
-                                audio.hide_count();
+                if (controller.highlighted_podcast.content_type == MediaType.AUDIO) {
+                    foreach (CoverArt audio in all_art) {
+                        if (audio.podcast == details.podcast) {
+                            audio.set_count (details.unplayed_count);
+                            if (details.unplayed_count > 0) {
+                                audio.show_count ();
+                            } else {
+                                audio.hide_count ();
+                            }
                         }
                     }
                 }
                 else {
-                    foreach(CoverArt video in all_art)
-                    {
-                        if(video.podcast == details.podcast)
-                        {
-                            video.set_count(details.unplayed_count);
-                            if(details.unplayed_count > 0)
-                                video.show_count();
-                            else
-                                video.hide_count();
+                    foreach (CoverArt video in all_art) {
+                        if (video.podcast == details.podcast) {
+                            video.set_count (details.unplayed_count);
+                            if (details.unplayed_count > 0) {
+                                video.show_count ();
+                            } else {
+                                video.hide_count ();
+                            }
                         }
                     }
                 }
-                
+
                 new_episodes_view.populate_episodes_list ();
             }
         }
 
 
-		/*
-		 * Called when the user moves the cursor when a video is playing
-		 */
-        private bool on_motion_event(Gdk.EventMotion e) {
+        /*
+         * Called when the user moves the cursor when a video is playing
+         */
+        private bool on_motion_event (Gdk.EventMotion e) {
 
             // Figure out if you should just move the window
             if (mouse_primary_down) {
                 mouse_primary_down = false;
                 this.begin_move_drag (Gdk.BUTTON_PRIMARY,
                     (int)e.x_root, (int)e.y_root, e.time);
-                
+
             } else {
 
                 // Show the cursor again
@@ -1363,7 +1350,7 @@ namespace Vocal {
                 hovering_over_video_controls = false;
 
                 int min_height, natural_height;
-                video_controls.get_preferred_height(out min_height, out natural_height);
+                video_controls.get_preferred_height (out min_height, out natural_height);
 
 
                 // Figure out whether or not the cursor is over the video bar at the bottom
@@ -1387,17 +1374,16 @@ namespace Vocal {
                     Source.remove (hiding_timer);
                 }
 
-                if(current_widget == video_widget) {
+                if (current_widget == video_widget) {
 
                     hiding_timer = GLib.Timeout.add (2000, () => {
 
-                        if(current_widget != video_widget)
-                        {
+                        if (current_widget != video_widget) {
                             this.get_window ().set_cursor (null);
                             return false;
                         }
 
-                        if(!fullscreened && (hovering_over_video_controls || hovering_over_return_button)) {
+                        if (!fullscreened && (hovering_over_video_controls || hovering_over_return_button)) {
                             hiding_timer = 0;
                             return true;
                         }
@@ -1407,10 +1393,10 @@ namespace Vocal {
                             return true;
                         }
 
-                        video_controls.set_reveal_child(false);
-                        return_revealer.set_reveal_child(false);
+                        video_controls.set_reveal_child (false);
+                        return_revealer.set_reveal_child (false);
 
-                        if(controller.player.playing && !hovering_over_headerbar) {
+                        if (controller.player.playing && !hovering_over_headerbar) {
                             this.get_window ().set_cursor (new Gdk.Cursor (Gdk.CursorType.BLANK_CURSOR));
                         }
 
@@ -1418,12 +1404,12 @@ namespace Vocal {
                     });
 
 
-                    if(fullscreened) {
+                    if (fullscreened) {
                         bottom_actor.width = stage.width;
                         bottom_actor.y = stage.height - natural_height;
-                        video_controls.set_reveal_child(true);
+                        video_controls.set_reveal_child (true);
                     }
-                    return_revealer.set_reveal_child(true);
+                    return_revealer.set_reveal_child (true);
 
                 }
             }
@@ -1435,43 +1421,43 @@ namespace Vocal {
         /*
          * Called when the subscribe button is clicked either on the store or on a search page
          */
-        public void on_new_subscription(string itunes_url) {
+        public void on_new_subscription (string itunes_url) {
 
             // We are given an iTunes store URL. We need to get the actual RSS feed from  this
-            string rss = controller.itunes.get_rss_from_itunes_url(itunes_url);
+            string rss = controller.itunes.get_rss_from_itunes_url (itunes_url);
 
-            controller.add_podcast_feed(rss);
+            controller.add_podcast_feed (rss);
         }
 
 
         /*
          * Called when the user requests to remove a podcast from the controller.library via the right-click menu
          */
-        public void on_remove_request() {
-            if(controller.highlighted_podcast != null) {
+        public void on_remove_request () {
+            if (controller.highlighted_podcast != null) {
                 Gtk.MessageDialog msg = new Gtk.MessageDialog (this, Gtk.DialogFlags.MODAL, Gtk.MessageType.WARNING, Gtk.ButtonsType.NONE,
-                                                               _("Are you sure you want to remove '%s' from your controller.library?"),
-                                                               controller.highlighted_podcast.name.replace("%27", "'"));
+                                                               _ ("Are you sure you want to remove '%s' from your controller.library?"),
+                                                               controller.highlighted_podcast.name.replace ("%27", "'"));
 
 
-                msg.add_button (_("No"), Gtk.ResponseType.NO);
-                Gtk.Button delete_button = (Gtk.Button) msg.add_button(_("Yes"), Gtk.ResponseType.YES);
-                delete_button.get_style_context().add_class("destructive-action");
+                msg.add_button (_ ("No"), Gtk.ResponseType.NO);
+                Gtk.Button delete_button = (Gtk.Button) msg.add_button (_ ("Yes"), Gtk.ResponseType.YES);
+                delete_button.get_style_context ().add_class ("destructive-action");
 
-                var image = new Gtk.Image.from_icon_name("dialog-warning", Gtk.IconSize.DIALOG);
+                var image = new Gtk.Image.from_icon_name ("dialog-warning", Gtk.IconSize.DIALOG);
                 msg.image = image;
-                msg.image.show_all();
+                msg.image.show_all ();
 
                 msg.response.connect ((response_id) => {
                     switch (response_id) {
                         case Gtk.ResponseType.YES:
-                            controller.library.remove_podcast(controller.highlighted_podcast);
+                            controller.library.remove_podcast (controller.highlighted_podcast);
                             controller.highlighted_podcast = null;
                             if ( controller.library.empty ()) {
                                 switch_visible_page (welcome);
                             } else {
-                                switch_visible_page(all_scrolled);
-                                populate_views_async();
+                                switch_visible_page (all_scrolled);
+                                populate_views_async ();
                             }
                             break;
 
@@ -1479,7 +1465,7 @@ namespace Vocal {
                             break;
                     }
 
-                    msg.destroy();
+                    msg.destroy ();
                 });
                 msg.show ();
             }
@@ -1489,22 +1475,22 @@ namespace Vocal {
         /*
          * Called when the video needs to be hidden and the library shown again
          */
-        public void on_return_to_library() {
+        public void on_return_to_library () {
 
             // If fullscreen, first exit fullscreen so you won't be "trapped" in fullscreen mode
-            if(fullscreened)
-                on_fullscreen_request();
-                
+            if (fullscreened)
+                on_fullscreen_request ();
+
             // It's possible this was triggered by the directory on a first run, so check
             // the new episodes button
             if (!controller.library.empty ()) {
                 toolbar.new_episodes_button.set_no_show_all (false);
                 toolbar.new_episodes_button.show ();
             }
-                
+
             // Since we can't see the video any more pause playback if necessary
-            if(current_widget == video_widget && controller.player.playing)
-                controller.pause();
+            if (current_widget == video_widget && controller.player.playing)
+                controller.pause ();
 
             // If the library is empty, always return to the welcome screen.
             if (controller.library.empty ()) {
@@ -1514,7 +1500,7 @@ namespace Vocal {
             if (previous_widget == directory_scrolled || previous_widget == search_results_scrolled)
                 previous_widget = all_scrolled;
 
-            switch_visible_page(previous_widget);
+            switch_visible_page (previous_widget);
 
             // Make sure the cursor is visible again
             this.get_window ().set_cursor (null);
@@ -1523,17 +1509,17 @@ namespace Vocal {
          /*
           * Called when the user clicks on a podcast in the search popover
           */
-         private void on_search_popover_podcast_selected(Podcast p) {
-            if(p != null) {
+         private void on_search_popover_podcast_selected (Podcast p) {
+            if (p != null) {
                 bool found = false;
                 int i = 0;
-                while(!found && i < all_art.size) {
+                while (!found && i < all_art.size) {
                     CoverArt a = all_art[i];
-                    if(a.podcast.name == p.name) {
-                        all_flowbox.unselect_all();
+                    if (a.podcast.name == p.name) {
+                        all_flowbox.unselect_all ();
                         this.current_episode_art = a;
                         controller.highlighted_podcast = a.podcast;
-                        show_details(a.podcast);
+                        show_details (a.podcast);
                         found = true;
                     }
                     i++;
@@ -1545,19 +1531,19 @@ namespace Vocal {
          /*
           * Called when the user clickson an episode in the search popover
           */
-         private void on_search_popover_episode_selected(Podcast p, Episode e) {
-            if(p != null && e != null) {
+         private void on_search_popover_episode_selected (Podcast p, Episode e) {
+            if (p != null && e != null) {
                 bool podcast_found = false;
                 int i = 0;
-                while(!podcast_found && i < all_art.size) {
+                while (!podcast_found && i < all_art.size) {
                     CoverArt a = all_art[i];
-                    if(a.podcast.name == p.name) {
-                        all_flowbox.unselect_all();
+                    if (a.podcast.name == p.name) {
+                        all_flowbox.unselect_all ();
                         this.current_episode_art = a;
                         controller.highlighted_podcast = a.podcast;
-                        show_details(a.podcast);
+                        show_details (a.podcast);
                         podcast_found = true;
-                        details.select_episode(e);
+                        details.select_episode (e);
                     }
                     i++;
                 }
@@ -1568,9 +1554,9 @@ namespace Vocal {
         /*
          * Shows a full search results listing
          */
-        public void on_show_search() {
-            switch_visible_page(search_results_scrolled);
-            show_all();
+        public void on_show_search () {
+            switch_visible_page (search_results_scrolled);
+            show_all ();
         }
 
 
@@ -1578,14 +1564,14 @@ namespace Vocal {
          * Called when the user toggles the show name label setting.
          * Calls the show/hide label method for every cover art.
          */
-        public void on_show_name_label_toggled() {
-            if(controller.settings.show_name_label) {
-                foreach(CoverArt a in all_art) {
-                    a.show_name_label();
+        public void on_show_name_label_toggled () {
+            if (controller.settings.show_name_label) {
+                foreach (CoverArt a in all_art) {
+                    a.show_name_label ();
                 }
             } else {
-                foreach(CoverArt a in all_art) {
-                    a.hide_name_label();
+                foreach (CoverArt a in all_art) {
+                    a.hide_name_label ();
                 }
             }
         }
@@ -1594,38 +1580,38 @@ namespace Vocal {
         /*
          * Called when the player finishes a stream
          */
-        public void on_stream_ended() {
+        public void on_stream_ended () {
 
             // hide the playback box and set the image on the pause button to play
-            toolbar.hide_playback_box();
+            toolbar.hide_playback_box ();
 
-            var playpause_image = new Gtk.Image.from_icon_name("media-playback-start-symbolic", Gtk.IconSize.LARGE_TOOLBAR);
-            toolbar.set_play_pause_image(playpause_image);
+            var playpause_image = new Gtk.Image.from_icon_name ("media-playback-start-symbolic", Gtk.IconSize.LARGE_TOOLBAR);
+            toolbar.set_play_pause_image (playpause_image);
 
             // If there is a video showing, return to the controller.library view
-            if(controller.current_episode.parent.content_type == MediaType.VIDEO) {
-                on_return_to_library();
+            if (controller.current_episode.parent.content_type == MediaType.VIDEO) {
+                on_return_to_library ();
             }
 
             controller.player.current_episode.last_played_position = 0;
-            controller.library.set_episode_playback_position(controller.player.current_episode);
+            controller.library.set_episode_playback_position (controller.player.current_episode);
 
-            controller.playback_status_changed("Stopped");
+            controller.playback_status_changed ("Stopped");
 
-            controller.current_episode = controller.library.get_next_episode_in_queue();
+            controller.current_episode = controller.library.get_next_episode_in_queue ();
 
-            if(controller.current_episode != null) {
+            if (controller.current_episode != null) {
 
-                controller.play();
+                controller.play ();
 
                 // Set the shownotes, the media information, and update the last played media in the settings
-                controller.track_changed(controller.current_episode.title, controller.current_episode.parent.name, controller.current_episode.parent.coverart_uri, (uint64) controller.player.duration);
-                shownotes.set_notes_text(controller.current_episode.description);
-                controller.settings.last_played_media = "%s,%s".printf(controller.current_episode.title, controller.current_episode.parent.name);
+                controller.track_changed (controller.current_episode.title, controller.current_episode.parent.name, controller.current_episode.parent.coverart_uri, (uint64) controller.player.duration);
+                shownotes.set_notes_text (controller.current_episode.description);
+                controller.settings.last_played_media = "%s,%s".printf (controller.current_episode.title, controller.current_episode.parent.name);
             } else {
                 controller.player.playing = false;
             }
-            
+
             // Regenerate the new episode list in case the ended episode was one of the new episodes
             new_episodes_view.populate_episodes_list ();
 
@@ -1633,82 +1619,78 @@ namespace Vocal {
 
 
         /*
-		 * Called when the unplayed count changes and the banner count in the iconviews needs updated
-		 */
-        public void on_unplayed_count_changed(int n) {
-            foreach(CoverArt a in all_art)
-                {
-                    if(a.podcast == details.podcast)
-                    {
-                        a.set_count(n);
-                        if(n > 0)
-                            a.show_count();
+         * Called when the unplayed count changes and the banner count in the iconviews needs updated
+         */
+        public void on_unplayed_count_changed (int n) {
+            foreach (CoverArt a in all_art) {
+                if (a.podcast == details.podcast) {
+                    a.set_count (n);
+                    if (n > 0) {
+                        a.show_count ();
+                    } else {
+                        a.hide_count ();
+                    }
+                }
+            }
+            if (controller.highlighted_podcast.content_type == MediaType.AUDIO) {
+                foreach (CoverArt audio in all_art) {
+                    if (audio.podcast == details.podcast) {
+                        audio.set_count (n);
+                        if (n > 0) {
+                            audio.show_count ();
+                        } else {
+                            audio.hide_count ();
+                        }
+                    }
+                }
+            }
+            else {
+                foreach (CoverArt video in all_art) {
+                    if (video.podcast == details.podcast) {
+                        video.set_count (n);
+                        if (n > 0)
+                            video.show_count ();
                         else
-                            a.hide_count();
+                            video.hide_count ();
                     }
                 }
-                if(controller.highlighted_podcast.content_type == MediaType.AUDIO) {
-                    foreach(CoverArt audio in all_art)
-                    {
-                        if(audio.podcast == details.podcast)
-                        {
-                            audio.set_count(n);
-                            if(n > 0)
-                                audio.show_count();
-                            else
-                                audio.hide_count();
-                        }
-                    }
-                }
-                else {
-                    foreach(CoverArt video in all_art)
-                    {
-                        if(video.podcast == details.podcast)
-                        {
-                            video.set_count(n);
-                            if(n > 0)
-                                video.show_count();
-                            else
-                                video.hide_count();
-                        }
-                    }
-                }
+            }
         }
-        
+
         /*
          * Called when a user manually sets a new cover art file
          */
-        public void on_new_cover_art_set(string path) {
-            
+        public void on_new_cover_art_set (string path) {
+
             // Find the cover art in the controller.library and set the new image
-            foreach(CoverArt a in all_art) {
-                if(a.podcast == details.podcast) {
-                    GLib.File cover = GLib.File.new_for_path(path);
-                    InputStream input_stream = cover.read();
-                    var pixbuf = a.create_cover_image(input_stream);
-                    
+            foreach (CoverArt a in all_art) {
+                if (a.podcast == details.podcast) {
+                    GLib.File cover = GLib.File.new_for_path (path);
+                    InputStream input_stream = cover.read ();
+                    var pixbuf = a.create_cover_image (input_stream);
+
                     a.image.pixbuf = pixbuf;
-                    
+
                     // Now copy the image to controller.library cache and set it in the db
-                    controller.library.set_new_local_album_art(path, a.podcast);
+                    controller.library.set_new_local_album_art (path, a.podcast);
                 }
             }
-        }        
+        }
 
         /*
          * Requests the app to be taken fullscreen if the video widget
          * is double-clicked
          */
-        private bool on_video_button_press_event(EventButton e) {
+        private bool on_video_button_press_event (EventButton e) {
             mouse_primary_down = true;
-            if(e.type == Gdk.EventType.2BUTTON_PRESS) {
-                on_fullscreen_request();
+            if (e.type == Gdk.EventType.2BUTTON_PRESS) {
+                on_fullscreen_request ();
             }
 
             return false;
         }
 
-        private bool on_video_button_release_event(EventButton e) {
+        private bool on_video_button_release_event (EventButton e) {
             mouse_primary_down = false;
             return false;
         }
@@ -1716,11 +1698,11 @@ namespace Vocal {
         /*
          * Handles responses from the welcome screen
          */
-        private void on_welcome(int index) {
+        private void on_welcome (int index) {
 
             // Show the store
-            if(index == 0) {
-                switch_visible_page(directory_scrolled);
+            if (index == 0) {
+                switch_visible_page (directory_scrolled);
 
                 // Set the controller.library as the previous widget for return_to_library to work
                 previous_widget = all_scrolled;
@@ -1728,17 +1710,17 @@ namespace Vocal {
 
             // Add a new feed
             if (index == 1 ) {
-                add_feed = new AddFeedDialog(this, controller.on_elementary);
-                add_feed.response.connect(on_add_podcast_feed);
-                add_feed.show_all();
+                add_feed = new AddFeedDialog (this, controller.on_elementary);
+                add_feed.response.connect (on_add_podcast_feed);
+                add_feed.show_all ();
 
             // Import from OPML
             } else if (index == 2) {
 
                 // The import podcasts method will handle any errors
-                import_podcasts();
+                import_podcasts ();
 
-            } 
+            }
         }
 
 
@@ -1746,72 +1728,71 @@ namespace Vocal {
          * Saves the window height and width before closing, and decides whether to close or minimize
          * based on whether or not a track is currently playing
          */
-        private bool on_window_closing() {
+        private bool on_window_closing () {
 
             controller.is_closing = true;
 
-        	// If flagged to quit immediately, return true to go ahead and do that.
-        	// This flag is usually only set when the user wants to exit while downloads
-        	// are active
-        	if(controller.should_quit_immediately) {
-        		return false;
-        	}
+            // If flagged to quit immediately, return true to go ahead and do that.
+            // This flag is usually only set when the user wants to exit while downloads
+            // are active
+            if (controller.should_quit_immediately) {
+                return false;
+            }
 
             int width, height;
-            this.get_size(out width, out height);
+            this.get_size (out width, out height);
             controller.settings.window_height = height;
             controller.settings.window_width = width;
 
 
 
             // Save the playback position
-            if(controller.player.current_episode != null) {
-                stdout.printf("Setting the last played position to %s\n", controller.player.current_episode.last_played_position.to_string());
-                if(controller.player.current_episode.last_played_position != 0)
-                    controller.library.set_episode_playback_position(controller.player.current_episode);
+            if (controller.player.current_episode != null) {
+                stdout.printf ("Setting the last played position to %s\n", controller.player.current_episode.last_played_position.to_string ());
+                if (controller.player.current_episode.last_played_position != 0)
+                    controller.library.set_episode_playback_position (controller.player.current_episode);
             }
 
             // If an episode is currently playing and Vocal is set to keep playing in the background, hide the window
-            if(controller.player.playing && controller.settings.keep_playing_in_background) {
-                this.hide();
+            if (controller.player.playing && controller.settings.keep_playing_in_background) {
+                this.hide ();
                 return true;
-            } else if(downloads != null && downloads.downloads.size > 0) {
-
-            	//If there are downloads verify that the user wishes to exit and cancel the downloads
-            	var downloads_active_dialog = new Gtk.MessageDialog(this, Gtk.DialogFlags.MODAL, Gtk.MessageType.WARNING, Gtk.ButtonsType.YES_NO, _("Vocal is currently downloading episodes. Exiting will cause the downloads to be canceled. Are you sure you want to exit?"));
-            	downloads_active_dialog.response.connect ((response_id) => {
-            		downloads_active_dialog.destroy();
-					if(response_id == Gtk.ResponseType.YES) {
-						controller.should_quit_immediately = true;
-						this.close();
-					}
-				});
-				downloads_active_dialog.show();
-				return true;
+            } else if (downloads != null && downloads.downloads.size > 0) {
+                //If there are downloads verify that the user wishes to exit and cancel the downloads
+                var downloads_active_dialog = new Gtk.MessageDialog (this, Gtk.DialogFlags.MODAL, Gtk.MessageType.WARNING, Gtk.ButtonsType.YES_NO, _ ("Vocal is currently downloading episodes. Exiting will cause the downloads to be canceled. Are you sure you want to exit?"));
+                downloads_active_dialog.response.connect ((response_id) => {
+                    downloads_active_dialog.destroy ();
+                    if (response_id == Gtk.ResponseType.YES) {
+                        controller.should_quit_immediately = true;
+                        this.close ();
+                    }
+                });
+                downloads_active_dialog.show ();
+                return true;
             } else {
-            	// If no downloads are active and nothing is playing,
-            	// return false to allow other handlers to close the window.
-            	return false;
-        	}
+                // If no downloads are active and nothing is playing,
+                // return false to allow other handlers to close the window.
+                return false;
+            }
         }
 
-		/*
-		 * Handler for when the window state changes
-		 */
-        private void on_window_state_changed(Gdk.WindowState state) {
+        /*
+         * Handler for when the window state changes
+         */
+        private void on_window_state_changed (Gdk.WindowState state) {
 
-            if(controller.open_hidden) {
-                show_all();
+            if (controller.open_hidden) {
+                show_all ();
                 controller.open_hidden = false;
             }
 
-            if(ignore_window_state_change)
+            if (ignore_window_state_change)
                 return;
 
             bool maximized = (state & Gdk.WindowState.MAXIMIZED) == 0;
 
-            if(!maximized && !fullscreened && current_widget == video_widget) {
-                on_fullscreen_request();
+            if (!maximized && !fullscreened && current_widget == video_widget) {
+                on_fullscreen_request ();
             }
         }
         

--- a/src/Objects/DirectoryEntry.vala
+++ b/src/Objects/DirectoryEntry.vala
@@ -18,9 +18,9 @@
 ***/
 
 namespace Vocal {
-    
-    public class DirectoryEntry { 
-    
+
+    public class DirectoryEntry {
+
         public string artist = "";
         public string artworkUrl55 = "";
         public string artworkUrl60 = "";
@@ -30,7 +30,7 @@ namespace Vocal {
         public string feedUrl = "";
         public string summary = "";
         public string title = "";
-        
-        public DirectoryEntry() {}
+
+        public DirectoryEntry () {}
     }
 }

--- a/src/Objects/DirectoryEntry.vala
+++ b/src/Objects/DirectoryEntry.vala
@@ -22,12 +22,12 @@ namespace Vocal {
     public class DirectoryEntry {
 
         public string artist = "";
-        public string artworkUrl55 = "";
-        public string artworkUrl60 = "";
-        public string artworkUrl170 = "";
-        public string artworkUrl600 = "";
-        public string itunesUrl = "";
-        public string feedUrl = "";
+        public string artworkUrl55 = "";  // vala-lint=naming-convention
+        public string artworkUrl60 = "";  // vala-lint=naming-convention
+        public string artworkUrl170 = "";  // vala-lint=naming-convention
+        public string artworkUrl600 = "";  // vala-lint=naming-convention
+        public string itunesUrl = "";  // vala-lint=naming-convention
+        public string feedUrl = "";  // vala-lint=naming-convention
         public string summary = "";
         public string title = "";
 

--- a/src/Objects/Episode.vala
+++ b/src/Objects/Episode.vala
@@ -113,7 +113,14 @@ namespace Vocal {
             if (date_released != null) {
                 GLib.Time tm = GLib.Time ();
                 tm.strptime (date_released, "%a, %d %b %Y %H:%M:%S %Z");
-                datetime_released = new DateTime.local (1900 + tm.year, 1 + tm.month, tm.day, tm.hour, tm.minute, tm.second);
+                datetime_released = new DateTime.local (
+                    1900 + tm.year,
+                    1 + tm.month,
+                    tm.day,
+                    tm.hour,
+                    tm.minute,
+                    tm.second
+                );
             }
         }
 

--- a/src/Objects/Episode.vala
+++ b/src/Objects/Episode.vala
@@ -21,42 +21,42 @@ using GLib;
 
 namespace Vocal {
 
-	public class Episode : GLib.Object {
+    public class Episode : GLib.Object {
 
-		public string           title = "";              // the title of the episode
-		public string           description = "";        // the description/shownotes
-		public string           uri = "";                // the remote location for the media file
-		public string           local_uri = "";          // the local location for the media file, if any
-		public double           last_played_position;    // the latest position that has been played
-		public string           date_released;           // when the episode was released, in string form
-		public EpisodeStatus    status;                  // whether the episode is played or unplayed
-		public DownloadStatus	current_download_status; // whether the episode is downloaded or not downloaded
+        public string title = "";                       // the title of the episode
+        public string description = "";                 // the description/shownotes
+        public string uri = "";                         // the remote location for the media file
+        public string local_uri = "";                   // the local location for the media file, if any
+        public double last_played_position;             // the latest position that has been played
+        public string date_released;                    // when the episode was released, in string form
+        public EpisodeStatus status;                    // whether the episode is played or unplayed
+        public DownloadStatus current_download_status;  // whether the episode is downloaded or not downloaded
 
-		public Podcast          parent;                  // the parent that the episode belongs to
-		public DateTime         datetime_released;       // the datetime corresponding the when the episode was released
+        public Podcast parent;                          // the parent that the episode belongs to
+        public DateTime datetime_released;              // the datetime corresponding the when the episode was released
 
-		/*
-		 * Gets the playback uri based on whether the file is local or remote
-		 * (and if it is local, by making sure it actually exists on disk)
-		 *
-		 * Sets the playback uri (and corresponding fields) based on whether it's
-		 * local or remote
-		 */
+        /*
+         * Gets the playback uri based on whether the file is local or remote
+         * (and if it is local, by making sure it actually exists on disk)
+         *
+         * Sets the playback uri (and corresponding fields) based on whether it's
+         * local or remote
+         */
         public string playback_uri {
 
             get {
 
                 GLib.File local;
 
-                if(local_uri != null) {
+                if (local_uri != null) {
 
-                    if(local_uri.contains("file://"))
-                        local = GLib.File.new_for_uri(local_uri);
+                    if (local_uri.contains ("file://"))
+                        local = GLib.File.new_for_uri (local_uri);
                     else
-                        local = GLib.File.new_for_uri("file://" + local_uri);
-                    if(local.query_exists()) {
+                        local = GLib.File.new_for_uri ("file://" + local_uri);
+                    if (local.query_exists ()) {
 
-                        if(local_uri.contains("file://"))
+                        if (local_uri.contains ("file://"))
                             return local_uri;
                         else {
                             local_uri = "file://" + local_uri;
@@ -77,11 +77,11 @@ namespace Vocal {
 
             // If the URI begins with "file://" set local uri, otherwise set the remote uri
             set {
-                string[] split = value.split(":");
-                if(split[0] == "http" || split[0] == "HTTP") {
+                string[] split = value.split (":");
+                if (split[0] == "http" || split[0] == "HTTP") {
                     uri = value;
                 } else {
-                    if(!value.contains("file://")) {
+                    if (!value.contains ("file://")) {
                         local_uri = """file://""" + value;
                     }
                     else {
@@ -95,7 +95,7 @@ namespace Vocal {
          * Default constructor for an empty episode. Fields are public members and can
          * be accessed and set directly when necessary by other classes.
          */
-        public Episode() {
+        public Episode () {
             parent = null;
             local_uri = null;
             status = EpisodeStatus.UNPLAYED;
@@ -108,12 +108,12 @@ namespace Vocal {
          * Sets the local datetime based on the standardized "pubdate" as listed
          * in the feed.
          */
-        public void set_datetime_from_pubdate() {
+        public void set_datetime_from_pubdate () {
 
-            if(date_released != null) {
+            if (date_released != null) {
                 GLib.Time tm = GLib.Time ();
                 tm.strptime (date_released, "%a, %d %b %Y %H:%M:%S %Z");
-                datetime_released = new DateTime.local(1900 + tm.year, 1 + tm.month, tm.day, tm.hour, tm.minute, tm.second);
+                datetime_released = new DateTime.local (1900 + tm.year, 1 + tm.month, tm.day, tm.hour, tm.minute, tm.second);
             }
         }
 

--- a/src/Objects/Podcast.vala
+++ b/src/Objects/Podcast.vala
@@ -22,15 +22,15 @@ using Gee;
 namespace Vocal {
     public class Podcast {
 
-        public  ArrayList<Episode> episodes = null;  // the episodes belonging to this podcast
+        public ArrayList<Episode> episodes = null;  // the episodes belonging to this podcast
 
-        public string       name = "";               // podcast name
-        public string       feed_uri = "";           // the uri for the podcast
-        public string       remote_art_uri = "";     // the web link to the album art if local is unavailable
-        public string       local_art_uri = "";      // where the locally cached album art is located
-        public string       description = "";        // the episode's description
-        public MediaType    content_type;            // is the podcast an audio or video feed?
-        public License license = License.UNKNOWN; // the type of license
+        public string name = "";                    // podcast name
+        public string feed_uri = "";                // the uri for the podcast
+        public string remote_art_uri = "";          // the web link to the album art if local is unavailable
+        public string local_art_uri = "";           // where the locally cached album art is located
+        public string description = "";             // the episode's description
+        public MediaType content_type;              // is the podcast an audio or video feed?
+        public License license = License.UNKNOWN;   // the type of license
 
         /*
          * Gets and sets the coverart, whether it's from a remote source
@@ -56,12 +56,12 @@ namespace Vocal {
 
             // If the URI begins with "file://" set local uri, otherwise set the remote uri
             set {
-                string[] split = value.split(":");
-                string proto = split[0].ascii_down();
-                if(proto == "http" || proto == "https") {
-                    remote_art_uri = value.replace("%27", "'");
+                string[] split = value.split (":");
+                string proto = split[0].ascii_down ();
+                if (proto == "http" || proto == "https") {
+                    remote_art_uri = value.replace ("%27", "'");
                 } else {
-                    local_art_uri = "file://" + value.replace("%27", "'");
+                    local_art_uri = "file://" + value.replace ("%27", "'");
                 }
             }
         }
@@ -71,20 +71,20 @@ namespace Vocal {
          * Default constructor for an empty podcast
          */
         public Podcast () {
-            episodes = new ArrayList<Episode>();
+            episodes = new ArrayList<Episode> ();
             content_type = MediaType.UNKNOWN;
         }
 
-        public Podcast.with_name(string name) {
-            this();
+        public Podcast.with_name (string name) {
+            this ();
             this.name = name;
         }
 
         /*
          * Add a new episode to the library
          */
-        public void add_episode(Episode new_episode) {
-            episodes.insert(0, new_episode);
+        public void add_episode (Episode new_episode) {
+            episodes.insert (0, new_episode);
         }
 
     }

--- a/src/Services/ImageCache.vala
+++ b/src/Services/ImageCache.vala
@@ -26,7 +26,7 @@ namespace Vocal {
 
     public class ImageCache : GLib.Object {
         private class CacheState {
-            public signal void load_complete();
+            public signal void load_complete ();
             public bool is_loaded;
         }
 
@@ -37,55 +37,55 @@ namespace Vocal {
 
         static construct {
             // till the cache get initialized
-            state = new CacheState();
+            state = new CacheState ();
             state.is_loaded = false;
-            cache = new Gee.HashMap<uint, File>();
+            cache = new Gee.HashMap<uint, File> ();
 
-            var home_dir = GLib.Environment.get_home_dir();
-            var cache_directory = Constants.CACHE_DIR.replace("~", home_dir);
+            var home_dir = GLib.Environment.get_home_dir ();
+            var cache_directory = Constants.CACHE_DIR.replace ("~", home_dir);
 
-            soup_client = new SoupClient();            
-            cacher = new DiskCacher(cache_directory);
-            cacher.get_cached_files.begin((obj, res) => {
-                cache = cacher.get_cached_files.end(res);
+            soup_client = new SoupClient ();
+            cacher = new DiskCacher (cache_directory);
+            cacher.get_cached_files.begin ((obj, res) => {
+                cache = cacher.get_cached_files.end (res);
                 state.is_loaded = true;
-                state.load_complete();
+                state.load_complete ();
             });
         }
 
-        public ImageCache() {}
+        public ImageCache () {}
 
         // Get image and cache it
-        public async Gdk.Pixbuf get_image(string url) {
-            uint url_hash = url.hash();
+        public async Gdk.Pixbuf get_image (string url) {
+            uint url_hash = url.hash ();
             Gdk.Pixbuf pixbuf;
 
             if (!state.is_loaded) {
-                state.load_complete.connect(() => { get_image.callback(); });
+                state.load_complete.connect (() => { get_image.callback (); });
                 yield;
             }
 
-            if (cache.has_key(url_hash) && cache.@get(url_hash) != null) {
-                pixbuf = yield cacher.get_cached_file(cache.@get(url_hash));
+            if (cache.has_key (url_hash) && cache.@get (url_hash) != null) {
+                pixbuf = yield cacher.get_cached_file (cache.@get (url_hash));
                 if (pixbuf == null) {
-                    warning("Could not load cached file");
+                    warning ("Could not load cached file");
                 }
             } else {
-                pixbuf = yield load_image_async(url);
+                pixbuf = yield load_image_async (url);
                 if (pixbuf != null) {
-                    var cached_file = yield cacher.cache_file(url_hash, pixbuf);
-                    cache.@set(url_hash, cached_file);
+                    var cached_file = yield cacher.cache_file (url_hash, pixbuf);
+                    cache.@set (url_hash, cached_file);
                 }
             }
 
             return pixbuf;
         }
 
-        private async Gdk.Pixbuf? load_image_async(string url) {
+        private async Gdk.Pixbuf? load_image_async (string url) {
             Gdk.Pixbuf pixbuf = null;
 
             try {
-	            pixbuf = new Gdk.Pixbuf.from_stream(soup_client.request(HttpMethod.GET, url), null);
+                pixbuf = new Gdk.Pixbuf.from_stream (soup_client.request (HttpMethod.GET, url), null);
             } catch (Error e) {
                 warning ("Failed to load image. %s", e.message);
                 return null;
@@ -98,60 +98,60 @@ namespace Vocal {
             private File cache_location;
             private string location;
 
-            public DiskCacher(string location) {
+            public DiskCacher (string location) {
                 this.location = location;
-                this.cache_location = File.new_for_path(location);
+                this.cache_location = File.new_for_path (location);
             }
 
-            public async Gee.HashMap<uint, File> get_cached_files() {
-                Gee.HashMap<uint, File> files = new Gee.HashMap<uint, File>();
+            public async Gee.HashMap<uint, File> get_cached_files () {
+                Gee.HashMap<uint, File> files = new Gee.HashMap<uint, File> ();
 
-                if (!cache_location.query_exists()) {
-                    cache_location.make_directory_with_parents();
+                if (!cache_location.query_exists ()) {
+                    cache_location.make_directory_with_parents ();
                 }
 
                 try {
                     FileEnumerator enumerator = yield
-                        cache_location.enumerate_children_async("standard::*",
+                        cache_location.enumerate_children_async ("standard::*",
                                                                 FileQueryInfoFlags.NONE,
                                                                 Priority.DEFAULT, null);
                     List<FileInfo> infos;
-                    while((infos = yield enumerator.next_files_async(10)) != null) {
-                        foreach(var info in infos) {
-                            var name = info.get_name();
-                            var file = File.new_for_path("%s/%s".printf(location, name));
-                            var hashed_name = (uint)uint64.parse(name);
-                            files.@set(hashed_name, file);
+                    while ((infos = yield enumerator.next_files_async (10)) != null) {
+                        foreach (var info in infos) {
+                            var name = info.get_name ();
+                            var file = File.new_for_path ("%s/%s".printf (location, name));
+                            var hashed_name = (uint)uint64.parse (name);
+                            files.@set (hashed_name, file);
                         }
                     }
                 } catch (Error e) {
-                    warning("Could not load cached images " + e.message);
+                    warning ("Could not load cached images " + e.message);
                 }
                 return files;
             }
 
-            public async File cache_file(uint hashed_name, Gdk.Pixbuf pixbuf) {
-                var file_loc = "%s/%ud.png".printf(this.location, hashed_name);
-                var cfile = File.new_for_path(file_loc);
+            public async File cache_file (uint hashed_name, Gdk.Pixbuf pixbuf) {
+                var file_loc = "%s/%ud.png".printf (this.location, hashed_name);
+                var cfile = File.new_for_path (file_loc);
 
                 FileIOStream fiostream;
-                if (cfile.query_exists()) {
-                    fiostream = yield cfile.replace_readwrite_async(null, false, FileCreateFlags.NONE);
+                if (cfile.query_exists ()) {
+                    fiostream = yield cfile.replace_readwrite_async (null, false, FileCreateFlags.NONE);
                 } else {
-                    fiostream = yield cfile.create_readwrite_async(FileCreateFlags.NONE);
+                    fiostream = yield cfile.create_readwrite_async (FileCreateFlags.NONE);
                 }
                 // switch to async version later, currently the bindings have a bug
-                pixbuf.save_to_stream(fiostream.get_output_stream(), "png");
+                pixbuf.save_to_stream (fiostream.get_output_stream (), "png");
 
                 return cfile;
             }
 
-            public async Gdk.Pixbuf get_cached_file(File file) {
+            public async Gdk.Pixbuf get_cached_file (File file) {
                 Gdk.Pixbuf pixbuf = null;
                 try {
-                    var fiostream = yield file.open_readwrite_async();
-                    pixbuf = yield new Gdk.Pixbuf.from_stream_async(fiostream.get_input_stream(), null);
-                } catch(Error e) {
+                    var fiostream = yield file.open_readwrite_async ();
+                    pixbuf = yield new Gdk.Pixbuf.from_stream_async (fiostream.get_input_stream (), null);
+                } catch (Error e) {
                     warning ("Couldn't write to file. " + e.message);
                 }
                 return pixbuf;

--- a/src/Utils/FeedParser.vala
+++ b/src/Utils/FeedParser.vala
@@ -22,36 +22,36 @@ namespace Vocal {
     errordomain VocalUpdateError {
         NETWORK_ERROR, EMPTY_ADDRESS_ERROR;
     }
-    
+
     class FeedParser {
 
-        private Gee.ArrayList<string> queue = new Gee.ArrayList<string>();
+        private Gee.ArrayList<string> queue = new Gee.ArrayList<string> ();
 
         private SoupClient soup_client = null;
 
         public FeedParser () {
-            soup_client = new SoupClient();
+            soup_client = new SoupClient ();
         }
 
         /*
          * Creates a new podcast by iterating through the queue and finding appropriate
          * key/value pairs
          */
-        private Podcast create_podcast_from_queue() {
-        
+        private Podcast create_podcast_from_queue () {
+
             // Create the new podcast object
-            Podcast podcast = new Podcast();
-            
+            Podcast podcast = new Podcast ();
+
             bool found_podcast_title = false;
             bool found_podcast_link = false;
             bool found_cover_art = false;
             bool found_main_description = false;
-            
+
             int i = 0;
-            
+
             while (i < queue.size) {
                 string current = queue[i];
-                
+
                 // Title can be ambigous, so only accept the first one
                 if (current == "title" && found_podcast_title == false) {
                     i++;
@@ -60,37 +60,37 @@ namespace Vocal {
                     i++;
                 }
                 else if (current == "new-feed-url"&& found_podcast_link == false) {
-                    
+
                     i++;
                     podcast.feed_uri = queue[i];
                     found_podcast_link = true;
                     i++;
                 }
-                
+
                 // Most feeds use the new-feed-url enclosure, but if not we have to check links manually
                 else if (current == "link" && found_podcast_link == false) {
                     i++;
                     string href = null;
                     bool store_ref = false;
-                    
+
                     // There are six fields, but we can't assume any order
                     for (int n = 0; n < 6; n++) {
-                        if(queue[i+n] == "application/rss+xml") {
+                        if (queue[i+n] == "application/rss+xml") {
                             store_ref = true;
                         }
-                        if(queue[i+n] == "href") {
+                        if (queue[i+n] == "href") {
                             href = queue[i + n + 1];
                         }
                     }
-                    
-                    if(store_ref) {
+
+                    if (store_ref) {
                         podcast.feed_uri = href;
                         found_podcast_link = true;
                     }
-                    
-                    
+
+
                 }
-                
+
                 else if (current == "description" && found_main_description == false) {
                     i++;
                     podcast.description = queue[i];
@@ -98,16 +98,16 @@ namespace Vocal {
                     i++;
                 }
                 else if (current == "image" && found_cover_art == false) {
-                
-                    if(queue[i + 2] == "href") {
+
+                    if (queue[i + 2] == "href") {
                         i += 3;
                         podcast.remote_art_uri = queue[i];
                     }
                     else {
-                        while(queue[i] != "url") {
+                        while (queue[i] != "url") {
                             i++;
                         }
-                        
+
                         i++;
                         podcast.remote_art_uri = queue[i];
                     }
@@ -122,108 +122,108 @@ namespace Vocal {
                     }
                     i++;
                 }
-                
+
                 // We've found an episode!!
                 else if (current == "item") {
-                    
+
                     // Create a new episode
-                    Episode episode = new Episode();
+                    Episode episode = new Episode ();
                     string next_item_in_queue = null;
                     bool found_summary = false;
-                    
+
                     while (next_item_in_queue != "item" && i < queue.size - 1) {
                         i++;
                         next_item_in_queue = queue[i];
 
-                        if(next_item_in_queue == "title") {
+                        if (next_item_in_queue == "title") {
                             i++;
                             episode.title = queue[i];
                         }
-                        else if(next_item_in_queue == "enclosure") {
+                        else if (next_item_in_queue == "enclosure") {
                             bool uri_found = false;
                             bool type_found = false;
-                            
+
                             // Because different podcasts enclose information differently,
                             // we must individually search for both the uri and the type
-                            while(uri_found != true || type_found != true) {
+                            while (uri_found != true || type_found != true) {
                                 // Look at next item
                                 i++;
-                                
-                                if(queue[i] == "url") {
-                                    
+
+                                if (queue[i] == "url") {
+
                                     i++;
                                     episode.uri = queue[i];
                                     uri_found = true;
-                                    
+
                                 }
-                                else if(queue[i] == "type") {
+                                else if (queue[i] == "type") {
                                     i++;
 
-						            string typestring = queue[i].slice(0, 5);
-						            if(podcast.content_type == MediaType.UNKNOWN) {
-							            if(typestring == "audio") {
-								            podcast.content_type = MediaType.AUDIO;
-							            }
-							            else if (typestring == "video") {
-								            podcast.content_type = MediaType.VIDEO;
-							            }
-							            else {
-							                podcast.content_type = MediaType.UNKNOWN;
-							            }
-							
-						            }
-						            
-						            type_found = true;
-					            }
-					        }
-                            
-                        }
-                        else if(next_item_in_queue == "pubDate") {
-                            i++;
-                            
-                            episode.date_released = queue[i];
-                            episode.set_datetime_from_pubdate();
+                                    string typestring = queue[i].slice (0, 5);
+                                    if (podcast.content_type == MediaType.UNKNOWN) {
+                                        if (typestring == "audio") {
+                                            podcast.content_type = MediaType.AUDIO;
+                                        }
+                                        else if (typestring == "video") {
+                                            podcast.content_type = MediaType.VIDEO;
+                                        }
+                                        else {
+                                            podcast.content_type = MediaType.UNKNOWN;
+                                        }
+
+                                    }
+
+                                    type_found = true;
+                                }
+                            }
 
                         }
-                        else if(next_item_in_queue == "summary") {
+                        else if (next_item_in_queue == "pubDate") {
+                            i++;
+
+                            episode.date_released = queue[i];
+                            episode.set_datetime_from_pubdate ();
+
+                        }
+                        else if (next_item_in_queue == "summary") {
                             // Save the summary as description if we haven't found a description yet.
                             // Subsequent descriptions will overwrite this.
-                            if (episode.description.char_count() == 0) {
+                            if (episode.description.char_count () == 0) {
                                 i++;
                                 episode.description = queue[i];
                             }
                         }
-                        else if(next_item_in_queue == "description") {
+                        else if (next_item_in_queue == "description") {
                             i++;
                             episode.description = queue[i];
                         }
                     }
-                    
-                    
+
+
                     // Add the new episode to the podcast
-                    podcast.add_episode(episode);
-                    
+                    podcast.add_episode (episode);
+
                 }
-                
+
                 // Otherwise, simply increment and keep going
                 else {
                     i++;
                 }
             }
-            
+
             return podcast;
         }
 
         /*
          * Finds only the podcast description and returns it as a string
          */
-        public string? find_description_from_file(string path) throws GLib.Error{
+        public string? find_description_from_file (string path) throws GLib.Error {
 
             string description = "";
-            
+
             // Call the Xml.Parser to parse the file, which returns an unowned reference
             Xml.Doc* doc = Xml.Parser.parse_file (path);
-            
+
             // Make sure that it didn't return a null reference
             if (doc == null) {
                 warning ("Error opening file %s", path);
@@ -232,53 +232,53 @@ namespace Vocal {
 
             // Get the root node
             Xml.Node* root = doc->get_root_element ();
-            
+
             // Make sure that it didn't return a null reference, either
             if (root == null) {
-            
+
                 // If it did, free the document manually (since unowned)
                 delete doc;
                 warning ("The XML file '%s' is empty", path);
                 return null;
             }
-            
+
             // Parse the root node, which in turn will cause all nodes and properties to be parsed
-            parse_node(root);
-                    
+            parse_node (root);
+
             string next_item_in_queue = null;
-                                
+
             for (int i = 0; i < queue.size - 1; i++) {
 
                 next_item_in_queue = queue[i];
-                
-                if(next_item_in_queue == "summary") {
+
+                if (next_item_in_queue == "summary") {
                     i++;
                     description = queue[i];
                     return description;
 
                 }
-                else if(next_item_in_queue == "description") {
+                else if (next_item_in_queue == "description") {
                     i++;
                     description = queue[i];
                     return description;
                 }
             }
-            
+
             // Free the document
             delete doc;
-            
+
             return null;
         }
-        
+
         /*
          * Parses a given XML file and returns a new podcast object if able to parse it properly
          */
-        public Podcast? get_podcast_from_file(string path) throws GLib.Error {
+        public Podcast? get_podcast_from_file (string path) throws GLib.Error {
             /*
                 For reference: podcast rss feeds typically have the structure:
                 0. Rss
                     1. Channel
-                        2. Title 
+                        2. Title
                         2. Link
                         2. General
                             3. Explicit
@@ -288,20 +288,20 @@ namespace Vocal {
                         2. ID2 (Episode)
                         2. ...
             */
-        
+
             // Call the Xml.Parser to parse the file, which returns an unowned reference
             Xml.Doc* doc;
-            if(SoupClient.valid_http_uri(path)) {
+            if (SoupClient.valid_http_uri (path)) {
                 try {
-                    doc = XmlUtils.parse_string(soup_client.request_as_string(HttpMethod.GET, path));
+                    doc = XmlUtils.parse_string (soup_client.request_as_string (HttpMethod.GET, path));
                 } catch (GLib.Error e) {
-                    warning("Failed to get podcast. %s", e.message);
+                    warning ("Failed to get podcast. %s", e.message);
                     return null;
                 }
             } else {
                 doc = Xml.Parser.parse_file (path);
             }
-            
+
             // Make sure that it didn't return a null reference
             if (doc == null) {
                 warning ("Error parsing xml file %s", path);
@@ -310,7 +310,7 @@ namespace Vocal {
 
             // Get the root node
             Xml.Node* root = doc->get_root_element ();
-            
+
             // Make sure that it didn't return a null reference, either
             if (root == null) {
                 // If it did, free the document manually (since unowned)
@@ -318,88 +318,87 @@ namespace Vocal {
                 warning ("The XML file '%s' is empty", path);
                 return null;
             }
-            
+
             // Parse the root node, which in turn will cause all nodes and properties to be parsed
-            parse_node(root);
-            
+            parse_node (root);
+
             // Create the podcast object and set it as parent to child episodes
             Podcast podcast = null;
 
             if (root->name == "feed") {
-                podcast = create_podcast_from_queue_atom(root);
+                podcast = create_podcast_from_queue_atom (root);
             } else {
-                podcast = create_podcast_from_queue();
+                podcast = create_podcast_from_queue ();
             }
-            
+
             if (podcast.name.length < 1) {
                 warning ("Something went wrong during podcast parsing. Abort.");
                 return null;
             }
 
-            foreach(Episode child in podcast.episodes) {
+            foreach (Episode child in podcast.episodes) {
                 child.parent = podcast;
-                
+
             }
-            
-            if(podcast.coverart_uri == null || podcast.coverart_uri.length < 1) {
+
+            if (podcast.coverart_uri == null || podcast.coverart_uri.length < 1) {
                 podcast.coverart_uri = "resource:///com/github/needleandthread/vocal/banner.png";
             }
-            
-            if(podcast.feed_uri == null || podcast.feed_uri.length < 1) {
+
+            if (podcast.feed_uri == null || podcast.feed_uri.length < 1) {
                 podcast.feed_uri = path;
             }
-            
+
             // Free the document
             delete doc;
-            
+
             return podcast;
         }
-        
+
         /*
          * Parses an OPML file and returns an array listing each feed discovered within
          */
-        public string[] parse_feeds_from_OPML(string path) throws VocalLibraryError{
-            var feeds = new Gee.ArrayList<string>();
-            
-            queue.clear();
+        public string[] parse_feeds_from_OPML (string path) throws VocalLibraryError {
+            var feeds = new Gee.ArrayList<string> ();
 
-        
+            queue.clear ();
+
             // Call the Xml.Parser to parse the file, which returns an unowned reference
             Xml.Doc* doc = Xml.Parser.parse_file (path);
-            
+
             // Make sure that it didn't return a null reference
             if (doc == null) {
-                throw new VocalLibraryError.IMPORT_ERROR(_("Selected file doesn't appear to contain podcast subscriptions."));
+                throw new VocalLibraryError.IMPORT_ERROR (_ ("Selected file doesn't appear to contain podcast subscriptions."));
             }
 
             // Get the root node
             Xml.Node* root = doc->get_root_element ();
-            
+
             // Make sure that it didn't return a null reference, either
             if (root == null) {
-            
+
                 // If it did, free the document manually (since unowned)
                 delete doc;
-                warning(_("Selected file seems to be empty."));
-                return feeds.to_array();
+                warning (_ ("Selected file seems to be empty."));
+                return feeds.to_array ();
             }
-           
+
             // Parse the root node, which in turn will cause all nodes and properties to be parsed
-            parse_node(root);
-            
+            parse_node (root);
+
             int i = 0;
             string current;
-            
-            while(i < queue.size - 1) {
+
+            while (i < queue.size - 1) {
                 i++;
                 current = queue[i];
                 if (current == "url" || current == "xmlUrl") {
                     i++;
-                    feeds.add(queue[i]);
+                    feeds.add (queue[i]);
                 }
             }
-            
-            string[] feeds_array = feeds.to_array();
+
+            string[] feeds_array = feeds.to_array ();
             return feeds_array;
         }
 
@@ -407,11 +406,11 @@ namespace Vocal {
          * Parse the feed starting at a node (recursively called)
          */
         private void parse_node (Xml.Node* node) {
-        
+
             // Loop over the passed node's children
-            
+
             for (Xml.Node* iter = node->children; iter != null; iter = iter->next) {
-            
+
                 // Spaces between tags are also nodes, discard them
                 if (iter->type != Xml.ElementType.ELEMENT_NODE) {
                     continue;
@@ -419,12 +418,12 @@ namespace Vocal {
 
                 // Get the node's name
                 string node_name = iter->name;
-                queue.add(node_name);
-                
+                queue.add (node_name);
+
                 // Get the node's content with <tags> stripped
                 string node_content = iter->get_content ();
-                queue.add(node_content);
-                
+                queue.add (node_content);
+
                 // Now parse the node's properties (attributes) ...
                 parse_properties (iter);
 
@@ -437,15 +436,15 @@ namespace Vocal {
          * Parse the properties of a node
          */
         private void parse_properties (Xml.Node* node) {
-        
+
             // Loop over the passed node's properties (attributes)
             for (Xml.Attr* prop = node->properties; prop != null; prop = prop->next) {
-            
+
                 string attr_name = prop->name;
-                queue.add(attr_name);
+                queue.add (attr_name);
 
                 string attr_content = prop->children->content;
-                queue.add(attr_content);
+                queue.add (attr_content);
 
             }
         }
@@ -453,94 +452,94 @@ namespace Vocal {
         /*
          * Re-parses the feed for a given podcast and finds episodes newer than the previous newest episode
          */
-        public int update_feed(Podcast podcast) throws GLib.Error {
-        
-            Gee.ArrayList<Episode> new_episodes = new Gee.ArrayList<Episode>();
+        public int update_feed (Podcast podcast) throws GLib.Error {
+
+            Gee.ArrayList<Episode> new_episodes = new Gee.ArrayList<Episode> ();
             bool previous_found = false;
-            
-            queue.clear();
+
+            queue.clear ();
             Episode previous_newest_episode = null;
 
-            if(podcast.episodes.size > 0) {      
+            if (podcast.episodes.size > 0) {
                 previous_newest_episode = podcast.episodes[podcast.episodes.size - 1];
             }
-            
+
             string path = podcast.feed_uri;
-        
+
             // Call the Xml.Parser to parse the file, which returns an unowned reference
             Xml.Doc* doc;
-            
-            if(SoupClient.valid_http_uri(path)) {
-                doc = XmlUtils.parse_string(soup_client.request_as_string(HttpMethod.GET, path));
+
+            if (SoupClient.valid_http_uri (path)) {
+                doc = XmlUtils.parse_string (soup_client.request_as_string (HttpMethod.GET, path));
             } else {
                 doc = Xml.Parser.parse_file (path);
-                
+
                 // Make sure that it didn't return a null reference
                 if (doc == null) {
-                    throw new VocalUpdateError.NETWORK_ERROR("Error opening file %s. Parser returned null.".printf(path));
+                    throw new VocalUpdateError.NETWORK_ERROR ("Error opening file %s. Parser returned null.".printf (path));
                 }
             }
 
             // Get the root node
             Xml.Node* root = doc->get_root_element ();
-            
+
             // Make sure that it didn't return a null reference, either
             if (root == null) {
-            
+
                 // If it did, free the document manually (since unowned)
                 delete doc;
-                throw new VocalUpdateError.NETWORK_ERROR("The XML file '%s' is empty".printf(path));
+                throw new VocalUpdateError.NETWORK_ERROR ("The XML file '%s' is empty".printf (path));
             }
-            
+
 
             // Parse the root node, which in turn will cause all nodes and properties to be parsed
-            parse_node(root);
+            parse_node (root);
 
             if (root->name == "feed") {
-                new_episodes = create_podcast_from_queue_atom_new_episodes(root,podcast,previous_newest_episode);
+                new_episodes = create_podcast_from_queue_atom_new_episodes (root,podcast,previous_newest_episode);
             } else {
                 int i = 0;
-                
+
                 while ( i < queue.size && !previous_found) {
-                
+
                     if (queue[i] == "item") {
-                        
+
                         // Create a new episode
-                        Episode episode = new Episode();
+                        Episode episode = new Episode ();
                         string next_item_in_queue = null;
                         bool found_summary = false;
 
-                                            
+
                         while (next_item_in_queue != "item" && i < queue.size - 1) {
                             i++;
                             next_item_in_queue = queue[i];
-                            if(next_item_in_queue == "title") {
+                            if (next_item_in_queue == "title") {
                                 i++;
                                 episode.title = queue[i];
                             }
-                            else if(next_item_in_queue == "enclosure") {
+                            else if (next_item_in_queue == "enclosure") {
                                 bool uri_found = false;
                                 bool type_found = false;
-                                
+
                                 // Because different podcasts enclose information differently,
                                 // we must individually search for both the uri and the type
-                                while(uri_found != true || type_found != true) {
+                                while (uri_found != true || type_found != true) {
                                     // Look at next item
                                     i++;
-                                    
-                                    if(queue[i] == "url") {
-                                        
+
+                                    if (queue[i] == "url") {
+
                                         i++;
                                         episode.uri = queue[i];
                                         uri_found = true;
-                                        
+
                                     }
-                                    else if(queue[i] == "type") {
+                                    else if (queue[i] == "type") {
                                         i++;
 
-                                        string typestring = queue[i].slice(0, 5);
-                                        if(podcast.content_type == MediaType.UNKNOWN) {
-                                            if(typestring == "audio") {
+                                        string typestring = queue[i].slice (0, 5);
+                                        if (podcast.content_type == MediaType.UNKNOWN) {
+                                            if (typestring == "audio") {
                                                 podcast.content_type = MediaType.AUDIO;
                                             }
                                             else if (typestring == "video") {
@@ -549,48 +548,48 @@ namespace Vocal {
                                             else {
                                                 podcast.content_type = MediaType.UNKNOWN;
                                             }
-                            
+
                                         }
-                                        
+
                                         type_found = true;
                                     }
                                 }
-                                
-                            }
-                            else if(next_item_in_queue == "pubDate") {
-                                i++;
-                                
-                                episode.date_released = queue[i];
-                                episode.set_datetime_from_pubdate();
 
                             }
-                            else if(next_item_in_queue == "summary") {
+                            else if (next_item_in_queue == "pubDate") {
+                                i++;
+
+                                episode.date_released = queue[i];
+                                episode.set_datetime_from_pubdate ();
+
+                            }
+                            else if (next_item_in_queue == "summary") {
                                 // Save the summary as description if we haven't found a description yet.
                                 // Subsequent descriptions will overwrite this.
-                                if (episode.description.char_count() == 0) {
+                                if (episode.description.char_count () == 0) {
                                     i++;
                                     episode.description = queue[i];
                                 }
                             }
-                            else if(next_item_in_queue == "description") {
+                            else if (next_item_in_queue == "description") {
                                 i++;
                                 episode.description = queue[i];
                             }
                         }
-                        
+
                         episode.parent = podcast;
-                        
-                        if(previous_newest_episode != null) {
-                            if(episode.title == previous_newest_episode.title.replace("%27", "'")) {
+
+                        if (previous_newest_episode != null) {
+                            if (episode.title == previous_newest_episode.title.replace ("%27", "'")) {
                                 previous_found = true;
                             } else {
-                                new_episodes.add(episode);
+                                new_episodes.add (episode);
                             }
                         } else {
-                            new_episodes.add(episode);
+                            new_episodes.add (episode);
                         }
                     }
-                    
+
                     // Otherwise, simply increment and keep going
                     else {
                         i++;
@@ -601,8 +600,8 @@ namespace Vocal {
             // Iterate through the arraylist of new episodes
 
             // Keep in mind that the newest episode is on the bottom, so go in reverse order
-            for(int index = new_episodes.size - 1; index >= 0; index--) {
-                podcast.episodes.add(new_episodes[index]);
+            for (int index = new_episodes.size - 1; index >= 0; index--) {
+                podcast.episodes.add (new_episodes[index]);
             }
 
             int episodes_added = new_episodes.size;
@@ -610,7 +609,7 @@ namespace Vocal {
 
             // Free up the space from the root node
             delete root;
-            
+
             return episodes_added;
         }
     }
@@ -618,11 +617,11 @@ namespace Vocal {
     /*
      * This method collects the episodes from atom xml file.
      */
-    private Gee.ArrayList<Episode> create_podcast_from_queue_atom_new_episodes( Xml.Node* node,Podcast podcast,Episode? previous_newest_episode) {
-        
-        bool previous_found = false; 
-        Gee.ArrayList<Episode> new_episodes = new Gee.ArrayList<Episode>(); //array of new episodes
-        Gee.ArrayList<Episode> episodes = new Gee.ArrayList<Episode>(); // array of episodes from xml
+    private Gee.ArrayList<Episode> create_podcast_from_queue_atom_new_episodes ( Xml.Node* node,Podcast podcast,Episode? previous_newest_episode) {
+
+        bool previous_found = false;
+        Gee.ArrayList<Episode> new_episodes = new Gee.ArrayList<Episode> (); //array of new episodes
+        Gee.ArrayList<Episode> episodes = new Gee.ArrayList<Episode> (); // array of episodes from xml
 
         /* Create the new podcast object */
         for (Xml.Node* iter = node->children; iter != null ; iter = iter->next) {
@@ -631,7 +630,7 @@ namespace Vocal {
             }
 
             /* Creating a Episode with values from <entry> tag. */
-            Episode entry = new Episode();
+            Episode entry = new Episode ();
 
             for (Xml.Node* iterEntry = iter->children; iterEntry != null; iterEntry = iterEntry->next) {
                 switch (iterEntry->name) {
@@ -644,8 +643,8 @@ namespace Vocal {
                     case "updated":
                         GLib.Time tm = GLib.Time ();
                         tm.strptime ( iterEntry->get_content (), "%Y-%m-%dT%H:%M:%S%Z");
-                        entry.date_released=tm.format("%a, %d %b %Y %H:%M:%S %Z");
-                        entry.set_datetime_from_pubdate();
+                        entry.date_released=tm.format ("%a, %d %b %Y %H:%M:%S %Z");
+                        entry.set_datetime_from_pubdate ();
                         break;
                     case "link":
                         for (Xml.Attr* propEntry = iterEntry->properties; propEntry != null; propEntry = propEntry->next) {
@@ -655,9 +654,9 @@ namespace Vocal {
                             } else if (attr_name == "type" && podcast!= null) {
                                 podcast.content_type = MediaType.UNKNOWN;
 
-                                if (propEntry->children->content.contains("audio/")) {
+                                if (propEntry->children->content.contains ("audio/")) {
                                     podcast.content_type = MediaType.AUDIO;
-                                } else if (propEntry->children->content.contains("video/")) {
+                                } else if (propEntry->children->content.contains ("video/")) {
                                     podcast.content_type = MediaType.VIDEO;
                                 }
                             }
@@ -669,20 +668,20 @@ namespace Vocal {
             }
 
             entry.parent=podcast;
-            episodes.add(entry);
+            episodes.add (entry);
         }
 
         for (int i=episodes.size;i>0 && !previous_found;i--) {
             Episode entry=episodes[i-1];
 
             if (previous_newest_episode != null) {
-                if (entry.title == previous_newest_episode.title.replace("%27", "'")) {
+                if (entry.title == previous_newest_episode.title.replace ("%27", "'")) {
                     previous_found = true;
                 } else {
-                    new_episodes.add(entry);
+                    new_episodes.add (entry);
                 }
             } else {
-                new_episodes.add(entry);
+                new_episodes.add (entry);
             }
         }
 
@@ -690,12 +689,12 @@ namespace Vocal {
     }
 
     /*
-     * This method, using XML structure of a atom file, populates attributes 
-     * for a podcasts and its entries. 
+     * This method, using XML structure of a atom file, populates attributes
+     * for a podcasts and its entries.
      */
-    private Podcast create_podcast_from_queue_atom( Xml.Node* node) {
+    private Podcast create_podcast_from_queue_atom ( Xml.Node* node) {
 
-        Podcast podcast = new Podcast();
+        Podcast podcast = new Podcast ();
 
         for (Xml.Node* iter = node->children; iter != null; iter = iter->next) {
             /* Assigning podcast properties... */
@@ -710,9 +709,9 @@ namespace Vocal {
                     podcast.remote_art_uri= iter->get_content ();
                     break;
                 case "rights":
-                    if (iter->get_content ().index_of("cc-") == 0) {
+                    if (iter->get_content ().index_of ("cc-") == 0) {
                         podcast.license = License.CC;
-                    } else { 
+                    } else {
                         podcast.license = License.UNKNOWN;
                     }
                     break;
@@ -722,18 +721,18 @@ namespace Vocal {
                             podcast.feed_uri=prop->children->content;
                         }
                     }
-                    break;                             
+                    break;
                 default:
                     break;
             }
         }
 
-        Gee.ArrayList<Episode> episodes = create_podcast_from_queue_atom_new_episodes(node,podcast,null);
+        Gee.ArrayList<Episode> episodes = create_podcast_from_queue_atom_new_episodes (node,podcast,null);
 
         foreach (Episode episode in episodes) {
-            podcast.episodes.add(episode);
+            podcast.episodes.add (episode);
         }
-    
+
         return podcast;
     }
 }

--- a/src/Utils/FeedParser.vala
+++ b/src/Utils/FeedParser.vala
@@ -59,7 +59,7 @@ namespace Vocal {
                     found_podcast_title = true;
                     i++;
                 }
-                else if (current == "new-feed-url"&& found_podcast_link == false) {
+                else if (current == "new-feed-url" && found_podcast_link == false) {
 
                     i++;
                     podcast.feed_uri = queue[i];
@@ -75,10 +75,10 @@ namespace Vocal {
 
                     // There are six fields, but we can't assume any order
                     for (int n = 0; n < 6; n++) {
-                        if (queue[i+n] == "application/rss+xml") {
+                        if (queue[i + n] == "application/rss+xml") {
                             store_ref = true;
                         }
-                        if (queue[i+n] == "href") {
+                        if (queue[i + n] == "href") {
                             href = queue[i + n + 1];
                         }
                     }
@@ -358,7 +358,7 @@ namespace Vocal {
         /*
          * Parses an OPML file and returns an array listing each feed discovered within
          */
-        public string[] parse_feeds_from_OPML (string path) throws VocalLibraryError {
+        public string[] parse_feeds_from_OPML (string path) throws VocalLibraryError {  // vala-lint=naming-convention
             var feeds = new Gee.ArrayList<string> ();
 
             queue.clear ();
@@ -368,7 +368,9 @@ namespace Vocal {
 
             // Make sure that it didn't return a null reference
             if (doc == null) {
-                throw new VocalLibraryError.IMPORT_ERROR (_ ("Selected file doesn't appear to contain podcast subscriptions."));
+                throw new VocalLibraryError.IMPORT_ERROR (
+                    _ ("Selected file doesn't appear to contain podcast subscriptions.")
+                );
             }
 
             // Get the root node
@@ -476,7 +478,9 @@ namespace Vocal {
 
                 // Make sure that it didn't return a null reference
                 if (doc == null) {
-                    throw new VocalUpdateError.NETWORK_ERROR ("Error opening file %s. Parser returned null.".printf (path));
+                    throw new VocalUpdateError.NETWORK_ERROR (
+                        "Error opening file %s. Parser returned null.".printf (path)
+                    );
                 }
             }
 
@@ -496,7 +500,7 @@ namespace Vocal {
             parse_node (root);
 
             if (root->name == "feed") {
-                new_episodes = create_podcast_from_queue_atom_new_episodes (root,podcast,previous_newest_episode);
+                new_episodes = create_podcast_from_queue_atom_new_episodes (root, podcast, previous_newest_episode);
             } else {
                 int i = 0;
 
@@ -617,7 +621,11 @@ namespace Vocal {
     /*
      * This method collects the episodes from atom xml file.
      */
-    private Gee.ArrayList<Episode> create_podcast_from_queue_atom_new_episodes ( Xml.Node* node,Podcast podcast,Episode? previous_newest_episode) {
+    private Gee.ArrayList<Episode> create_podcast_from_queue_atom_new_episodes (
+        Xml.Node* node,
+        Podcast podcast,
+        Episode? previous_newest_episode
+    ) {
 
         bool previous_found = false;
         Gee.ArrayList<Episode> new_episodes = new Gee.ArrayList<Episode> (); //array of new episodes
@@ -647,11 +655,11 @@ namespace Vocal {
                         entry.set_datetime_from_pubdate ();
                         break;
                     case "link":
-                        for (Xml.Attr* propEntry = iterEntry->properties; propEntry != null; propEntry = propEntry->next) {
+                        for (Xml.Attr* propEntry = iterEntry->properties; propEntry != null; propEntry = propEntry->next) {  // vala-lint=line-length
                             string attr_name = propEntry->name;
                             if (attr_name == "href") {
                                 entry.uri=propEntry->children->content;
-                            } else if (attr_name == "type" && podcast!= null) {
+                            } else if (attr_name == "type" && podcast != null) {
                                 podcast.content_type = MediaType.UNKNOWN;
 
                                 if (propEntry->children->content.contains ("audio/")) {
@@ -671,8 +679,8 @@ namespace Vocal {
             episodes.add (entry);
         }
 
-        for (int i=episodes.size;i>0 && !previous_found;i--) {
-            Episode entry=episodes[i-1];
+        for (int i=episodes.size; i > 0 && !previous_found; i--) {
+            Episode entry=episodes[i - 1];
 
             if (previous_newest_episode != null) {
                 if (entry.title == previous_newest_episode.title.replace ("%27", "'")) {
@@ -727,7 +735,7 @@ namespace Vocal {
             }
         }
 
-        Gee.ArrayList<Episode> episodes = create_podcast_from_queue_atom_new_episodes (node,podcast,null);
+        Gee.ArrayList<Episode> episodes = create_podcast_from_queue_atom_new_episodes (node, podcast, null);
 
         foreach (Episode episode in episodes) {
             podcast.episodes.add (episode);

--- a/src/Utils/MPRIS.vala
+++ b/src/Utils/MPRIS.vala
@@ -14,468 +14,464 @@
   with this program.  If not, see <http://www.gnu.org/licenses>
 
   END LICENSE
-  
+
   Note: Parts of this MPRIS implementation are inspired by the Noise
   MPRIS plugin:
 
-  		Original Authors: Andreas Obergrusberger
-                   			Jörn Magens
- 
- 		Edited by: Scott Ringwelski
+          Original Authors: Andreas Obergrusberger
+                               Jörn Magens
+
+         Edited by: Scott Ringwelski
 
   BEGIN LICENSE
 ***/
 
 using Gee;
 using GLib;
- 
-namespace Vocal { 
+
+namespace Vocal {
 
     public class MPRIS : GLib.Object {
-	    public MprisPlayer 	player = null;
-	    public MprisRoot 	root = null;
-	    
-	    private Controller controller;
+        public MprisPlayer player = null;
+        public MprisRoot root = null;
 
-	    private unowned 	DBusConnection conn;
-	    private uint 		owner_id;
+        private Controller controller;
 
-		/*
-		 * Default constructor that simply sets the controller.window
-		 */
-	    public MPRIS(Controller controller) {
-	        this.controller = controller;
-	    }
+        private unowned DBusConnection conn;
+        private uint owner_id;
 
-		/*
-		 * Initializes MPRIS support
-		 */
-	    public void initialize() {
-	        
-		    owner_id = Bus.own_name(BusType.SESSION,
-		                            "org.mpris.MediaPlayer2.com.github.needleandthread.vocal",
-		                            GLib.BusNameOwnerFlags.NONE,
-                            		on_bus_acquired,
-                            		on_name_acquired,
-                            		on_name_lost);
+        /*
+         * Default constructor that simply sets the controller.window
+         */
+        public MPRIS (Controller controller) {
+            this.controller = controller;
+        }
 
-		    if(owner_id == 0) {
-			    warning("Could not initialize MPRIS session.\n");
-		    }  
-	    }
+        /*
+         * Initializes MPRIS support
+         */
+        public void initialize () {
 
-		/*
-		 * Handler for when the DBus connection gets acquired
-		 */
-	    private void on_bus_acquired(DBusConnection connection, string name) {
-		    this.conn = connection;
-		    debug("bus acquired\n");
-		    try {
-			    root = new MprisRoot();
-			    connection.register_object("/org/mpris/MediaPlayer2", root);
+            owner_id = Bus.own_name (BusType.SESSION,
+                                    "org.mpris.MediaPlayer2.com.github.needleandthread.vocal",
+                                    GLib.BusNameOwnerFlags.NONE,
+                                    on_bus_acquired,
+                                    on_name_acquired,
+                                    on_name_lost);
 
-			    root.quit_requested.connect(() => {
-			    	controller.window.destroy();
-		    	});
-			    root.raise_requiested.connect(() => {
-			    	controller.window.present();
-		    	});
+            if (owner_id == 0) {
+                warning ("Could not initialize MPRIS session.\n");
+            }
+        }
 
-			    
-			    player = new MprisPlayer(connection);
+        /*
+         * Handler for when the DBus connection gets acquired
+         */
+        private void on_bus_acquired (DBusConnection connection, string name) {
+            this.conn = connection;
+            debug ("bus acquired\n");
+            try {
+                root = new MprisRoot ();
+                connection.register_object ("/org/mpris/MediaPlayer2", root);
 
-			    // Set up all the signals
-			    controller.track_changed.connect(player.set_media_metadata);
-			    controller.playback_status_changed.connect(player.set_playback_status);
+                root.quit_requested.connect (() => {
+                    controller.window.destroy ();
+                });
+                root.raise_requiested.connect (() => {
+                    controller.window.present ();
+                });
 
-			    player.play.connect(() => {
-			    	controller.play();
-		    	});
 
-		    	player.pause.connect(() => {
-		    		controller.pause();
-		    	});
+                player = new MprisPlayer (connection);
 
-		    	player.play_pause.connect(() => {
-		    		controller.play_pause();
-	    		});	
+                // Set up all the signals
+                controller.track_changed.connect (player.set_media_metadata);
+                controller.playback_status_changed.connect (player.set_playback_status);
 
-		    	player.next.connect(() => {
-		    		controller.seek_forward();
-		    	});
+                player.play.connect (() => {
+                    controller.play ();
+                });
 
-		    	player.previous.connect(() => {
-		    		controller.seek_backward();
-		    	});
+                player.pause.connect (() => {
+                    controller.pause ();
+                });
 
-			    connection.register_object("/org/mpris/MediaPlayer2", player);
-			    
+                player.play_pause.connect (() => {
+                    controller.play_pause ();
+                });
 
-		    } 
-		    catch(IOError e) {
-			    warning("could not create MPRIS player: %s\n", e.message);
-		    }
-	    }
+                player.next.connect (() => {
+                    controller.seek_forward ();
+                });
 
-		/*
-		 * Handler for when the name gets acquired
-		 */
-	    private void on_name_acquired(DBusConnection connection, string name) {}	
+                player.previous.connect (() => {
+                    controller.seek_backward ();
+                });
 
-		/*
-		 * Handler for when the name gets lost
-		 */
-	    private void on_name_lost(DBusConnection connection, string name) {}
+                connection.register_object ("/org/mpris/MediaPlayer2", player);
+
+
+            }
+            catch (IOError e) {
+                warning ("could not create MPRIS player: %s\n", e.message);
+            }
+        }
+
+        /*
+         * Handler for when the name gets acquired
+         */
+        private void on_name_acquired (DBusConnection connection, string name) {}
+
+        /*
+         * Handler for when the name gets lost
+         */
+        private void on_name_lost (DBusConnection connection, string name) {}
     }
-    
-    [DBus(name = "org.mpris.MediaPlayer2.Player")]
+
+    [DBus (name = "org.mpris.MediaPlayer2.Player")]
     public class MprisPlayer : GLib.Object {
-	    private unowned DBusConnection conn;
-	    
-	    public signal void play();
-	    public signal void pause();
-	    public signal void play_pause();
-	    public signal void next();
-	    public signal void previous();
+        private unowned DBusConnection conn;
 
-	    private uint send_property_source = 0;
-	    private uint update_metadata_source = 0;
-	    private HashTable<string,Variant> changed_properties = null;
-	    private HashTable<string,Variant> _metadata;
-	    private string playback_status = "Stopped";
+        public signal void play ();
+        public signal void pause ();
+        public signal void play_pause ();
+        public signal void next ();
+        public signal void previous ();
 
-
-	    private const string INTERFACE_NAME = "org.mpris.MediaPlayer2.Player";
-	    const string TRACK_ID = "/com/github/needleandthread/vocal/Track/%d";
-
-	    public MprisPlayer(DBusConnection conn) {
-		    this.conn = conn;
-
-		    // Set the metadata on initialization
-		    this.set_media_metadata(" ", " ", """file:///usr/share/vocal/vocal-missing.png""", 60);
-	    }
-
-	    // MPRIS requires a mpris:trackid metadata item.
-	    private GLib.ObjectPath get_track_id(string s) { 
-		    string id = TRACK_ID.printf(s);
-		    return new GLib.ObjectPath(id);
-	    }
-
-	    private void trigger_metadata_update() {
-	        if(update_metadata_source != 0)
-	            Source.remove(update_metadata_source);
-
-	        update_metadata_source = Timeout.add(300, () => {
-
-	            Variant variant = this.PlaybackStatus;
-	            
-	            queue_property_for_notification("PlaybackStatus", variant);
-	            queue_property_for_notification("Metadata", _metadata);
-	            update_metadata_source = 0;
-	            return false;
-	        });
-	    }
-
-	    public void set_media_metadata (string episode_title, string podcast, string art_uri, uint64 duration) {
-	    	string[] artists = {podcast};
-	        _metadata = new HashTable<string, Variant> (null, null);
-
-	        _metadata.insert("mpris:trackid", get_track_id (episode_title));
-	        _metadata.insert("mpris:length", duration);
-
-	        _metadata.insert("mpris:artUrl", art_uri);
-	        _metadata.insert("xesam:title", episode_title);
-	        _metadata.insert("xesam:album", artists);
-	        _metadata.insert("xesam:artist", artists);
-	        _metadata.insert("xesam:albumArtist", podcast);
-
-	        trigger_metadata_update();
-	    }
+        private uint send_property_source = 0;
+        private uint update_metadata_source = 0;
+        private HashTable<string,Variant> changed_properties = null;
+        private HashTable<string,Variant> _metadata;
+        private string playback_status = "Stopped";
 
 
-	    private bool send_property_change() {
-        
-	        if(changed_properties == null)
-	            return false;
-	        
-	        var builder             = new VariantBuilder(VariantType.ARRAY);
-	        var invalidated_builder = new VariantBuilder(new VariantType("as"));
-	        
-	        foreach(string name in changed_properties.get_keys()) {
-	            Variant variant = changed_properties.lookup(name);
-	            builder.add("{sv}", name, variant);
-	        }
-	        
-	        changed_properties = null;
-	        
-	        try {
-	            conn.emit_signal (null,
-	                              "/org/mpris/MediaPlayer2", 
-	                              "org.freedesktop.DBus.Properties", 
-	                              "PropertiesChanged", 
-	                              new Variant("(sa{sv}as)", 
-	                                         INTERFACE_NAME, 
-	                                         builder, 
-	                                         invalidated_builder)
-	                             );
-	        }
-	        catch(Error e) {
-	            print("Could not send MPRIS property change: %s\n", e.message);
-	        }
-	        send_property_source = 0;
-	        return false;
-	    }
-	    
-	    private void queue_property_for_notification(string property, Variant val) {
-	        // putting the properties into a hashtable works as akind of event compression
-	        
-	        if(changed_properties == null)
-	            changed_properties = new HashTable<string,Variant>(str_hash, str_equal);
-	        
-	        changed_properties.insert(property, val);
-	        
-	        if(send_property_source == 0) {
-	            send_property_source = Idle.add(send_property_change);
-	        }
-	    }
+        private const string INTERFACE_NAME = "org.mpris.MediaPlayer2.Player";
+        const string TRACK_ID = "/com/github/needleandthread/vocal/Track/%d";
 
-	    public void set_playback_status(string status)
-	    {
-	    	this.playback_status = status;
+        public MprisPlayer (DBusConnection conn) {
+            this.conn = conn;
 
-	    	trigger_metadata_update();
-	    }
+            // Set the metadata on initialization
+            this.set_media_metadata (" ", " ", """file:///usr/share/vocal/vocal-missing.png""", 60);
+        }
+
+        // MPRIS requires a mpris:trackid metadata item.
+        private GLib.ObjectPath get_track_id (string s) {
+            string id = TRACK_ID.printf (s);
+            return new GLib.ObjectPath (id);
+        }
+
+        private void trigger_metadata_update () {
+            if (update_metadata_source != 0)
+                Source.remove (update_metadata_source);
+
+            update_metadata_source = Timeout.add (300, () => {
+
+                Variant variant = this.PlaybackStatus;
+
+                queue_property_for_notification ("PlaybackStatus", variant);
+                queue_property_for_notification ("Metadata", _metadata);
+                update_metadata_source = 0;
+                return false;
+            });
+        }
+
+        public void set_media_metadata (string episode_title, string podcast, string art_uri, uint64 duration) {
+            string[] artists = {podcast};
+            _metadata = new HashTable<string, Variant> (null, null);
+
+            _metadata.insert ("mpris:trackid", get_track_id (episode_title));
+            _metadata.insert ("mpris:length", duration);
+
+            _metadata.insert ("mpris:artUrl", art_uri);
+            _metadata.insert ("xesam:title", episode_title);
+            _metadata.insert ("xesam:album", artists);
+            _metadata.insert ("xesam:artist", artists);
+            _metadata.insert ("xesam:albumArtist", podcast);
+
+            trigger_metadata_update ();
+        }
 
 
-	    public double Volume {
+        private bool send_property_change () {
+
+            if (changed_properties == null)
+                return false;
+
+            var builder = new VariantBuilder (VariantType.ARRAY);
+            var invalidated_builder = new VariantBuilder (new VariantType ("as"));
+
+            foreach (string name in changed_properties.get_keys ()) {
+                Variant variant = changed_properties.lookup (name);
+                builder.add ("{sv}", name, variant);
+            }
+
+            changed_properties = null;
+
+            try {
+                conn.emit_signal (null,
+                                  "/org/mpris/MediaPlayer2",
+                                  "org.freedesktop.DBus.Properties",
+                                  "PropertiesChanged",
+                                  new Variant (" (sa{sv}as)",
+                                             INTERFACE_NAME,
+                                             builder,
+                                             invalidated_builder)
+                                 );
+            }
+            catch (Error e) {
+                print ("Could not send MPRIS property change: %s\n", e.message);
+            }
+            send_property_source = 0;
+            return false;
+        }
+
+        private void queue_property_for_notification (string property, Variant val) {
+            // putting the properties into a hashtable works as akind of event compression
+
+            if (changed_properties == null)
+                changed_properties = new HashTable<string,Variant> (str_hash, str_equal);
+
+            changed_properties.insert (property, val);
+
+            if (send_property_source == 0) {
+                send_property_source = Idle.add (send_property_change);
+            }
+        }
+
+        public void set_playback_status (string status) {
+            this.playback_status = status;
+
+            trigger_metadata_update ();
+        }
+
+
+        public double Volume {
             get {
-            	return 1.0;
+                return 1.0;
             } set {
 
             }
-	    }
-
-	    public int64 Position {
-		    get {
-		    	return 0;
-		    }
-	    }
-
-	    public double Rate {
-		    get {	
-		    	return 1.0;
-	    	}
-	    }
-
-	    public bool Shuffle {
-	    	get {
-	    		return false;
-	    	}
-	    }
-
-
-	    public bool CanGoNext {
-		    get {
-			    return true;
-		    }
-	    }
-
-	    public bool CanGoPrevious {
-		    get {
-			    return true;
-		    }
-	    }
-
-	    public bool CanPlay {
-		    get {
-			    return true;
-		    }
-	    }
-
-	    public bool CanPause {
-		    get {
-			    return true;
-		    }
-	    }
-
-	    public bool CanSeek {
-		    get {
-			    return true;
-		    }
-	    }
-
-	    public bool CanControl {
-		    get {
-			    return true;
-		    }
-	    }
-
-	    public signal void Seeked(int64 Position);
-
-	    public void Next() {
-            next();
-	    }
-
-	    public void Previous() {
-            previous();
-	    }
-
-	    public void Pause() {
-            pause();
-	    }
-
-	    public void PlayPause() {
-            play_pause();
-	    }
-
-	    public void Stop() {
-            pause();
-	    }
-
-	    public void Play() {
-            play();
-	    }
-
-	    public void Seek(int64 Offset) {
-	        
         }
-    
-	    public void SetPosition(string dobj, int64 Position) {
-	        Seeked(Position);
-	    }
-	    
-	    public void OpenUri(string Uri) {
-	        
-	    }
 
-	    public string LoopStatus {
-	    	get {
-    			return "None";
-			}
-    	}
+        public int64 Position {
+            get {
+                return 0;
+            }
+        }
 
-	    public string PlaybackStatus {
-	    	get {
-	    		return playback_status;
-    		}
-	    }
+        public double Rate {
+            get {
+                return 1.0;
+            }
+        }
 
-	    public HashTable<string,Variant>? Metadata { //a{sv}
-	        owned get {
-	            return _metadata;
-	        }
-    	}
+        public bool Shuffle {
+            get {
+                return false;
+            }
+        }
+
+
+        public bool CanGoNext {
+            get {
+                return true;
+            }
+        }
+
+        public bool CanGoPrevious {
+            get {
+                return true;
+            }
+        }
+
+        public bool CanPlay {
+            get {
+                return true;
+            }
+        }
+
+        public bool CanPause {
+            get {
+                return true;
+            }
+        }
+
+        public bool CanSeek {
+            get {
+                return true;
+            }
+        }
+
+        public bool CanControl {
+            get {
+                return true;
+            }
+        }
+
+        public signal void Seeked (int64 Position);
+
+        public void Next () {
+            next ();
+        }
+
+        public void Previous () {
+            previous ();
+        }
+
+        public void Pause () {
+            pause ();
+        }
+
+        public void PlayPause () {
+            play_pause ();
+        }
+
+        public void Stop () {
+            pause ();
+        }
+
+        public void Play () {
+            play ();
+        }
+
+        public void Seek (int64 Offset) {
+
+        }
+
+        public void SetPosition (string dobj, int64 Position) {
+            Seeked (Position);
+        }
+
+        public void OpenUri (string Uri) {
+
+        }
+
+        public string LoopStatus {
+            get {
+                return "None";
+            }
+        }
+
+        public string PlaybackStatus {
+            get {
+                return playback_status;
+            }
+        }
+
+        public HashTable<string,Variant>? Metadata { //a{sv}
+            owned get {
+                return _metadata;
+            }
+        }
     }
 
-    [DBus(name = "org.mpris.MediaPlayer2")]
-	public class MprisRoot : GLib.Object {
+    [DBus (name = "org.mpris.MediaPlayer2")]
+    public class MprisRoot : GLib.Object {
 
-		public signal void quit_requested();
-		public signal void raise_requiested();
+        public signal void quit_requested ();
+        public signal void raise_requiested ();
 
-	    public bool CanQuit { 
-	        get {
-	            return true;
-	        } 
-	    }
+        public bool CanQuit {
+            get {
+                return true;
+            }
+        }
 
-	    public bool CanRaise { 
-	        get {
-	            return true;
-	        } 
-	    }
-	    
-	    public string DesktopEntry { 
-	        owned get {
-	            return "com.github.needleandthread.vocal";
-	        } 
-	    }
-	    
-	    public bool HasTrackList {
-	        get {
-	            return false;
-	        }
-	    }
-	    
-	    
-	    public string Identity {
-	        owned get {
-	            return "Vocal";
-	        }
-	    }
-	    
-	    public string[] SupportedMimeTypes {
-			    owned get {
-				    string[] sa = {
-				        "audio/3gpp",
-						"audio/aac",
-						"audio/AMR",
-						"audio/AMR-WB",
-						"audio/ac3",
-						"audio/basic",
-						"audio/flac",
-						"audio/mp2",
-						"audio/mpeg",
-						"audio/mp4",
-						"audio/ogg",
-						"audio/vnd.rn-realaudio",
-						"audio/vorbis",
-						"audio/x-aac",
-						"audio/x-aiff",
-						"audio/x-ape",
-						"audio/x-flac",
-						"audio/x-gsm",
-						"audio/x-it",
-						"audio/x-m4a",
-						"audio/x-matroska",
-						"audio/x-mod",
-						"audio/x-ms-asf",
-						"audio/x-ms-wma",
-						"audio/x-mp3",
-						"audio/x-mpeg",
-						"audio/x-musepack",
-						"audio/x-pn-aiff",
-						"audio/x-pn-au",
-						"audio/x-pn-realaudio",
-						"audio/x-pn-realaudio-plugin",
-						"audio/x-pn-wav",
-						"audio/x-pn-controller.windows-acm",
-						"audio/x-realaudio",
-						"audio/x-real-audio",
-						"audio/x-sbc",
-						"audio/x-speex",
-						"audio/x-tta",
-						"audio/x-vorbis",
-						"audio/x-vorbis+ogg",
-						"audio/x-wav",
-						"audio/x-wavpack",
-						"audio/x-xm",
-						"application/ogg",
-						"application/x-extension-m4a",
-						"application/x-extension-mp4",
-						"application/x-flac",
-						"application/x-ogg"
-				    };
-				    return sa;
-			    }
-		    }
-		    
-	    public string[] SupportedUriSchemes {
-	        owned get {
-	            string[] sa = {"http", "file", "https", "ftp"};
-	            return sa;
-	        }
-	    }
+        public bool CanRaise {
+            get {
+                return true;
+            }
+        }
 
-	    public void Quit () {
-	        quit_requested();
-	    }
-	    
-	    public void Raise () {
-	        raise_requiested();
-	    }
-	}
+        public string DesktopEntry {
+            owned get {
+                return "com.github.needleandthread.vocal";
+            }
+        }
+
+        public bool HasTrackList {
+            get {
+                return false;
+            }
+        }
 
 
-    
+        public string Identity {
+            owned get {
+                return "Vocal";
+            }
+        }
+
+        public string[] SupportedMimeTypes {
+            owned get {
+                string[] sa = {
+                    "audio/3gpp",
+                    "audio/aac",
+                    "audio/AMR",
+                    "audio/AMR-WB",
+                    "audio/ac3",
+                    "audio/basic",
+                    "audio/flac",
+                    "audio/mp2",
+                    "audio/mpeg",
+                    "audio/mp4",
+                    "audio/ogg",
+                    "audio/vnd.rn-realaudio",
+                    "audio/vorbis",
+                    "audio/x-aac",
+                    "audio/x-aiff",
+                    "audio/x-ape",
+                    "audio/x-flac",
+                    "audio/x-gsm",
+                    "audio/x-it",
+                    "audio/x-m4a",
+                    "audio/x-matroska",
+                    "audio/x-mod",
+                    "audio/x-ms-asf",
+                    "audio/x-ms-wma",
+                    "audio/x-mp3",
+                    "audio/x-mpeg",
+                    "audio/x-musepack",
+                    "audio/x-pn-aiff",
+                    "audio/x-pn-au",
+                    "audio/x-pn-realaudio",
+                    "audio/x-pn-realaudio-plugin",
+                    "audio/x-pn-wav",
+                    "audio/x-pn-controller.windows-acm",
+                    "audio/x-realaudio",
+                    "audio/x-real-audio",
+                    "audio/x-sbc",
+                    "audio/x-speex",
+                    "audio/x-tta",
+                    "audio/x-vorbis",
+                    "audio/x-vorbis+ogg",
+                    "audio/x-wav",
+                    "audio/x-wavpack",
+                    "audio/x-xm",
+                    "application/ogg",
+                    "application/x-extension-m4a",
+                    "application/x-extension-mp4",
+                    "application/x-flac",
+                    "application/x-ogg"
+                };
+                return sa;
+            }
+        }
+
+        public string[] SupportedUriSchemes {
+            owned get {
+                string[] sa = {"http", "file", "https", "ftp"};
+                return sa;
+            }
+        }
+
+        public void Quit () {
+            quit_requested ();
+        }
+
+        public void Raise () {
+            raise_requiested ();
+        }
+    }
 }

--- a/src/Utils/MPRIS.vala
+++ b/src/Utils/MPRIS.vala
@@ -309,41 +309,41 @@ namespace Vocal {
             }
         }
 
-        public signal void Seeked (int64 Position);
+        public signal void Seeked (int64 Position);  // vala-lint=naming-convention
 
-        public void Next () {
+        public void Next () {  // vala-lint=naming-convention
             next ();
         }
 
-        public void Previous () {
+        public void Previous () {  // vala-lint=naming-convention
             previous ();
         }
 
-        public void Pause () {
+        public void Pause () {  // vala-lint=naming-convention
             pause ();
         }
 
-        public void PlayPause () {
+        public void PlayPause () {  // vala-lint=naming-convention
             play_pause ();
         }
 
-        public void Stop () {
+        public void Stop () {  // vala-lint=naming-convention
             pause ();
         }
 
-        public void Play () {
+        public void Play () {  // vala-lint=naming-convention
             play ();
         }
 
-        public void Seek (int64 Offset) {
+        public void Seek (int64 Offset) {  // vala-lint=naming-convention
 
         }
 
-        public void SetPosition (string dobj, int64 Position) {
+        public void SetPosition (string dobj, int64 Position) {  // vala-lint=naming-convention
             Seeked (Position);
         }
 
-        public void OpenUri (string Uri) {
+        public void OpenUri (string Uri) {  // vala-lint=naming-convention
 
         }
 
@@ -466,11 +466,11 @@ namespace Vocal {
             }
         }
 
-        public void Quit () {
+        public void Quit () {  // vala-lint=naming-convention
             quit_requested ();
         }
 
-        public void Raise () {
+        public void Raise () {  // vala-lint=naming-convention
             raise_requiested ();
         }
     }

--- a/src/Utils/Player.vala
+++ b/src/Utils/Player.vala
@@ -25,42 +25,42 @@ using Gst.PbUtils;
 namespace Vocal {
     public class Player : ClutterGst.Playback {
 
-    	private static Player? player = null;
+        private static Player? player = null;
         public static Player? get_default (string[] args) {
             if (player == null) {
-                player = new Player(args);
+                player = new Player (args);
             }
             return player;
         }
-    
-        public signal void state_changed(Gst.State new_state);
-        public signal void additional_plugins_required(Gst.Message message);
 
-        public signal void new_position_available();
+        public signal void state_changed (Gst.State new_state);
+        public signal void additional_plugins_required (Gst.Message message);
+
+        public signal void new_position_available ();
         private string tag_string;
 
         public Episode current_episode;
 
-        private Player(string[]? args) {
-        
+        private Player (string[]? args) {
+
             bool new_launch = true;
 
             current_episode = null;
-            
+
             // Check every half-second if the current media is playing, and if it is
             // send a signal that there is a new position available
-            GLib.Timeout.add(500, () => {
-                
-                if(playing)
-                    new_position_available();
+            GLib.Timeout.add (500, () => {
+
+                if (playing)
+                    new_position_available ();
                 if (new_launch && duration > 0.0) {
-                    new_position_available();
+                    new_position_available ();
                     new_launch = false;
                 }
                 return true;
             });
         }
-        
+
         /*
          *  Returns the total duration of the currently playing media
          */
@@ -75,32 +75,32 @@ namespace Vocal {
             return this.progress;
         }
 
-	    /*
+        /*
          * Sets the current state to pause
          */
         public void pause () {
             this.playing = false;
         }
 
-	    /*
+        /*
          * Sets the current state to playing
          */
         public void play () {
 
             this.playing = true;
         }
-        
+
         /*
          * Seeks backward in the currently playing media n number of seconds
          */
         public void seek_backward (int num_seconds) {
-            
+
             double total_seconds = duration;
             double percentage_of_total_seconds = num_seconds / total_seconds;
 
-            set_position(progress - percentage_of_total_seconds);
+            set_position (progress - percentage_of_total_seconds);
         }
-        
+
         /*
          * Seeks forward in the currently playing media n number of seconds
          */
@@ -108,75 +108,75 @@ namespace Vocal {
             double total_seconds = duration;
             double percentage_of_total_seconds = num_seconds / total_seconds;
 
-            set_position(progress + percentage_of_total_seconds);
+            set_position (progress + percentage_of_total_seconds);
         }
-        
+
         /*
          * Sets the episode that is currently being played
          */
         public void set_episode (Episode episode) {
-  
+
             this.current_episode = episode;
-            
+
             // Set the URI
             this.uri = episode.playback_uri;
-            info("Setting playback URI: %s".printf(episode.playback_uri));
+            info ("Setting playback URI: %s".printf (episode.playback_uri));
             /*
-            
+
             // If it's a video podcast, get the width and height and configure that information
-            if(episode.parent.content_type == MediaType.VIDEO) {
-	            try {
-		            var info = new Gst.PbUtils.Discoverer (10 * Gst.SECOND).discover_uri (this.uri);
-		            var video = info.get_video_streams ();
-		            if (video.data != null) {
-		                var video_info = (Gst.PbUtils.DiscovererVideoInfo)video.data;
-		                video_width = video_info.get_width ();
-		                video_height = video_info.get_height ();
+            if (episode.parent.content_type == MediaType.VIDEO) {
+                try {
+                    var info = new Gst.PbUtils.Discoverer (10 * Gst.SECOND).discover_uri (this.uri);
+                    var video = info.get_video_streams ();
+                    if (video.data != null) {
+                        var video_info = (Gst.PbUtils.DiscovererVideoInfo)video.data;
+                        video_width = video_info.get_width ();
+                        video_height = video_info.get_height ();
 
-		                configure_video();
+                        configure_video ();
 
-		            }
-	            }catch(Error e) {
-	            	warning(e.message);
-	            }
+                    }
+                }catch (Error e) {
+                    warning (e.message);
+                }
             }
             */
         }
-        
+
         /*
          * Change the playback rate
          */
         /*
-        public void set_playback_rate(double rate) {
-            int64 pos = get_position();
+        public void set_playback_rate (double rate) {
+            int64 pos = get_position ();
             this.seek (2.0,
             Gst.Format.TIME, Gst.SeekFlags.SKIP,
             Gst.SeekType.NONE, pos,
             Gst.SeekType.NONE, duration);
-        } 
+        }
         */
-        
-        
+
+
         /*
          *  Sets the currently playing media position
          */
         public void set_position (double pos) {
             this.progress = pos;
-            new_position_available();
+            new_position_available ();
         }
 
-		/*
-		 * Sets the current volume
-		 */
-	    public void set_volume (double val) {
-	        this.audio_volume = val;
-	    }
-	    
-	    /*
-		 * Gets the current volume
-		 */
-	    public double get_volume () {
-	        return this.audio_volume;
-	    }
+        /*
+         * Sets the current volume
+         */
+        public void set_volume (double val) {
+            this.audio_volume = val;
+        }
+
+        /*
+         * Gets the current volume
+         */
+        public double get_volume () {
+            return this.audio_volume;
+        }
     }
 }

--- a/src/Utils/SoupClient.vala
+++ b/src/Utils/SoupClient.vala
@@ -59,11 +59,19 @@ public class SoupClient {
 
             case Soup.Status.CANT_RESOLVE:
             case Soup.Status.CANT_RESOLVE_PROXY:
-                throw new PublishingError.NO_ANSWER ("Unable to resolve %s (error code %u)", message.get_uri ().to_string (false), message.status_code);
+                throw new PublishingError.NO_ANSWER (
+                    "Unable to resolve %s (error code %u)",
+                    message.get_uri ().to_string (false),
+                    message.status_code
+                );
 
             case Soup.Status.CANT_CONNECT:
             case Soup.Status.CANT_CONNECT_PROXY:
-                throw new PublishingError.NO_ANSWER ("Unable to connect to %s (error code %u)", message.get_uri ().to_string (false), message.status_code);
+                throw new PublishingError.NO_ANSWER (
+                    "Unable to connect to %s (error code %u)",
+                    message.get_uri ().to_string (false),
+                    message.status_code
+                );
 
             default:
                 // status codes below 100 are used by Soup, 100 and above are defined HTTP codes
@@ -71,7 +79,11 @@ public class SoupClient {
                     throw new PublishingError.NO_ANSWER ("Service %s returned HTTP status code %u %s",
                     message.get_uri ().to_string (false), message.status_code, message.reason_phrase);
                 } else {
-                    throw new PublishingError.NO_ANSWER ("Failure communicating with %s (error code %u)", message.get_uri ().to_string (false), message.status_code);
+                    throw new PublishingError.NO_ANSWER (
+                        "Failure communicating with %s (error code %u)",
+                        message.get_uri ().to_string (false),
+                        message.status_code
+                    );
                 }
         }
 

--- a/src/Utils/SoupClient.vala
+++ b/src/Utils/SoupClient.vala
@@ -7,43 +7,43 @@ public class SoupClient {
         soup_session.user_agent = Constants.USER_AGENT;
     }
 
-    public string request_as_string(HttpMethod method, string url) throws Error {
-        var data_stream = new DataInputStream(request(method, url));
+    public string request_as_string (HttpMethod method, string url) throws Error {
+        var data_stream = new DataInputStream (request (method, url));
         var builder = new StringBuilder ();
 
-        for (string line = data_stream.read_line_utf8(); line != null; line = data_stream.read_line_utf8()) {
-            builder.append(line);
+        for (string line = data_stream.read_line_utf8 (); line != null; line = data_stream.read_line_utf8 ()) {
+            builder.append (line);
         }
 
         return builder.str;
     }
 
     public InputStream request (HttpMethod method, string url) throws Error {
-        if (!valid_http_uri(url)) {
-            throw new PublishingError.PROTOCOL_ERROR("%s is not a valid URI. Should be http or https", url);
+        if (!valid_http_uri (url)) {
+            throw new PublishingError.PROTOCOL_ERROR ("%s is not a valid URI. Should be http or https", url);
         }
 
         var message = new Soup.Message (method.to_string (), url);
 
         InputStream stream = soup_session.send (message);
 
-        check_response_headers(message);
+        check_response_headers (message);
 
         return stream;
     }
 
-    public static bool valid_http_uri(string url) {
-        return url.index_of("http://") == 0 || url.index_of("https://") == 0;
+    public static bool valid_http_uri (string url) {
+        return url.index_of ("http://") == 0 || url.index_of ("https://") == 0;
     }
 
-    public static bool check_connection() {
+    public static bool check_connection () {
         var uri = "http://www.needleandthread.co";
 
         try {
-            SoupClient soup_client = new SoupClient();
-            soup_client.request_as_string(HttpMethod.GET, uri);
-        } catch(Error e) {
-            warning(e.message);
+            SoupClient soup_client = new SoupClient ();
+            soup_client.request_as_string (HttpMethod.GET, uri);
+        } catch (Error e) {
+            warning (e.message);
             return false;
         }
 
@@ -59,19 +59,19 @@ public class SoupClient {
 
             case Soup.Status.CANT_RESOLVE:
             case Soup.Status.CANT_RESOLVE_PROXY:
-                throw new PublishingError.NO_ANSWER ("Unable to resolve %s (error code %u)", message.get_uri().to_string (false), message.status_code);
+                throw new PublishingError.NO_ANSWER ("Unable to resolve %s (error code %u)", message.get_uri ().to_string (false), message.status_code);
 
             case Soup.Status.CANT_CONNECT:
             case Soup.Status.CANT_CONNECT_PROXY:
-                throw new PublishingError.NO_ANSWER ("Unable to connect to %s (error code %u)", message.get_uri().to_string (false), message.status_code);
+                throw new PublishingError.NO_ANSWER ("Unable to connect to %s (error code %u)", message.get_uri ().to_string (false), message.status_code);
 
             default:
                 // status codes below 100 are used by Soup, 100 and above are defined HTTP codes
                 if (message.status_code >= 100) {
                     throw new PublishingError.NO_ANSWER ("Service %s returned HTTP status code %u %s",
-                    message.get_uri().to_string (false), message.status_code, message.reason_phrase);
+                    message.get_uri ().to_string (false), message.status_code, message.reason_phrase);
                 } else {
-                    throw new PublishingError.NO_ANSWER ("Failure communicating with %s (error code %u)", message.get_uri().to_string (false), message.status_code);
+                    throw new PublishingError.NO_ANSWER ("Failure communicating with %s (error code %u)", message.get_uri ().to_string (false), message.status_code);
                 }
         }
 

--- a/src/Utils/Utils.vala
+++ b/src/Utils/Utils.vala
@@ -19,8 +19,8 @@
 
 [DBus (name = "org.gnome.SettingsDaemon.MediaKeys")]
 public interface GnomeMediaKeys : GLib.Object {
-    public abstract void GrabMediaPlayerKeys (string application, uint32 time) throws GLib.IOError;
-    public abstract void ReleaseMediaPlayerKeys (string application) throws GLib.IOError;
+    public abstract void GrabMediaPlayerKeys (string application, uint32 time) throws GLib.IOError;  // vala-lint=line-length, naming-convention
+    public abstract void ReleaseMediaPlayerKeys (string application) throws GLib.IOError;  // vala-lint=line-length, naming-convention
     public signal void MediaPlayerKeyPressed (string application, string key);
 }
 
@@ -118,8 +118,12 @@ public class Utils {
         while (nextOpenBracketIndex >= 0) {
             nextOpenBracketIndex = markup.index_of ("<", 0);
             nextCloseBracketIndex = markup.index_of (">", nextOpenBracketIndex) + 1;
-            if (nextOpenBracketIndex < nextCloseBracketIndex && nextOpenBracketIndex >= 0
-                    && nextCloseBracketIndex >= 0 && nextOpenBracketIndex <= markup.length && nextCloseBracketIndex <= markup.length) {
+            if (
+                nextOpenBracketIndex < nextCloseBracketIndex && nextOpenBracketIndex >= 0
+                && nextCloseBracketIndex >= 0
+                && nextOpenBracketIndex <= markup.length
+                && nextCloseBracketIndex <= markup.length
+            ) {
                 markup = markup.splice (nextOpenBracketIndex, nextCloseBracketIndex);
                 nextOpenBracketIndex = 0;
                 nextCloseBracketIndex = 0;
@@ -309,7 +313,7 @@ public class Utils {
     }
 
     public static string get_shareable_link_for_episode (Vocal.Episode e) {
-        string output = "http://needleandthread.co/apps/vocal/simpleshare.html?podcastName=%s&artUri=%s&episodeTitle=%s&mediaUri=%s";
+        string output = "http://needleandthread.co/apps/vocal/simpleshare.html?podcastName=%s&artUri=%s&episodeTitle=%s&mediaUri=%s";  // vala-lint=line-length
         string podcastName = GLib.Uri.escape_string (e.parent.name);
         string albumArt = e.parent.remote_art_uri;
         string episodeTitle = GLib.Uri.escape_string (e.title);
@@ -361,14 +365,21 @@ const string CLOSE = """
         return str;
     }
 
-    public static async bool upload_to_internet_archive (string local_uri, string title, string podcast, string description) {
+    public static async bool upload_to_internet_archive (
+        string local_uri,
+        string title,
+        string podcast,
+        string description
+    ) {
 
         info ("Uploading to internet archive");
         string container = Uri.escape_string (podcast.replace (" ", "-").replace (":", "").down ());
         if (container[container.len () - 1] == '-') {
             container = container.substring (0, container.len () - 1);
         }
-        string episode = Uri.escape_string (title.replace (" ", "-").down () + local_uri.substring (local_uri.last_index_of (".")));
+        string episode = Uri.escape_string (
+            title.replace (" ", "-").down () + local_uri.substring (local_uri.last_index_of ("."))
+        );
         info (container);
         info (episode);
         var session = new Soup.Session ();

--- a/src/Utils/Utils.vala
+++ b/src/Utils/Utils.vala
@@ -24,105 +24,103 @@ public interface GnomeMediaKeys : GLib.Object {
     public signal void MediaPlayerKeyPressed (string application, string key);
 }
 
-public class Utils
-{
+public class Utils {
 
-    public static bool check_elementary() {
+    public static bool check_elementary () {
         string output;
-        output = GLib.Environment.get_variable("XDG_CURRENT_DESKTOP");
-        string icon_name = Gtk.Settings.get_default().gtk_icon_theme_name;
+        output = GLib.Environment.get_variable ("XDG_CURRENT_DESKTOP");
+        string icon_name = Gtk.Settings.get_default ().gtk_icon_theme_name;
 
-        if (output != null && output.contains ("Pantheon") && icon_name.contains("elementary")) {
+        if (output != null && output.contains ("Pantheon") && icon_name.contains ("elementary")) {
             return true;
         } else {
             return false;
         }
     }
 
-	/*
-	 * A convenience method that sends a generic notification with a message and title
-	 * (assuming libnotify is enabled)
-	 */
-    public static void send_generic_notification(string message, string? title = "Vocal")
-    {
+    /*
+     * A convenience method that sends a generic notification with a message and title
+     * (assuming libnotify is enabled)
+     */
+    public static void send_generic_notification (string message, string? title = "Vocal") {
 #if HAVE_LIBNOTIFY
-        var notification = new Notify.Notification(title, message, "vocal");
-        notification.show();
+        var notification = new Notify.Notification (title, message, "vocal");
+        notification.show ();
 #endif
     }
-    
+
     /*
     * Find the real URI for a resource (locates redirected URIs, etc)
     *
     * Code primarily taken from a patch by
     * Olivier Duchateau <duchateau.olivierd@gmail.com>
     */
-    public static string get_real_uri(string resource) {
+    public static string get_real_uri (string resource) {
         Soup.Session session;
         Soup.Message msg;
         string new_url = null;
-        
+
         /* Create Soup objects */
-        session = new Soup.Session();
+        session = new Soup.Session ();
         session.user_agent = Constants.USER_AGENT;
-        msg = new Soup.Message("GET", resource);
-        
+        msg = new Soup.Message ("GET", resource);
+
         /* Signal */
-        msg.got_headers.connect(() => {
+        msg.got_headers.connect (() => {
             /* 302 */
             if (msg.status_code == Soup.Status.FOUND) {
-                new_url = msg.response_headers.get_one("Location");
+                new_url = msg.response_headers.get_one ("Location");
                 /* Finish processing request */
-                session.cancel_message(msg, Soup.Status.CANCELLED);
+                session.cancel_message (msg, Soup.Status.CANCELLED);
             }
         });
-        
-        session.send_message(msg);
-        
+
+        session.send_message (msg);
+
         if (new_url == null) {
-           new_url = "%s".printf(resource);
+           new_url = "%s".printf (resource);
         }
-        
+
         return new_url;
     }
 
-	/*
-	 * Strips a string of HTML tags, except for ones that are useful in markup
-	 */
-    public static string html_to_markup(string original) {
+    /*
+     * Strips a string of HTML tags, except for ones that are useful in markup
+     */
+    public static string html_to_markup (string original) {
 
-        string markup = GLib.Uri.unescape_string(original);
+        string markup = GLib.Uri.unescape_string (original);
 
         if ( markup == null ) {
             markup = original;
         }
 
-        markup = markup.replace("&", "&amp;");
+        markup = markup.replace ("&", "&amp;");
 
         // Simplify (keep only href attribute) & preserve anchor tags.
-        Regex simpleLinks = new Regex("<a (.*?(href[\\s=]*?\".*?\").*?)>(.*?)<[\\s\\/]*?a[\\s>]*",
+        Regex simpleLinks = new Regex ("<a (.*? (href[\\s=]*?\".*?\").*?)> (.*?)<[\\s\\/]*?a[\\s>]*",
                                       RegexCompileFlags.CASELESS | RegexCompileFlags.DOTALL);
-        markup = simpleLinks.replace(markup, -1, 0, "?a? \\2?a-end?\\3 ?/a?");
+        markup = simpleLinks.replace (markup, -1, 0, "?a? \\2?a-end?\\3 ?/a?");
 
         // Replace <br> tags with line breaks.
-        Regex lineBreaks = new Regex("<br[\\s\\/]*?>", RegexCompileFlags.CASELESS);
-        markup = lineBreaks.replace(markup, -1, 0, "\n");
+        Regex lineBreaks = new Regex ("<br[\\s\\/]*?>", RegexCompileFlags.CASELESS);
+        markup = lineBreaks.replace (markup, -1, 0, "\n");
 
-        markup = markup.replace("<a", "?a?");
-        markup = markup.replace("</a>", "?/a?");
+        markup = markup.replace ("<a", "?a?");
+        markup = markup.replace ("</a>", "?/a?");
 
         // Preserve bold tags
-        markup = markup.replace("<b>", "?b?");
-        markup = markup.replace("</b>", "?/b?");
+        markup = markup.replace ("<b>", "?b?");
+        markup = markup.replace ("</b>", "?/b?");
 
         int nextOpenBracketIndex = 0;
         int nextCloseBracketIndex = 0;
         while (nextOpenBracketIndex >= 0) {
-            nextOpenBracketIndex = markup.index_of("<", 0);
-            nextCloseBracketIndex = markup.index_of(">", nextOpenBracketIndex) + 1;
+            nextOpenBracketIndex = markup.index_of ("<", 0);
+            nextCloseBracketIndex = markup.index_of (">", nextOpenBracketIndex) + 1;
             if (nextOpenBracketIndex < nextCloseBracketIndex && nextOpenBracketIndex >= 0
                     && nextCloseBracketIndex >= 0 && nextOpenBracketIndex <= markup.length && nextCloseBracketIndex <= markup.length) {
-                markup = markup.splice(nextOpenBracketIndex, nextCloseBracketIndex);
+                markup = markup.splice (nextOpenBracketIndex, nextCloseBracketIndex);
                 nextOpenBracketIndex = 0;
                 nextCloseBracketIndex = 0;
             } else {
@@ -131,17 +129,17 @@ public class Utils
         }
 
         // remaining < & > tags are translated
-        markup = markup.replace("<", "&lt;");
-        markup = markup.replace(">", "&gt;");
+        markup = markup.replace ("<", "&lt;");
+        markup = markup.replace (">", "&gt;");
 
         // Preserve hyperlinks
-        markup = markup.replace("?a?", "<a");
-        markup = markup.replace("?a-end?", ">");
-        markup = markup.replace("?/a?", "</a>");
+        markup = markup.replace ("?a?", "<a");
+        markup = markup.replace ("?a-end?", ">");
+        markup = markup.replace ("?/a?", "</a>");
 
         // Preserve bold tags
-        markup = markup.replace("?b?", "<b>");
-        markup = markup.replace("?/b?", "</b>");
+        markup = markup.replace ("?b?", "<b>");
+        markup = markup.replace ("?/b?", "</b>");
 
         if (markup != null && markup.length > 0)
             return markup;
@@ -150,180 +148,180 @@ public class Utils
 
     }
 
-    public static Gee.HashMap<string, string> get_itunes_country_codes() {
-        Gee.HashMap<string, string> code_map = new Gee.HashMap<string, string>();
-        code_map.set("ae", "United Arab Emirates");
-        code_map.set("ag", "Antigua and Barbuda");
-        code_map.set("ai", "Anguilla");
-        code_map.set("al", "Albania");
-        code_map.set("am", "Armenia");
-        code_map.set("ao", "Angola");
-        code_map.set("ar", "Argentina");
-        code_map.set("at", "Austria");
-        code_map.set("au", "Australia");
-        code_map.set("az", "Azerbaijan");
-        code_map.set("bb", "Barbados");
-        code_map.set("be", "Belgium");
-        code_map.set("bf", "Burkina-Faso");
-        code_map.set("bg", "Bulgaria");
-        code_map.set("bh", "Bahrain");
-        code_map.set("bj", "Benin");
-        code_map.set("bm", "Bermuda");
-        code_map.set("bn", "Brunei Darussalam");
-        code_map.set("bo", "Bolivia");
-        code_map.set("br", "Brazil");
-        code_map.set("bs", "Bahamas");
-        code_map.set("bt", "Bhutan");
-        code_map.set("bw", "Botswana");
-        code_map.set("by", "Belarus");
-        code_map.set("bz", "Belize");
-        code_map.set("ca", "Canada");
-        code_map.set("cg", "Democratic Republic of the Congo");
-        code_map.set("ch", "Switzerland");
-        code_map.set("cl", "Chile");
-        code_map.set("cn", "China");
-        code_map.set("co", "Colombia");
-        code_map.set("cr", "Costa Rica");
-        code_map.set("cv", "Cape Verde");
-        code_map.set("cy", "Cyprus");
-        code_map.set("cz", "Czech Republic");
-        code_map.set("de", "Germany");
-        code_map.set("dk", "Denmark");
-        code_map.set("dm", "Dominica");
-        code_map.set("do", "Dominican Republic");
-        code_map.set("dz", "Algeria");
-        code_map.set("ec", "Ecuador");
-        code_map.set("ee", "Estonia");
-        code_map.set("eg", "Egypt");
-        code_map.set("es", "Spain");
-        code_map.set("fi", "Finland");
-        code_map.set("fj", "Fiji");
-        code_map.set("fm", "Federated States of Micronesia");
-        code_map.set("fr", "France");
-        code_map.set("gb", "Great Britain");
-        code_map.set("gd", "Grenada");
-        code_map.set("gh", "Ghana");
-        code_map.set("gm", "Gambia");
-        code_map.set("gr", "Greece");
-        code_map.set("gt", "Guatemala");
-        code_map.set("gw", "Guinea Bissau");
-        code_map.set("gy", "Guyana");
-        code_map.set("hk", "Hong Kong");
-        code_map.set("hn", "Honduras");
-        code_map.set("hr", "Croatia");
-        code_map.set("hu", "Hungaria");
-        code_map.set("id", "Indonesia");
-        code_map.set("ie", "Ireland");
-        code_map.set("il", "Israel");
-        code_map.set("in", "India");
-        code_map.set("is", "Iceland");
-        code_map.set("it", "Italy");
-        code_map.set("jm", "Jamaica");
-        code_map.set("jo", "Jordan");
-        code_map.set("jp", "Japan");
-        code_map.set("ke", "Kenya");
-        code_map.set("kg", "Krygyzstan");
-        code_map.set("kh", "Cambodia");
-        code_map.set("kn", "Saint Kitts and Nevis");
-        code_map.set("kr", "South Korea");
-        code_map.set("kw", "Kuwait");
-        code_map.set("ky", "Cayman Islands");
-        code_map.set("kz", "Kazakhstan");
-        code_map.set("la", "Laos");
-        code_map.set("lb", "Lebanon");
-        code_map.set("lc", "Saint Lucia");
-        code_map.set("lk", "Sri Lanka");
-        code_map.set("lr", "Liberia");
-        code_map.set("lt", "Lithuania");
-        code_map.set("lu", "Luxembourg");
-        code_map.set("lv", "Latvia");
-        code_map.set("md", "Moldova");
-        code_map.set("mg", "Madagascar");
-        code_map.set("mk", "Macedonia");
-        code_map.set("ml", "Mali");
-        code_map.set("mn", "Mongolia");
-        code_map.set("mo", "Macau");
-        code_map.set("mr", "Mauritania");
-        code_map.set("ms", "Montserrat");
-        code_map.set("mt", "Malta");
-        code_map.set("mu", "Mauritius");
-        code_map.set("mw", "Malawi");
-        code_map.set("mx", "Mexico");
-        code_map.set("my", "Malaysia");
-        code_map.set("mz", "Mozambique");
-        code_map.set("na", "Namibia");
-        code_map.set("ne", "Niger");
-        code_map.set("ng", "Nigeria");
-        code_map.set("ni", "Nicaragua");
-        code_map.set("nl", "Netherlands");
-        code_map.set("np", "Nepal");
-        code_map.set("no", "Norway");
-        code_map.set("nz", "New Zealand");
-        code_map.set("om", "Oman");
-        code_map.set("pa", "Panama");
-        code_map.set("pe", "Peru");
-        code_map.set("pg", "Papua New Guinea");
-        code_map.set("ph", "Philippines");
-        code_map.set("pk", "Pakistan");
-        code_map.set("pl", "Poland");
-        code_map.set("pt", "Portugal");
-        code_map.set("pw", "Palau");
-        code_map.set("py", "Paraguay");
-        code_map.set("qa", "Qatar");
-        code_map.set("ro", "Romania");
-        code_map.set("ru", "Russia");
-        code_map.set("sa", "Saudi Arabia");
-        code_map.set("sb", "Soloman Islands");
-        code_map.set("sc", "Seychelles");
-        code_map.set("se", "Sweden");
-        code_map.set("sg", "Singapore");
-        code_map.set("si", "Slovenia");
-        code_map.set("sk", "Slovakia");
-        code_map.set("sl", "Sierra Leone");
-        code_map.set("sn", "Senegal");
-        code_map.set("sr", "Suriname");
-        code_map.set("st", "Sao Tome e Principe");
-        code_map.set("sv", "El Salvador");
-        code_map.set("sz", "Swaziland");
-        code_map.set("tc", "Turks and Caicos Islands");
-        code_map.set("td", "Chad");
-        code_map.set("th", "Thailand");
-        code_map.set("tj", "Tajikistan");
-        code_map.set("tm", "Turkmenistan");
-        code_map.set("tn", "Tunisia");
-        code_map.set("tr", "Turkey");
-        code_map.set("tt", "Republic of Trinidad and Tobago");
-        code_map.set("tw", "Taiwan");
-        code_map.set("tz", "Tanzania");
-        code_map.set("ua", "Ukraine");
-        code_map.set("ug", "Uganda");
-        code_map.set("us", "United States of America");
-        code_map.set("uy", "Uruguay");
-        code_map.set("uz", "Uzbekistan");
-        code_map.set("vc", "Saint Vincent and the Grenadines");
-        code_map.set("ve", "Venezuela");
-        code_map.set("vg", "British Virgin Islands");
-        code_map.set("vn", "Vietnam");
-        code_map.set("ye", "Yemen");
-        code_map.set("za", "South Africa");
-        code_map.set("zw", "Zimbabwe");
+    public static Gee.HashMap<string, string> get_itunes_country_codes () {
+        Gee.HashMap<string, string> code_map = new Gee.HashMap<string, string> ();
+        code_map.set ("ae", "United Arab Emirates");
+        code_map.set ("ag", "Antigua and Barbuda");
+        code_map.set ("ai", "Anguilla");
+        code_map.set ("al", "Albania");
+        code_map.set ("am", "Armenia");
+        code_map.set ("ao", "Angola");
+        code_map.set ("ar", "Argentina");
+        code_map.set ("at", "Austria");
+        code_map.set ("au", "Australia");
+        code_map.set ("az", "Azerbaijan");
+        code_map.set ("bb", "Barbados");
+        code_map.set ("be", "Belgium");
+        code_map.set ("bf", "Burkina-Faso");
+        code_map.set ("bg", "Bulgaria");
+        code_map.set ("bh", "Bahrain");
+        code_map.set ("bj", "Benin");
+        code_map.set ("bm", "Bermuda");
+        code_map.set ("bn", "Brunei Darussalam");
+        code_map.set ("bo", "Bolivia");
+        code_map.set ("br", "Brazil");
+        code_map.set ("bs", "Bahamas");
+        code_map.set ("bt", "Bhutan");
+        code_map.set ("bw", "Botswana");
+        code_map.set ("by", "Belarus");
+        code_map.set ("bz", "Belize");
+        code_map.set ("ca", "Canada");
+        code_map.set ("cg", "Democratic Republic of the Congo");
+        code_map.set ("ch", "Switzerland");
+        code_map.set ("cl", "Chile");
+        code_map.set ("cn", "China");
+        code_map.set ("co", "Colombia");
+        code_map.set ("cr", "Costa Rica");
+        code_map.set ("cv", "Cape Verde");
+        code_map.set ("cy", "Cyprus");
+        code_map.set ("cz", "Czech Republic");
+        code_map.set ("de", "Germany");
+        code_map.set ("dk", "Denmark");
+        code_map.set ("dm", "Dominica");
+        code_map.set ("do", "Dominican Republic");
+        code_map.set ("dz", "Algeria");
+        code_map.set ("ec", "Ecuador");
+        code_map.set ("ee", "Estonia");
+        code_map.set ("eg", "Egypt");
+        code_map.set ("es", "Spain");
+        code_map.set ("fi", "Finland");
+        code_map.set ("fj", "Fiji");
+        code_map.set ("fm", "Federated States of Micronesia");
+        code_map.set ("fr", "France");
+        code_map.set ("gb", "Great Britain");
+        code_map.set ("gd", "Grenada");
+        code_map.set ("gh", "Ghana");
+        code_map.set ("gm", "Gambia");
+        code_map.set ("gr", "Greece");
+        code_map.set ("gt", "Guatemala");
+        code_map.set ("gw", "Guinea Bissau");
+        code_map.set ("gy", "Guyana");
+        code_map.set ("hk", "Hong Kong");
+        code_map.set ("hn", "Honduras");
+        code_map.set ("hr", "Croatia");
+        code_map.set ("hu", "Hungaria");
+        code_map.set ("id", "Indonesia");
+        code_map.set ("ie", "Ireland");
+        code_map.set ("il", "Israel");
+        code_map.set ("in", "India");
+        code_map.set ("is", "Iceland");
+        code_map.set ("it", "Italy");
+        code_map.set ("jm", "Jamaica");
+        code_map.set ("jo", "Jordan");
+        code_map.set ("jp", "Japan");
+        code_map.set ("ke", "Kenya");
+        code_map.set ("kg", "Krygyzstan");
+        code_map.set ("kh", "Cambodia");
+        code_map.set ("kn", "Saint Kitts and Nevis");
+        code_map.set ("kr", "South Korea");
+        code_map.set ("kw", "Kuwait");
+        code_map.set ("ky", "Cayman Islands");
+        code_map.set ("kz", "Kazakhstan");
+        code_map.set ("la", "Laos");
+        code_map.set ("lb", "Lebanon");
+        code_map.set ("lc", "Saint Lucia");
+        code_map.set ("lk", "Sri Lanka");
+        code_map.set ("lr", "Liberia");
+        code_map.set ("lt", "Lithuania");
+        code_map.set ("lu", "Luxembourg");
+        code_map.set ("lv", "Latvia");
+        code_map.set ("md", "Moldova");
+        code_map.set ("mg", "Madagascar");
+        code_map.set ("mk", "Macedonia");
+        code_map.set ("ml", "Mali");
+        code_map.set ("mn", "Mongolia");
+        code_map.set ("mo", "Macau");
+        code_map.set ("mr", "Mauritania");
+        code_map.set ("ms", "Montserrat");
+        code_map.set ("mt", "Malta");
+        code_map.set ("mu", "Mauritius");
+        code_map.set ("mw", "Malawi");
+        code_map.set ("mx", "Mexico");
+        code_map.set ("my", "Malaysia");
+        code_map.set ("mz", "Mozambique");
+        code_map.set ("na", "Namibia");
+        code_map.set ("ne", "Niger");
+        code_map.set ("ng", "Nigeria");
+        code_map.set ("ni", "Nicaragua");
+        code_map.set ("nl", "Netherlands");
+        code_map.set ("np", "Nepal");
+        code_map.set ("no", "Norway");
+        code_map.set ("nz", "New Zealand");
+        code_map.set ("om", "Oman");
+        code_map.set ("pa", "Panama");
+        code_map.set ("pe", "Peru");
+        code_map.set ("pg", "Papua New Guinea");
+        code_map.set ("ph", "Philippines");
+        code_map.set ("pk", "Pakistan");
+        code_map.set ("pl", "Poland");
+        code_map.set ("pt", "Portugal");
+        code_map.set ("pw", "Palau");
+        code_map.set ("py", "Paraguay");
+        code_map.set ("qa", "Qatar");
+        code_map.set ("ro", "Romania");
+        code_map.set ("ru", "Russia");
+        code_map.set ("sa", "Saudi Arabia");
+        code_map.set ("sb", "Soloman Islands");
+        code_map.set ("sc", "Seychelles");
+        code_map.set ("se", "Sweden");
+        code_map.set ("sg", "Singapore");
+        code_map.set ("si", "Slovenia");
+        code_map.set ("sk", "Slovakia");
+        code_map.set ("sl", "Sierra Leone");
+        code_map.set ("sn", "Senegal");
+        code_map.set ("sr", "Suriname");
+        code_map.set ("st", "Sao Tome e Principe");
+        code_map.set ("sv", "El Salvador");
+        code_map.set ("sz", "Swaziland");
+        code_map.set ("tc", "Turks and Caicos Islands");
+        code_map.set ("td", "Chad");
+        code_map.set ("th", "Thailand");
+        code_map.set ("tj", "Tajikistan");
+        code_map.set ("tm", "Turkmenistan");
+        code_map.set ("tn", "Tunisia");
+        code_map.set ("tr", "Turkey");
+        code_map.set ("tt", "Republic of Trinidad and Tobago");
+        code_map.set ("tw", "Taiwan");
+        code_map.set ("tz", "Tanzania");
+        code_map.set ("ua", "Ukraine");
+        code_map.set ("ug", "Uganda");
+        code_map.set ("us", "United States of America");
+        code_map.set ("uy", "Uruguay");
+        code_map.set ("uz", "Uzbekistan");
+        code_map.set ("vc", "Saint Vincent and the Grenadines");
+        code_map.set ("ve", "Venezuela");
+        code_map.set ("vg", "British Virgin Islands");
+        code_map.set ("vn", "Vietnam");
+        code_map.set ("ye", "Yemen");
+        code_map.set ("za", "South Africa");
+        code_map.set ("zw", "Zimbabwe");
         return code_map;
     }
 
-    public static string get_shareable_link_for_episode(Vocal.Episode e) {
+    public static string get_shareable_link_for_episode (Vocal.Episode e) {
         string output = "http://needleandthread.co/apps/vocal/simpleshare.html?podcastName=%s&artUri=%s&episodeTitle=%s&mediaUri=%s";
-        string podcastName = GLib.Uri.escape_string(e.parent.name);
+        string podcastName = GLib.Uri.escape_string (e.parent.name);
         string albumArt = e.parent.remote_art_uri;
-        string episodeTitle = GLib.Uri.escape_string(e.title);
+        string episodeTitle = GLib.Uri.escape_string (e.title);
         string audioSource = e.uri;
-        return output.printf(podcastName, albumArt, episodeTitle, audioSource);
+        return output.printf (podcastName, albumArt, episodeTitle, audioSource);
     }
 
     /*
-     * Takes HTML (most likely from show notes) and sets the background color, font family, and 
+     * Takes HTML (most likely from show notes) and sets the background color, font family, and
      * font size so that it looks good in the podcast view.
      */
-    public static string get_styled_html(string original_html) {
+    public static string get_styled_html (string original_html) {
 
 const string STYLE = """
 <html>
@@ -355,29 +353,29 @@ const string CLOSE = """
     /*
      * Truncates a string if it is longer than to the n. Returns the string unchanged otherwise.
      */
-    public static string truncate_string(string str, int n) {
-        if(str.length > n) {
-            return str.substring(0, n);
+    public static string truncate_string (string str, int n) {
+        if (str.length > n) {
+            return str.substring (0, n);
         }
 
         return str;
     }
-    
+
     public static async bool upload_to_internet_archive (string local_uri, string title, string podcast, string description) {
-    
+
         info ("Uploading to internet archive");
-        string container = Uri.escape_string (podcast.replace (" ", "-").replace(":", "").down ());
-        if (container[container.len() - 1] == '-') {
-            container = container.substring(0, container.len() - 1);
+        string container = Uri.escape_string (podcast.replace (" ", "-").replace (":", "").down ());
+        if (container[container.len () - 1] == '-') {
+            container = container.substring (0, container.len () - 1);
         }
         string episode = Uri.escape_string (title.replace (" ", "-").down () + local_uri.substring (local_uri.last_index_of (".")));
         info (container);
         info (episode);
         var session = new Soup.Session ();
         var message = new Soup.Message ("PUT","http://s3.us.archive.org/%s/%s".printf (container, episode));
-            
+
         SourceFunc callback = upload_to_internet_archive.callback;
-            
+
         ThreadFunc<void*> run = () => {
             uint8[] file_contents;
             GLib.FileUtils.get_data (local_uri, out file_contents);
@@ -389,17 +387,17 @@ const string CLOSE = """
             message.request_headers.append ("x-archive-auto-make-bucket", "1");
             message.request_headers.append ("x-archive-meta-title", podcast);
             message.request_headers.append ("x-archive-meta-description", description);
-            message.request_headers.append ("authorization", "LOW %s:%s".printf(accesskey, secretkey));
+            message.request_headers.append ("authorization", "LOW %s:%s".printf (accesskey, secretkey));
             session.send_message (message);
-            Idle.add((owned) callback);
+            Idle.add ((owned) callback);
             return null;
         };
-        Thread.create<void*>(run, false);
+        Thread.create<void*> (run, false);
 
         yield;
-        
-        info("archive.org request status code: %u", message.status_code);
-        info ( (string) message.response_body.data);
+
+        info ("archive.org request status code: %u", message.status_code);
+        info ((string) message.response_body.data);
         if (message.status_code == 200) {
             return true;
         } else {
@@ -407,11 +405,11 @@ const string CLOSE = """
         }
 
     }
-    
+
     public static string get_mime_type_for_file (string file_uri) {
-    
+
         string extension = file_uri.down ().substring (file_uri.last_index_of ("."));
-        
+
         // If all else fails, assume MP3
         string mime = "audio/mpeg3";
         switch (extension) {
@@ -443,7 +441,7 @@ const string CLOSE = """
                 mime = "video/quicktime";
                 break;
         }
-        
+
         return mime;
     }
 

--- a/src/Utils/XmlUtils.vala
+++ b/src/Utils/XmlUtils.vala
@@ -20,21 +20,21 @@
 namespace Vocal {
     public class XmlUtils {
 
-        public static string strip_trailing_rss_chars(string rss) {
+        public static string strip_trailing_rss_chars (string rss) {
             // If there is a feed tag , it is atom file, else a rss one.
-            if (rss.last_index_of("</feed>") > 0) {
-                return rss.substring(0, rss.last_index_of("</feed>") + "</feed>".length);
+            if (rss.last_index_of ("</feed>") > 0) {
+                return rss.substring (0, rss.last_index_of ("</feed>") + "</feed>".length);
             } else {
-                return rss.substring(0, rss.last_index_of("</rss>") + "</rss>".length);
+                return rss.substring (0, rss.last_index_of ("</rss>") + "</rss>".length);
             }
         }
-    
+
         public static unowned Xml.Doc parse_string (string? input_string) throws Error {
             if (input_string == null || input_string.length == 0) {
                 throw new PublishingError.MALFORMED_RESPONSE ("Empty XML string");
             }
 
-            var rss = strip_trailing_rss_chars(input_string);
+            var rss = strip_trailing_rss_chars (input_string);
 
             // Don't want blanks to be included as text nodes, and want the XML parser to tolerate
             // tolerable XML

--- a/src/Utils/iTunesProvider.vala
+++ b/src/Utils/iTunesProvider.vala
@@ -23,42 +23,42 @@ namespace Vocal {
 
         private SoupClient soup_client = null;
 
-        public iTunesProvider() {
-            soup_client = new SoupClient();
+        public iTunesProvider () {
+            soup_client = new SoupClient ();
         }
 
         /*
          * Finds the public RSS feed address from any given iTunes store URL
          */
-        public string? get_rss_from_itunes_url(string itunes_url, out string? name = null) {
+        public string? get_rss_from_itunes_url (string itunes_url, out string? name = null) {
 
             string rss = "";
 
             // We just need to get the iTunes store iD
-            int start_index = itunes_url.index_of("/id") + 3;
-            int stop_index = itunes_url.index_of("?");
+            int start_index = itunes_url.index_of ("/id") + 3;
+            int stop_index = itunes_url.index_of ("?");
 
-            string id = itunes_url.slice(start_index, stop_index);
+            string id = itunes_url.slice (start_index, stop_index);
 
-            var uri =  "https://itunes.apple.com/lookup?id=%s&entity=podcast".printf(id);
+            var uri = "https://itunes.apple.com/lookup?id=%s&entity=podcast".printf (id);
 
             try {
                 var parser = new Json.Parser ();
-                parser.load_from_stream (soup_client.request(HttpMethod.GET, uri));
+                parser.load_from_stream (soup_client.request (HttpMethod.GET, uri));
 
                 var root_object = parser.get_root ().get_object ();
 
-                if(root_object == null) {
-                    stdout.puts("Error. Root object was null.");
+                if (root_object == null) {
+                    stdout.puts ("Error. Root object was null.");
                     return null;
                 }
 
-                var elements = root_object.get_array_member("results").get_elements();
+                var elements = root_object.get_array_member ("results").get_elements ();
 
-                foreach(Json.Node e in elements) {
-                    var obj = e.get_object();
-                    rss = obj.get_string_member("feedUrl");
-                    name = obj.get_string_member("trackName");
+                foreach (Json.Node e in elements) {
+                    var obj = e.get_object ();
+                    rss = obj.get_string_member ("feedUrl");
+                    name = obj.get_string_member ("trackName");
                 }
             } catch (Error e) {
                 warning ("An error occurred while discovering the real RSS feed address %s\n", e.message);
@@ -70,83 +70,83 @@ namespace Vocal {
         /*
          * Finds the top n podcasts (100 by default) and returns it in an ArrayList
          */
-        public GLib.List<DirectoryEntry>? get_top_podcasts(int? limit = 100) {
-        
+        public GLib.List<DirectoryEntry>? get_top_podcasts (int? limit = 100) {
 
-            var settings = VocalSettings.get_default_instance();
 
-            var uri =  "https://itunes.apple.com/%s/rss/toppodcasts/limit=%d/json".printf(settings.itunes_store_country, limit);
+            var settings = VocalSettings.get_default_instance ();
 
-            GLib.List<DirectoryEntry> entries = new GLib.List<DirectoryEntry>();
+            var uri = "https://itunes.apple.com/%s/rss/toppodcasts/limit=%d/json".printf (settings.itunes_store_country, limit);
+
+            GLib.List<DirectoryEntry> entries = new GLib.List<DirectoryEntry> ();
 
             var parser = new Json.Parser ();
 
             try {
-                parser.load_from_stream (soup_client.request(HttpMethod.GET, uri));
+                parser.load_from_stream (soup_client.request (HttpMethod.GET, uri));
             } catch (Error e) {
                 warning ("An error occured fetching the top podcasts. %s", e.message);
                 return null;
             }
 
             var root_object = parser.get_root ().get_object ();
-            if(root_object == null) {
+            if (root_object == null) {
                 error ("Error loading iTunes results. Root object was null.");
                 return null;
             }
 
-            var elements = root_object.get_object_member("feed").get_array_member ("entry").get_elements();
-            
+            var elements = root_object.get_object_member ("feed").get_array_member ("entry").get_elements ();
 
-            foreach(Json.Node e in elements) {
+
+            foreach (Json.Node e in elements) {
 
                 // Create a new DirectoryEntry to store the results
-                DirectoryEntry ent = new DirectoryEntry();
+                DirectoryEntry ent = new DirectoryEntry ();
 
-                var obj = e.get_object();
+                var obj = e.get_object ();
                 if (obj != null) {
 
                     // Objects
-                    var id = obj.get_object_member("id"); // The podcast store URL
+                    var id = obj.get_object_member ("id"); // The podcast store URL
                     if (id != null)
-                        ent.itunesUrl = id.get_string_member("label");
-                    var title = obj.get_object_member("title");
+                        ent.itunesUrl = id.get_string_member ("label");
+                    var title = obj.get_object_member ("title");
                     if (title != null)
-                        ent.title = title.get_string_member("label");
-                    var summary = obj.get_object_member("summary");
+                        ent.title = title.get_string_member ("label");
+                    var summary = obj.get_object_member ("summary");
                     if (summary != null)
-                        ent.summary = summary.get_string_member("label");
-                    var artist = obj.get_object_member("im:artist");
-                    if (artist != null) 
-                        ent.artist = artist.get_string_member("label");
+                        ent.summary = summary.get_string_member ("label");
+                    var artist = obj.get_object_member ("im:artist");
+                    if (artist != null)
+                        ent.artist = artist.get_string_member ("label");
 
                     // Remove the artist name from the title
-                    ent.title = ent.title.replace(" - " + ent.artist, "");
+                    ent.title = ent.title.replace (" - " + ent.artist, "");
 
                     // Arrays
-                    var image = obj.get_member("im:image").get_array().get_elements();
+                    var image = obj.get_member ("im:image").get_array ().get_elements ();
 
                     int i = 0;
 
-                    foreach(Json.Node f in image) {
-                        switch(i) {
+                    foreach (Json.Node f in image) {
+                        switch (i) {
                             case 0:
-                                ent.artworkUrl55 = f.get_object().get_string_member("label");
+                                ent.artworkUrl55 = f.get_object ().get_string_member ("label");
                                 break;
                             case 1:
-                                ent.artworkUrl60 = f.get_object().get_string_member("label");
+                                ent.artworkUrl60 = f.get_object ().get_string_member ("label");
                                 break;
                             case 2:
-                                ent.artworkUrl170 = f.get_object().get_string_member("label");
+                                ent.artworkUrl170 = f.get_object ().get_string_member ("label");
                                 break;
                         }
                         i++;
                     }
 
-                    entries.append(ent);
+                    entries.append (ent);
                 }
 
             }
-            
+
 
             return entries;
         }
@@ -155,43 +155,43 @@ namespace Vocal {
          * Finds the top n podcasts that match a given term in the iTunes store and returns
          * them in an ArrayList
          */
-        public Gee.ArrayList<DirectoryEntry>? search_by_term(string term, int? limit = 25) {
+        public Gee.ArrayList<DirectoryEntry>? search_by_term (string term, int? limit = 25) {
 
-            var uri = "https://itunes.apple.com/search?term=%s&entity=podcast&limit=%d".printf(term.replace(" ", "+"), limit);
+            var uri = "https://itunes.apple.com/search?term=%s&entity=podcast&limit=%d".printf (term.replace (" ", "+"), limit);
 
-            Gee.ArrayList<DirectoryEntry> entries = new Gee.ArrayList<DirectoryEntry>();
+            Gee.ArrayList<DirectoryEntry> entries = new Gee.ArrayList<DirectoryEntry> ();
 
             try {
                 var parser = new Json.Parser ();
-                parser.load_from_stream (soup_client.request(HttpMethod.GET, uri));
+                parser.load_from_stream (soup_client.request (HttpMethod.GET, uri));
 
                 var root_object = parser.get_root ().get_object ();
 
-                if(root_object == null) {
-                    stdout.puts("Error. Root object was null.");
+                if (root_object == null) {
+                    stdout.puts ("Error. Root object was null.");
                     return null;
                 }
 
 
-                var elements = root_object.get_array_member ("results").get_elements();
+                var elements = root_object.get_array_member ("results").get_elements ();
 
-                foreach(Json.Node e in elements) {
+                foreach (Json.Node e in elements) {
 
 
                     // Create a new DirectoryEntry to store the results
-                    DirectoryEntry ent = new DirectoryEntry();
+                    DirectoryEntry ent = new DirectoryEntry ();
 
                     // Objects
-                    ent.itunesUrl = e.get_object().get_string_member("collectionViewUrl");
-                    ent.title = e.get_object().get_string_member("collectionName");
-                    ent.artist = e.get_object().get_string_member("artistName");
+                    ent.itunesUrl = e.get_object ().get_string_member ("collectionViewUrl");
+                    ent.title = e.get_object ().get_string_member ("collectionName");
+                    ent.artist = e.get_object ().get_string_member ("artistName");
 
                     // Remove the artist name from the title
-                    ent.title = ent.title.replace(" - " + ent.artist, "");
+                    ent.title = ent.title.replace (" - " + ent.artist, "");
 
-                    ent.artworkUrl600 = e.get_object().get_string_member("artworkUrl600");
+                    ent.artworkUrl600 = e.get_object ().get_string_member ("artworkUrl600");
 
-                    entries.add(ent);
+                    entries.add (ent);
 
                 }
 

--- a/src/Utils/iTunesProvider.vala
+++ b/src/Utils/iTunesProvider.vala
@@ -19,7 +19,7 @@
 
 namespace Vocal {
 
-    public class iTunesProvider {
+    public class iTunesProvider {  // vala-lint=naming-convention
 
         private SoupClient soup_client = null;
 
@@ -75,7 +75,10 @@ namespace Vocal {
 
             var settings = VocalSettings.get_default_instance ();
 
-            var uri = "https://itunes.apple.com/%s/rss/toppodcasts/limit=%d/json".printf (settings.itunes_store_country, limit);
+            var uri = "https://itunes.apple.com/%s/rss/toppodcasts/limit=%d/json".printf (
+                settings.itunes_store_country,
+                limit
+            );
 
             GLib.List<DirectoryEntry> entries = new GLib.List<DirectoryEntry> ();
 
@@ -157,7 +160,10 @@ namespace Vocal {
          */
         public Gee.ArrayList<DirectoryEntry>? search_by_term (string term, int? limit = 25) {
 
-            var uri = "https://itunes.apple.com/search?term=%s&entity=podcast&limit=%d".printf (term.replace (" ", "+"), limit);
+            var uri = "https://itunes.apple.com/search?term=%s&entity=podcast&limit=%d".printf (
+                term.replace (" ", "+"),
+                limit
+            );
 
             Gee.ArrayList<DirectoryEntry> entries = new Gee.ArrayList<DirectoryEntry> ();
 

--- a/src/Vocal.vala
+++ b/src/Vocal.vala
@@ -23,9 +23,9 @@ using Granite.Services;
 
 namespace Vocal {
 
-	namespace Option {
-		private static bool OPEN_HIDDEN = false;
-	}
+    namespace Option {
+        private static bool OPEN_HIDDEN = false;
+    }
 
     public class VocalApp : Granite.Application {
 
@@ -56,10 +56,10 @@ namespace Vocal {
             about_documenters = { "Nathan Dyer <mail@nathandyer.me>" };
             about_artists = { "Nathan Dyer (App) <mail@nathandyer.me>", "Harvey Cabaguio (Icons and Branding) <harvey@elementaryos.org", "Mashnoon Ibtesum (Artwork)" };
             about_comments = "Podcast Client for the Modern Desktop";
-            about_translators = _("translator-credits");
+            about_translators = _ ("translator-credits");
             about_license_type = Gtk.License.GPL_3_0;
 
-            set_options();
+            set_options ();
         }
 
         public const OptionEntry[] app_options = {
@@ -74,16 +74,16 @@ namespace Vocal {
         }
 
         public override void activate () {
-        
+
             if (controller == null) {
-                controller = new Controller(this);
+                controller = new Controller (this);
             }
 
             if (get_windows () == null) {
                 controller.window = new MainWindow (controller);
                 controller.open_hidden = Option.OPEN_HIDDEN;
-                if(!Option.OPEN_HIDDEN)
-                	controller.window.show_all ();
+                if (!Option.OPEN_HIDDEN)
+                    controller.window.show_all ();
             } else {
                 controller.window.present ();
             }
@@ -95,14 +95,14 @@ namespace Vocal {
             // Options
 
             var context = new OptionContext ();
-    		context.add_main_entries (app_options, "vocal");
-        	context.add_group (Gtk.get_option_group (true));
+            context.add_main_entries (app_options, "vocal");
+            context.add_group (Gtk.get_option_group (true));
 
-        	try {
-	            context.parse (ref args);
-	        } catch (Error e) {
-	            warning (e.message);
-	        }
+            try {
+                context.parse (ref args);
+            } catch (Error e) {
+                warning (e.message);
+            }
 
             // Init internationalization support
             string package_name = Constants.GETTEXT_PACKAGE;
@@ -114,25 +114,25 @@ namespace Vocal {
             // Initialize GtkClutter
             var err = GtkClutter.init (ref args);
             if (err != Clutter.InitError.SUCCESS) {
-                stdout.puts("Could not initialize clutter gtk\n");
+                stdout.puts ("Could not initialize clutter gtk\n");
                 error ("Could not initalize clutter! "+err.to_string ());
             }
 
             // Initialize Clutter
             err = Clutter.init (ref args);
             if (err != Clutter.InitError.SUCCESS) {
-                stdout.puts("Could not initialize clutter.\n");
+                stdout.puts ("Could not initialize clutter.\n");
                 error ("Could not initalize clutter! "+err.to_string ());
             }
 
             // Initialize GStreamer
             Gst.init (ref args);
-            Gst.PbUtils.init();
+            Gst.PbUtils.init ();
 
             // Set the media role
             GLib.Environ.set_variable ({"PULSE_PROP_media.role"}, "audio", "true");
 
-			// Create a new instance of the app and run it
+            // Create a new instance of the app and run it
             var app = new Vocal.VocalApp ();
             app.args = args;
             app.run (args);

--- a/src/VocalSettings.vala
+++ b/src/VocalSettings.vala
@@ -28,27 +28,27 @@ public class VocalSettings : Granite.Services.Settings {
     public bool dark_mode_enabled { get; set; }
     public bool newest_episodes_first { get; set; }
     public bool keep_playing_in_background { get; set; }
-    
+
     public int update_interval { get; set; }
     public int window_width { get; set; }
     public int window_height { get; set; }
     public int sidebar_width {get; set; }
     public int fast_forward_seconds { get; set; }
     public int rewind_seconds { get; set;}
-    
+
     public string library_location { get; set; }
     public string last_played_media { get; set; }
     public string itunes_store_country { get; set; }
     public string archive_access_key { get; set; }
     public string archive_secret_key { get; set; }
     
-    private VocalSettings() {
-        base("com.github.needleandthread.vocal");
+    private VocalSettings () {
+        base ("com.github.needleandthread.vocal");
     }
 
-    public static VocalSettings get_default_instance() {
-        if(_default_instance == null)
-            _default_instance = new VocalSettings();
+    public static VocalSettings get_default_instance () {
+        if (_default_instance == null)
+            _default_instance = new VocalSettings ();
 
         return _default_instance;
     }

--- a/src/Widgets/AddFeedDialog.vala
+++ b/src/Widgets/AddFeedDialog.vala
@@ -21,79 +21,81 @@ using Gtk;
 
 namespace Vocal {
 
-    
-    public class AddFeedDialog : Gtk.Dialog {
-    
-        public	Gtk.Entry 	entry;			
-        public	Gtk.Button 	add_feed_button;
 
-	      private bool		on_elementary;
-    
-        public AddFeedDialog(Window parent, bool? using_elementary = true) {
-	          this.on_elementary = using_elementary;
-            set_default_response(Gtk.ResponseType.OK);
-            set_size_request(500, 150);
-            set_modal(true);
-            set_transient_for(parent);
-            set_attached_to(parent);
-            set_resizable(false);
-            setup();
-            get_action_area().margin = 7;
-            this.title = _("Add New Podcast");
+    public class AddFeedDialog : Gtk.Dialog {
+
+        public Gtk.Entry entry;
+        public Gtk.Button add_feed_button;
+
+        private bool on_elementary;
+
+        public AddFeedDialog (Window parent, bool? using_elementary = true) {
+            this.on_elementary = using_elementary;
+            set_default_response (Gtk.ResponseType.OK);
+            set_size_request (500, 150);
+            set_modal (true);
+            set_transient_for (parent);
+            set_attached_to (parent);
+            set_resizable (false);
+            setup ();
+            get_action_area ().margin = 7;
+            this.title = _ ("Add New Podcast");
         }
-            
+
         /*
          * Sets up the properties of the dialog
          */
-        private void setup() {
-            var content_box = new Gtk.Box(Gtk.Orientation.HORIZONTAL, 0);
+        private void setup () {
+            var content_box = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 0);
             content_box.margin_right = 12;
             content_box.margin_left = 12;
-            
-            var add_label = new Gtk.Label(_("<b>Add a new podcast feed to the library</b>"));
+
+            var add_label = new Gtk.Label (_ ("<b>Add a new podcast feed to the library</b>"));
             add_label.use_markup = true;
-            add_label.set_property("xalign", 0);
-            
-            entry = new Gtk.Entry();
-            entry.placeholder_text = _("Podcast feed web address");
+            add_label.set_property ("xalign", 0);
+
+            entry = new Gtk.Entry ();
+            entry.placeholder_text = _ ("Podcast feed web address");
             entry.activates_default = false;
             entry.margin = 12;
-            entry.changed.connect(on_entry_changed);
-            
+            entry.changed.connect (on_entry_changed);
+
             Gtk.Image add_img;
-      	    if(on_elementary)
-      	        add_img = new Gtk.Image.from_icon_name ("list-add-symbolic", Gtk.IconSize.DIALOG);
-      	    else
-      		      add_img = new Gtk.Image.from_icon_name ("list-add", Gtk.IconSize.DIALOG);
+            if (on_elementary) {
+                add_img = new Gtk.Image.from_icon_name ("list-add-symbolic", Gtk.IconSize.DIALOG);
+            }
+            else {
+                add_img = new Gtk.Image.from_icon_name ("list-add", Gtk.IconSize.DIALOG);
+            }
             add_img.margin_right = 12;
-            
-            content_box.add(add_img);
-            content_box.add(add_label);
-            
+
+            content_box.add (add_img);
+            content_box.add (add_label);
+
             // Add items to box
             add_button ("_Cancel", Gtk.ResponseType.CANCEL);
-            add_feed_button = (Gtk.Button)add_button("_Add Podcast", Gtk.ResponseType.OK);
-            add_feed_button.get_style_context().add_class("suggested-action");
+            add_feed_button = (Gtk.Button)add_button ("_Add Podcast", Gtk.ResponseType.OK);
+            add_feed_button.get_style_context ().add_class ("suggested-action");
             add_feed_button.sensitive = false;
-            
-            // Set up the text entry activate signal to "click" the add button
-            entry.activate.connect(() => {
-                if(add_feed_button.sensitive)
-                    add_feed_button.clicked();
-            });
-            
-            
-            this.get_content_area().add(content_box);
-            this.get_content_area().add(entry);
 
-        }  
-        
+            // Set up the text entry activate signal to "click" the add button
+            entry.activate.connect (() => {
+                if (add_feed_button.sensitive) {
+                    add_feed_button.clicked ();
+                }
+            });
+
+
+            this.get_content_area ().add (content_box);
+            this.get_content_area ().add (entry);
+
+        }
+
         /*
          * Set the button's sensitivity based on whether or not there is any input
          */
-        private void on_entry_changed()
-        {
-            if(entry.text.length > 0) {
+        private void on_entry_changed () {
+            if (entry.text.length > 0) {
                 add_feed_button.sensitive = true;
             } else {
                 add_feed_button.sensitive = false;

--- a/src/Widgets/CloudLoginDialog.vala
+++ b/src/Widgets/CloudLoginDialog.vala
@@ -21,76 +21,76 @@ using Gtk;
 
 namespace Vocal {
 
-    
+
     public class CloudLoginDialog : Gtk.Dialog {
 
-        public signal void input_ready();
-    
-        private	Gtk.Entry 	uname_entry;			
-        private Gtk.Entry 	pw_entry;
+        public signal void input_ready ();
+
+        private Gtk.Entry uname_entry;
+        private Gtk.Entry pw_entry;
 
         string password;
         string username;
-    
-        public CloudLoginDialog(Window parent) {
-            set_default_response(Gtk.ResponseType.OK);
-            set_size_request(500, 200);
-            set_modal(true);
-            set_transient_for(parent);
-            set_attached_to(parent);
-            set_resizable(false);
-            setup();
-            get_action_area().margin = 7;
-            this.title = _("Login to gPodder.net");
+
+        public CloudLoginDialog (Window parent) {
+            set_default_response (Gtk.ResponseType.OK);
+            set_size_request (500, 200);
+            set_modal (true);
+            set_transient_for (parent);
+            set_attached_to (parent);
+            set_resizable (false);
+            setup ();
+            get_action_area ().margin = 7;
+            this.title = _ ("Login to gPodder.net");
         }
-            
+
         /*
          * Sets up the properties of the dialog
          */
-        private void setup() {
+        private void setup () {
 
-            uname_entry = new Gtk.Entry();
-            uname_entry.placeholder_text = _("Username");
-            pw_entry = new Gtk.Entry();
-            pw_entry.placeholder_text = _("Password");
+            uname_entry = new Gtk.Entry ();
+            uname_entry.placeholder_text = _ ("Username");
+            pw_entry = new Gtk.Entry ();
+            pw_entry.placeholder_text = _ ("Password");
             unichar ast = '*';
             pw_entry.invisible_char = ast;
             pw_entry.visibility = false;
 
-            var content_box = new Gtk.Box(Gtk.Orientation.VERTICAL, 15);
+            var content_box = new Gtk.Box (Gtk.Orientation.VERTICAL, 15);
             content_box.margin_right = 12;
             content_box.margin_left = 12;
 
-            content_box.pack_start(uname_entry, false, false, 5);
-            content_box.pack_start(pw_entry, false, false, 5);
+            content_box.pack_start (uname_entry, false, false, 5);
+            content_box.pack_start (pw_entry, false, false, 5);
 
-            var hor_box = new Gtk.Box(Gtk.Orientation.HORIZONTAL, 15);
+            var hor_box = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 15);
 
-            var login_button = new Gtk.Button.with_label(_("Login"));
-            var register_button = new Gtk.Button.with_label(_("Register for gPodder.net"));
+            var login_button = new Gtk.Button.with_label (_ ("Login"));
+            var register_button = new Gtk.Button.with_label (_ ("Register for gPodder.net"));
 
             register_button.xalign = 0;
 
-            login_button.get_style_context().add_class("suggested-action");
+            login_button.get_style_context ().add_class ("suggested-action");
 
-            login_button.clicked.connect(() => {
-                input_ready();
+            login_button.clicked.connect (() => {
+                input_ready ();
             });
 
-            register_button.clicked.connect(() => {
+            register_button.clicked.connect (() => {
 
                 try {
                   Gtk.show_uri (null, "http://gpodder.net/register", 0);
                 } catch (Error e) {}
-                
-            }); 
+
+            });
 
 
-            hor_box.pack_start(register_button, false, false, 5);
-            hor_box.pack_start(login_button, true, true, 5);
-            content_box.pack_start(hor_box, false, false, 5);
+            hor_box.pack_start (register_button, false, false, 5);
+            hor_box.pack_start (login_button, true, true, 5);
+            content_box.pack_start (hor_box, false, false, 5);
 
-            this.get_content_area().add(content_box);
+            this.get_content_area ().add (content_box);
         }
     }
 }

--- a/src/Widgets/CoverArt.vala
+++ b/src/Widgets/CoverArt.vala
@@ -17,9 +17,9 @@
   END LICENSE
 
   Additional contributors/authors:
-  
+
   * Artem Anufrij <artem.anufrij@live.de>
-  
+
 ***/
 
 
@@ -29,99 +29,99 @@ using Granite;
 
 namespace Vocal {
 
-	public class CoverArt : Gtk.Box {
+    public class CoverArt : Gtk.Box {
 
         private const int COVER_SIZE = 170;
 
-		public Gtk.Image 	image;					// The actual coverart image
-		private Gtk.Overlay count_overlay;			// Overlays the count on top of the banner
-		private Gtk.Label 	count_label;			// The label that stores the unplayed count
-		private Gtk.Label   podcast_name_label;     // The label that show the name of the podcast
-		                                                // (if it is enabled in the settings)
+        public Gtk.Image image;                // The actual coverart image
+        private Gtk.Overlay count_overlay;     // Overlays the count on top of the banner
+        private Gtk.Label count_label;         // The label that stores the unplayed count
+        private Gtk.Label podcast_name_label;  // The label that show the name of the podcast
+                                               // (if it is enabled in the settings)
 
-		public Podcast podcast;						// Refers to the podcast this coverart represents
+        public Podcast podcast;                // Refers to the podcast this coverart represents
 
 
-		/*
-		 * Constructor for CoverArt given an image path and a podcast
-		 */
-		public CoverArt(string path, Podcast podcast, bool? show_mimetype = false) {
-		
-			this.podcast = podcast;
-			this.margin = 10;
-			this.orientation = Gtk.Orientation.VERTICAL;
-			
+        /*
+         * Constructor for CoverArt given an image path and a podcast
+         */
+        public CoverArt (string path, Podcast podcast, bool? show_mimetype = false) {
 
-			try {
+            this.podcast = podcast;
+            this.margin = 10;
+            this.orientation = Gtk.Orientation.VERTICAL;
 
-				// Load the actual cover art
-				var file = GLib.File.new_for_uri(path.replace("%27", "'"));
 
-				var icon = new GLib.FileIcon(file);
+            try {
 
-				var image = new Gtk.Image.from_gicon(icon, Gtk.IconSize.DIALOG);
-				image.pixel_size = COVER_SIZE;
-				image.set_no_show_all(false);
-				image.show();
-				
-				count_overlay = new Gtk.Overlay();
+                // Load the actual cover art
+                var file = GLib.File.new_for_uri (path.replace ("%27", "'"));
 
-				// Partially set up the overlays
-				count_overlay.add(image);
+                var icon = new GLib.FileIcon (file);
 
-			} catch (Error e) {
-				warning ("Unable to load podcast cover art.");
-			}
-			
-            
-			if(count_overlay == null)
-				count_overlay = new Gtk.Overlay();
+                var image = new Gtk.Image.from_gicon (icon, Gtk.IconSize.DIALOG);
+                image.pixel_size = COVER_SIZE;
+                image.set_no_show_all (false);
+                image.show ();
 
-			// Create a label to display the number of new episodes
-			count_label = new Gtk.Label("");
-			count_label.use_markup = true;
-			count_label.set_alignment(1,0);
-			count_label.get_style_context().add_class("coverart-overlay");
-			count_label.halign = Gtk.Align.END;
-			count_label.valign = Gtk.Align.START;
-			count_label.width_chars = 2;
-			count_label.xalign = 0.50f;
-			count_label.margin_top = 3;
-			count_label.margin_right = 3;
+                count_overlay = new Gtk.Overlay ();
 
-			// Add a tooltip
-			this.tooltip_text = podcast.name.replace("%27", "'");
+                // Partially set up the overlays
+                count_overlay.add (image);
 
-			// Set up the overlays
+            } catch (Error e) {
+                warning ("Unable to load podcast cover art.");
+            }
 
-			count_overlay.add_overlay(count_label);
-			
-			this.pack_start(count_overlay, false, false, 0);
 
-			this.valign = Align.START;
-			string podcast_name = GLib.Uri.unescape_string(podcast.name);
-			if (podcast_name == null) {
-			    podcast_name = podcast.name.replace("%25", "%");
-			}
-			podcast_name = podcast_name.replace("&", """&amp;""");
+            if (count_overlay == null)
+                count_overlay = new Gtk.Overlay ();
 
-			podcast_name_label = new Gtk.Label("<b>" + podcast_name + "</b>");
-			podcast_name_label.wrap = true;
-			podcast_name_label.use_markup = true;
-			podcast_name_label.max_width_chars = 15;
-			this.pack_start(podcast_name_label, false, false, 12);
-			
-			if(!VocalSettings.get_default_instance().show_name_label) {
-			    podcast_name_label.no_show_all = true;
-			    podcast_name_label.visible = false;
-			}
+            // Create a label to display the number of new episodes
+            count_label = new Gtk.Label ("");
+            count_label.use_markup = true;
+            count_label.set_alignment (1,0);
+            count_label.get_style_context ().add_class ("coverart-overlay");
+            count_label.halign = Gtk.Align.END;
+            count_label.valign = Gtk.Align.START;
+            count_label.width_chars = 2;
+            count_label.xalign = 0.50f;
+            count_label.margin_top = 3;
+            count_label.margin_right = 3;
 
-			show_all();
-		}
+            // Add a tooltip
+            this.tooltip_text = podcast.name.replace ("%27", "'");
 
-		/*
-		 * Creates a pixbuf given an InputStream
-		 */
+            // Set up the overlays
+
+            count_overlay.add_overlay (count_label);
+
+            this.pack_start (count_overlay, false, false, 0);
+
+            this.valign = Align.START;
+            string podcast_name = GLib.Uri.unescape_string (podcast.name);
+            if (podcast_name == null) {
+                podcast_name = podcast.name.replace ("%25", "%");
+            }
+            podcast_name = podcast_name.replace ("&", """&amp;""");
+
+            podcast_name_label = new Gtk.Label ("<b>" + podcast_name + "</b>");
+            podcast_name_label.wrap = true;
+            podcast_name_label.use_markup = true;
+            podcast_name_label.max_width_chars = 15;
+            this.pack_start (podcast_name_label, false, false, 12);
+
+            if (!VocalSettings.get_default_instance ().show_name_label) {
+                podcast_name_label.no_show_all = true;
+                podcast_name_label.visible = false;
+            }
+
+            show_all ();
+        }
+
+        /*
+         * Creates a pixbuf given an InputStream
+         */
         public Gdk.Pixbuf create_cover_image (InputStream input_stream) {
             var cover_image = new Gdk.Pixbuf.from_stream (input_stream);
 
@@ -134,7 +134,7 @@ namespace Vocal {
                 int new_width = COVER_SIZE;
                 int offset = (new_height - new_width) / 2;
 
-                cover_image = new Gdk.Pixbuf.subpixbuf(cover_image.scale_simple (new_width, new_height, Gdk.InterpType.BILINEAR), 0, offset, COVER_SIZE, COVER_SIZE);
+                cover_image = new Gdk.Pixbuf.subpixbuf (cover_image.scale_simple (new_width, new_height, Gdk.InterpType.BILINEAR), 0, offset, COVER_SIZE, COVER_SIZE);
 
             } else if (cover_image.height < cover_image.width) {
 
@@ -142,63 +142,60 @@ namespace Vocal {
                 int new_width = COVER_SIZE * cover_image.width / cover_image.height;
                 int offset = (new_width - new_height) / 2;
 
-                cover_image = new Gdk.Pixbuf.subpixbuf(cover_image.scale_simple (new_width, new_height, Gdk.InterpType.BILINEAR), offset, 0, COVER_SIZE, COVER_SIZE);
+                cover_image = new Gdk.Pixbuf.subpixbuf (cover_image.scale_simple (new_width, new_height, Gdk.InterpType.BILINEAR), offset, 0, COVER_SIZE, COVER_SIZE);
             }
 
             return cover_image;
         }
 
-		/*
-		 * Hides the banner and the count
-		 */
-		public void hide_count()
-		{
-		    if (count_label != null) {
-			    count_label.set_no_show_all(true);
-			    count_label.hide();
-		    }
-		}
-	
-		/*
-		 * Sets the banner count
-		 */
-		public void set_count(int count)
-		{
-		    if (count_label != null) {
-			    count_label.set_text("%d".printf(count));
+        /*
+         * Hides the banner and the count
+         */
+        public void hide_count () {
+            if (count_label != null) {
+                count_label.set_no_show_all (true);
+                count_label.hide ();
             }
-		}
-		
-		/*
-		 * Shows the banner and the count
-		 */
-		public void show_count()
-		{
-		    if (count_label != null) {
-			    count_label.set_no_show_all(false);
-			    count_label.show();
-		    }
-		}
+        }
+
+        /*
+         * Sets the banner count
+         */
+        public void set_count (int count) {
+            if (count_label != null) {
+                count_label.set_text ("%d".printf (count));
+            }
+        }
+
+        /*
+         * Shows the banner and the count
+         */
+        public void show_count () {
+            if (count_label != null) {
+                count_label.set_no_show_all (false);
+                count_label.show ();
+            }
+        }
 
 
-		/*
-		 * Shows the name label underneath the cover art
-		 */
-		public void show_name_label() {
-		    if(podcast_name_label != null) {
-			    podcast_name_label.no_show_all = false;
-			    podcast_name_label.visible = true;
-		    }
-		}
+        /*
+         * Shows the name label underneath the cover art
+         */
+        public void show_name_label () {
+            if (podcast_name_label != null) {
+                podcast_name_label.no_show_all = false;
+                podcast_name_label.visible = true;
+            }
+        }
 
-		/*
-		 * Hides the name label underneath the cover art
-		 */
-	 	public void hide_name_label() {
-	 	    if(podcast_name_label != null) {
-	     		podcast_name_label.no_show_all = true;
-			    podcast_name_label.visible = false;
-		    }
-	 	}
-	}
+        /*
+         * Hides the name label underneath the cover art
+         */
+         public void hide_name_label () {
+             if (podcast_name_label != null) {
+                 podcast_name_label.no_show_all = true;
+                podcast_name_label.visible = false;
+            }
+         }
+    }
 }

--- a/src/Widgets/CoverArt.vala
+++ b/src/Widgets/CoverArt.vala
@@ -80,7 +80,7 @@ namespace Vocal {
             // Create a label to display the number of new episodes
             count_label = new Gtk.Label ("");
             count_label.use_markup = true;
-            count_label.set_alignment (1,0);
+            count_label.set_alignment (1, 0);
             count_label.get_style_context ().add_class ("coverart-overlay");
             count_label.halign = Gtk.Align.END;
             count_label.valign = Gtk.Align.START;
@@ -134,7 +134,13 @@ namespace Vocal {
                 int new_width = COVER_SIZE;
                 int offset = (new_height - new_width) / 2;
 
-                cover_image = new Gdk.Pixbuf.subpixbuf (cover_image.scale_simple (new_width, new_height, Gdk.InterpType.BILINEAR), 0, offset, COVER_SIZE, COVER_SIZE);
+                cover_image = new Gdk.Pixbuf.subpixbuf (
+                    cover_image.scale_simple (new_width, new_height, Gdk.InterpType.BILINEAR),
+                    0,
+                    offset,
+                    COVER_SIZE,
+                    COVER_SIZE
+                );
 
             } else if (cover_image.height < cover_image.width) {
 
@@ -142,7 +148,13 @@ namespace Vocal {
                 int new_width = COVER_SIZE * cover_image.width / cover_image.height;
                 int offset = (new_width - new_height) / 2;
 
-                cover_image = new Gdk.Pixbuf.subpixbuf (cover_image.scale_simple (new_width, new_height, Gdk.InterpType.BILINEAR), offset, 0, COVER_SIZE, COVER_SIZE);
+                cover_image = new Gdk.Pixbuf.subpixbuf (
+                    cover_image.scale_simple (new_width, new_height, Gdk.InterpType.BILINEAR),
+                    offset,
+                    0,
+                    COVER_SIZE,
+                    COVER_SIZE
+                );
             }
 
             return cover_image;

--- a/src/Widgets/DirectoryArt.vala
+++ b/src/Widgets/DirectoryArt.vala
@@ -37,7 +37,14 @@ namespace Vocal {
         private Gtk.Label summary_label;
         private Gtk.Box button_box;
 
-        public DirectoryArt (string url, string title, string? artist, string? summary, string artworkUrl170, bool? in_library = false) {
+        public DirectoryArt (  // vala-lint=naming-convention
+            string url,
+            string title,
+            string? artist,
+            string? summary,
+            string artworkUrl170,  // vala-lint=naming-convention
+            bool? in_library = false
+        ) {
 
             this.set_orientation (Gtk.Orientation.VERTICAL);
 
@@ -64,7 +71,10 @@ namespace Vocal {
             artist_label.set_property ("xalign", 0);
             label_box.pack_start (artist_label, false, false, 5);
 
-            var details_button = new Gtk.Button.from_icon_name (Utils.check_elementary () ? "help-info-symbolic" : "dialog-information-symbolic", Gtk.IconSize.SMALL_TOOLBAR);
+            var details_button = new Gtk.Button.from_icon_name (
+                Utils.check_elementary () ? "help-info-symbolic" : "dialog-information-symbolic",
+                Gtk.IconSize.SMALL_TOOLBAR
+            );
             details_button.valign = Gtk.Align.START;
             details_button.tooltip_text = _ ("Details");
             if (Utils.check_elementary ())
@@ -123,7 +133,12 @@ namespace Vocal {
             var bigartwork = artworkUrl170.replace ("170", "600");
 
             // Load the album artwork
-            var missing_pixbuf = new Gdk.Pixbuf.from_resource_at_scale ("/com/github/needleandthread/vocal/missing.png", 200, 200, true);
+            var missing_pixbuf = new Gdk.Pixbuf.from_resource_at_scale (
+                "/com/github/needleandthread/vocal/missing.png",
+                200,
+                200,
+                true
+            );
             var image = new Gtk.Image.from_pixbuf (missing_pixbuf);
             image.margin = 0;
             image.expand = false;

--- a/src/Widgets/DirectoryArt.vala
+++ b/src/Widgets/DirectoryArt.vala
@@ -17,9 +17,9 @@
   END LICENSE
 
   Additional contributors/authors:
-  
+
   * Artem Anufrij <artem.anufrij@live.de>
-  
+
 ***/
 
 
@@ -29,130 +29,129 @@ using Granite;
 
 namespace Vocal {
 
-	public class DirectoryArt : Gtk.Box {
+    public class DirectoryArt : Gtk.Box {
 
-		public signal void subscribe_button_clicked(string url);
+        public signal void subscribe_button_clicked (string url);
 
-		private Gtk.Popover details_popover;
-		private Gtk.Label summary_label;
-		private Gtk.Box button_box;
+        private Gtk.Popover details_popover;
+        private Gtk.Label summary_label;
+        private Gtk.Box button_box;
 
-		public DirectoryArt(string url, string title, string? artist, string? summary, string artworkUrl170, bool? in_library = false) {
+        public DirectoryArt (string url, string title, string? artist, string? summary, string artworkUrl170, bool? in_library = false) {
 
-			this.set_orientation(Gtk.Orientation.VERTICAL);
+            this.set_orientation (Gtk.Orientation.VERTICAL);
 
-			this.width_request = 200;
-			this.margin = 10;
+            this.width_request = 200;
+            this.margin = 10;
 
-			// Create labels for title and artist
-			var label_box = new Gtk.Box(Gtk.Orientation.VERTICAL, 0);
+            // Create labels for title and artist
+            var label_box = new Gtk.Box (Gtk.Orientation.VERTICAL, 0);
 
-			var title_label = new Gtk.Label("""<b>%s</b>""".printf(GLib.Markup.escape_text(title)));
-			title_label.justify = Gtk.Justification.LEFT;
-			title_label.use_markup = true;
-			title_label.max_width_chars = 15;
-			title_label.wrap = true;
-			title_label.set_property("xalign", 0);
-			label_box.pack_start(title_label, false, false, 5);
+            var title_label = new Gtk.Label ("""<b>%s</b>""".printf (GLib.Markup.escape_text (title)));
+            title_label.justify = Gtk.Justification.LEFT;
+            title_label.use_markup = true;
+            title_label.max_width_chars = 15;
+            title_label.wrap = true;
+            title_label.set_property ("xalign", 0);
+            label_box.pack_start (title_label, false, false, 5);
 
-			artist = artist ?? "";
+            artist = artist ?? "";
 
-			var artist_label = new Gtk.Label(artist);
-			artist_label.justify = Gtk.Justification.LEFT;
-			artist_label.max_width_chars = 15;
-			artist_label.wrap = true;
-			artist_label.set_property("xalign", 0);
-			label_box.pack_start(artist_label, false, false, 5);
+            var artist_label = new Gtk.Label (artist);
+            artist_label.justify = Gtk.Justification.LEFT;
+            artist_label.max_width_chars = 15;
+            artist_label.wrap = true;
+            artist_label.set_property ("xalign", 0);
+            label_box.pack_start (artist_label, false, false, 5);
 
-			var details_button = new Gtk.Button.from_icon_name(Utils.check_elementary() ? "help-info-symbolic" : "dialog-information-symbolic", Gtk.IconSize.SMALL_TOOLBAR);
-			details_button.valign = Gtk.Align.START;
-			details_button.tooltip_text = _("Details");
-			if (Utils.check_elementary ())
-			    details_button.relief = Gtk.ReliefStyle.NONE;
+            var details_button = new Gtk.Button.from_icon_name (Utils.check_elementary () ? "help-info-symbolic" : "dialog-information-symbolic", Gtk.IconSize.SMALL_TOOLBAR);
+            details_button.valign = Gtk.Align.START;
+            details_button.tooltip_text = _ ("Details");
+            if (Utils.check_elementary ())
+                details_button.relief = Gtk.ReliefStyle.NONE;
 
-			details_popover = new Gtk.Popover(details_button);
-			summary_label = new Gtk.Label ("");
-			summary_label.wrap = true;
-			details_popover.add(summary_label);
+            details_popover = new Gtk.Popover (details_button);
+            summary_label = new Gtk.Label ("");
+            summary_label.wrap = true;
+            details_popover.add (summary_label);
 
-			details_button.clicked.connect(() => {
-				if(summary.length > 0) {
-					summary_label.set_text(summary);
-				} else if (url.contains("itunes.apple")) {
-					var itunes = new iTunesProvider();
-					string rss_url = itunes.get_rss_from_itunes_url(url);
-					var feed_parser = new FeedParser();
+            details_button.clicked.connect (() => {
+                if (summary.length > 0) {
+                    summary_label.set_text (summary);
+                } else if (url.contains ("itunes.apple")) {
+                    var itunes = new iTunesProvider ();
+                    string rss_url = itunes.get_rss_from_itunes_url (url);
+                    var feed_parser = new FeedParser ();
 
-					string details_summary =  feed_parser.find_description_from_file(rss_url);
-					if (details_summary == null || details_summary.strip ().length == 0) {
-						details_summary = _("No summary available.");
-					}
+                    string details_summary = feed_parser.find_description_from_file (rss_url);
+                    if (details_summary == null || details_summary.strip ().length == 0) {
+                        details_summary = _ ("No summary available.");
+                    }
 
-					summary_label.set_text (details_summary);
-					feed_parser = null;
-				}
-				summary_label.max_width_chars = 64;
-				summary_label.margin = 20;
-				details_popover.show_all();
-			});
+                    summary_label.set_text (details_summary);
+                    feed_parser = null;
+                }
+                summary_label.max_width_chars = 64;
+                summary_label.margin = 20;
+                details_popover.show_all ();
+            });
 
-            var subscribe_button = new Gtk.Button.from_icon_name("list-add-symbolic", Gtk.IconSize.SMALL_TOOLBAR);
-            subscribe_button.tooltip_text = _("Subscribe");
+            var subscribe_button = new Gtk.Button.from_icon_name ("list-add-symbolic", Gtk.IconSize.SMALL_TOOLBAR);
+            subscribe_button.tooltip_text = _ ("Subscribe");
             if (Utils.check_elementary ())
                 subscribe_button.relief = Gtk.ReliefStyle.NONE;
-            subscribe_button.clicked.connect(() => {
-                subscribe_button_clicked(url);
+            subscribe_button.clicked.connect (() => {
+                subscribe_button_clicked (url);
             });
-		    subscribe_button.valign = Gtk.Align.START;
+            subscribe_button.valign = Gtk.Align.START;
 
-            button_box = new Gtk.Box(Gtk.Orientation.VERTICAL, 5);
-            button_box.add(details_button);
-            button_box.add(subscribe_button);
+            button_box = new Gtk.Box (Gtk.Orientation.VERTICAL, 5);
+            button_box.add (details_button);
+            button_box.add (subscribe_button);
             button_box.margin = 5;
             button_box.margin_right = 0;
 
-            var hor_box = new Gtk.Box(Gtk.Orientation.HORIZONTAL, 0);
-            hor_box.pack_start(label_box, true, true, 0);
-            hor_box.pack_start(button_box, false, false, 0);
+            var hor_box = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 0);
+            hor_box.pack_start (label_box, true, true, 0);
+            hor_box.pack_start (button_box, false, false, 0);
 
             hor_box.margin_left = 10;
             hor_box.margin_right = 10;
 
-            
+
             // By default we're only given the 170px version, but the 600px is available
-            var bigartwork = artworkUrl170.replace("170", "600");
+            var bigartwork = artworkUrl170.replace ("170", "600");
 
             // Load the album artwork
-            var missing_pixbuf = new Gdk.Pixbuf.from_resource_at_scale("/com/github/needleandthread/vocal/missing.png", 200, 200, true);
-            
-            var image = new Gtk.Image.from_pixbuf(missing_pixbuf);
+            var missing_pixbuf = new Gdk.Pixbuf.from_resource_at_scale ("/com/github/needleandthread/vocal/missing.png", 200, 200, true);
+            var image = new Gtk.Image.from_pixbuf (missing_pixbuf);
             image.margin = 0;
             image.expand = false;
             image.pixel_size = 200;
             image.margin_top = 5;
             image.margin_bottom = 5;
-            image.get_style_context().add_class("directory-art-image");
-            this.pack_start(image, false, false, 0);
+            image.get_style_context ().add_class ("directory-art-image");
+            this.pack_start (image, false, false, 0);
 
-            
-            ImageCache image_cache = new ImageCache();
-            image_cache.get_image.begin(bigartwork, (obj, res) => {
-                Gdk.Pixbuf pixbuf = image_cache.get_image.end(res);
+
+            ImageCache image_cache = new ImageCache ();
+            image_cache.get_image.begin (bigartwork, (obj, res) => {
+                Gdk.Pixbuf pixbuf = image_cache.get_image.end (res);
                 if (pixbuf != null) {
-                    image.clear();
+                    image.clear ();
                     image.gicon = pixbuf;
                     image.pixel_size = 200;
                 }
             });
-            
 
-            this.pack_start(hor_box, false, false, 0);
 
-            if (Utils.check_elementary()) {
-                this.get_style_context().add_class("card");
+            this.pack_start (hor_box, false, false, 0);
+
+            if (Utils.check_elementary ()) {
+                this.get_style_context ().add_class ("card");
             } else {
-                this.get_style_context().add_class("directory-art");
+                this.get_style_context ().add_class ("directory-art");
             }
         }
-	}
+    }
 }

--- a/src/Widgets/DirectoryView.vala
+++ b/src/Widgets/DirectoryView.vala
@@ -21,15 +21,15 @@ namespace Vocal {
 
     public class DirectoryView : Gtk.Box {
 
-        public signal void return_to_library();
-        public signal void return_to_welcome();
-        public signal void on_new_subscription(string url);
+        public signal void return_to_library ();
+        public signal void return_to_welcome ();
+        public signal void on_new_subscription (string url);
 
         private iTunesProvider itunes;
         private Gtk.FlowBox flowbox;
         private Gtk.Box banner_box;
-        public  Gtk.Button return_button;
-        public  Gtk.Button forward_button;
+        public Gtk.Button return_button;
+        public Gtk.Button forward_button;
         private Gtk.Button first_run_continue_button;
 
         private Gtk.Box loading_box;
@@ -38,17 +38,17 @@ namespace Vocal {
 
         private bool top_podcasts_loaded = false;
 
-        public DirectoryView(iTunesProvider itunes_provider, bool first_run = false) {
+        public DirectoryView (iTunesProvider itunes_provider, bool first_run = false) {
 
-            this.set_orientation(Gtk.Orientation.VERTICAL);
+            this.set_orientation (Gtk.Orientation.VERTICAL);
 
             // Set up the banner
 
-            banner_box = new Gtk.Box(Gtk.Orientation.HORIZONTAL, 0);
-            banner_box.get_style_context().add_class("toolbar");
-            banner_box.get_style_context().add_class("library-toolbar");
+            banner_box = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 0);
+            banner_box.get_style_context ().add_class ("toolbar");
+            banner_box.get_style_context ().add_class ("library-toolbar");
 
-            var itunes_title = new Gtk.Label(_("iTunes Top 100 Podcasts"));
+            var itunes_title = new Gtk.Label (_ ("iTunes Top 100 Podcasts"));
             itunes_title.margin_top = 15;
             itunes_title.margin_bottom = 5;
             itunes_title.justify = Gtk.Justification.CENTER;
@@ -59,116 +59,116 @@ namespace Vocal {
             itunes_title.get_style_context ().add_class ("h2");
 
             if (first_run) {
-                return_button = new Gtk.Button.with_label(_("Go Back"));
-            } else  {
-                return_button = new Gtk.Button.with_label(_("Return to Library"));
+                return_button = new Gtk.Button.with_label (_ ("Go Back"));
+            } else {
+                return_button = new Gtk.Button.with_label (_ ("Return to Library"));
             }
-            return_button.clicked.connect(() => { return_to_library (); });
-            return_button.get_style_context().add_class("back-button");
+            return_button.clicked.connect (() => { return_to_library (); });
+            return_button.get_style_context ().add_class ("back-button");
             return_button.margin = 6;
             return_button.expand = false;
             return_button.halign = Gtk.Align.START;
 
-            first_run_continue_button = new Gtk.Button.with_label(_("Done"));
-            first_run_continue_button.get_style_context().add_class("suggested-action");
+            first_run_continue_button = new Gtk.Button.with_label (_ ("Done"));
+            first_run_continue_button.get_style_context ().add_class ("suggested-action");
             first_run_continue_button.margin = 6;
             first_run_continue_button.expand = false;
             first_run_continue_button.halign = Gtk.Align.END;
-            first_run_continue_button.clicked.connect(() => {
-                return_button.label = _("Return to Library");
-                hide_first_run_continue_button();
-                return_to_library();
+            first_run_continue_button.clicked.connect (() => {
+                return_button.label = _ ("Return to Library");
+                hide_first_run_continue_button ();
+                return_to_library ();
             });
             first_run_continue_button.sensitive = false;
 
-            banner_box.pack_start(return_button, false, false, 0);
-            banner_box.pack_end(first_run_continue_button, false, false, 0);
+            banner_box.pack_start (return_button, false, false, 0);
+            banner_box.pack_end (first_run_continue_button, false, false, 0);
 
-            if(!first_run) {
-                hide_first_run_continue_button();
+            if (!first_run) {
+                hide_first_run_continue_button ();
             }
 
             banner_box.vexpand = false;
             banner_box.hexpand = true;
 
             itunes_title.vexpand = false;
-            itunes_title.hexpand  = true;
+            itunes_title.hexpand = true;
 
             this.itunes = itunes_provider;
-            this.add(banner_box);
-            this.add(itunes_title);
-            
-            loading_box = new  Gtk.Box(Gtk.Orientation.VERTICAL, 5);
-            var spinner = new Gtk.Spinner();
-            spinner.active = true; 
-            var loading_label = new Gtk.Label(_("Loading iTunes Store"));
-            loading_label.get_style_context().add_class("h2");
-            loading_box.add(loading_label);
-            loading_box.add(spinner);
-            this.pack_start(loading_box, true, true, 5);
+            this.add (banner_box);
+            this.add (itunes_title);
 
-            scrolled_window = new Gtk.ScrolledWindow(null, null);
-            this.pack_start(scrolled_window, true, true, 15);
+            loading_box = new Gtk.Box (Gtk.Orientation.VERTICAL, 5);
+            var spinner = new Gtk.Spinner ();
+            spinner.active = true;
+            var loading_label = new Gtk.Label (_ ("Loading iTunes Store"));
+            loading_label.get_style_context ().add_class ("h2");
+            loading_box.add (loading_label);
+            loading_box.add (spinner);
+            this.pack_start (loading_box, true, true, 5);
+
+            scrolled_window = new Gtk.ScrolledWindow (null, null);
+            this.pack_start (scrolled_window, true, true, 15);
 
         }
 
-        public async void load_top_podcasts() {
+        public async void load_top_podcasts () {
             SourceFunc callback = load_top_podcasts.callback;
 
             ThreadFunc<void*> run = () => {
-                if(top_podcasts_loaded) {
-                    info("Already loaded top 100 podcasts. Doing nothing.");
+                if (top_podcasts_loaded) {
+                    info ("Already loaded top 100 podcasts. Doing nothing.");
                     return null;
                 }
 
-                flowbox = new Gtk.FlowBox();
+                flowbox = new Gtk.FlowBox ();
 
                 // TODO: not actually asyncronous.
                 info ("Getting top podcasts asynchronously?.");
-                var entries = itunes.get_top_podcasts(100);
+                var entries = itunes.get_top_podcasts (100);
                 info ("Top 100 podcasts loaded.");
 
                 int i = 1;
-                if(entries == null) {
-                    info("iterating over entries");
+                if (entries == null) {
+                    info ("iterating over entries");
                     return null;
                 }
 
-                foreach(DirectoryEntry entry in entries) {
-                    DirectoryArt directory_art = new DirectoryArt(entry.itunesUrl, "%d. %s".printf(i, entry.title), entry.artist, entry.summary, entry.artworkUrl170);
+                foreach (DirectoryEntry entry in entries) {
+                    DirectoryArt directory_art = new DirectoryArt (entry.itunesUrl, "%d. %s".printf (i, entry.title), entry.artist, entry.summary, entry.artworkUrl170);
                     directory_art.expand = false;
-                    directory_art.subscribe_button_clicked.connect((url) => {
+                    directory_art.subscribe_button_clicked.connect ((url) => {
                         first_run_continue_button.sensitive = true;
-                        on_new_subscription(url);
+                        on_new_subscription (url);
                     });
-                    flowbox.add(directory_art);
+                    flowbox.add (directory_art);
                     i++;
                 }
 
                 top_podcasts_loaded = true;
 
-                Idle.add((owned) callback);
+                Idle.add ((owned) callback);
                 return null;
             };
-            Thread.create<void*>(run, false);
+            Thread.create<void*> (run, false);
 
             yield;
 
-            loading_box.set_no_show_all(true);
-            loading_box.hide();
+            loading_box.set_no_show_all (true);
+            loading_box.hide ();
 
-            scrolled_window.add(flowbox);
-            show_all();
+            scrolled_window.add (flowbox);
+            show_all ();
         }
 
-        public void show_first_run_continue_button() {
-            first_run_continue_button.set_no_show_all(false);
-            first_run_continue_button.show();
+        public void show_first_run_continue_button () {
+            first_run_continue_button.set_no_show_all (false);
+            first_run_continue_button.show ();
         }
 
-        public void hide_first_run_continue_button() {
-            first_run_continue_button.set_no_show_all(true);
-            first_run_continue_button.hide();
+        public void hide_first_run_continue_button () {
+            first_run_continue_button.set_no_show_all (true);
+            first_run_continue_button.hide ();
         }
 
     }

--- a/src/Widgets/DirectoryView.vala
+++ b/src/Widgets/DirectoryView.vala
@@ -123,7 +123,7 @@ namespace Vocal {
 
                 flowbox = new Gtk.FlowBox ();
 
-                // TODO: not actually asyncronous.
+                // TODO: not actually asyncronous.  vala-lint=note
                 info ("Getting top podcasts asynchronously?.");
                 var entries = itunes.get_top_podcasts (100);
                 info ("Top 100 podcasts loaded.");
@@ -135,7 +135,13 @@ namespace Vocal {
                 }
 
                 foreach (DirectoryEntry entry in entries) {
-                    DirectoryArt directory_art = new DirectoryArt (entry.itunesUrl, "%d. %s".printf (i, entry.title), entry.artist, entry.summary, entry.artworkUrl170);
+                    DirectoryArt directory_art = new DirectoryArt (
+                        entry.itunesUrl,
+                        "%d. %s".printf (i, entry.title),
+                        entry.artist,
+                        entry.summary,
+                        entry.artworkUrl170
+                    );
                     directory_art.expand = false;
                     directory_art.subscribe_button_clicked.connect ((url) => {
                         first_run_continue_button.sensitive = true;

--- a/src/Widgets/DownloadDetailBox.vala
+++ b/src/Widgets/DownloadDetailBox.vala
@@ -22,26 +22,26 @@ using Gtk;
 namespace Vocal {
     public class DownloadDetailBox : Gtk.Box {
 
-        public signal void cancel_requested(Episode e);		// Fired when the cancel button gets clicked
+        public signal void cancel_requested (Episode e);        // Fired when the cancel button gets clicked
 
         // Fired upon successful download
-        public signal void download_has_completed_successfully(string title, string parent_name);
+        public signal void download_has_completed_successfully (string title, string parent_name);
 
         // Fired when the box is ready for removal (usually when the download completes)
-        public signal void ready_for_removal(DownloadDetailBox box);
+        public signal void ready_for_removal (DownloadDetailBox box);
 
-        public signal void new_percentage_available();		// Fired when a new download percentage is available
+        public signal void new_percentage_available ();        // Fired when a new download percentage is available
 
-        public Gtk.Label 	 	title_label = null;
-        public Gtk.Label	 	podcast_label = null;
-        public Gtk.ProgressBar  progress_bar = null;
-        public Gtk.Label 		download_label = null;
+        public Gtk.Label title_label = null;
+        public Gtk.Label podcast_label = null;
+        public Gtk.ProgressBar progress_bar = null;
+        public Gtk.Label download_label = null;
 
-        public double	percentage;
-        public int 		secs_elapsed;
-        public bool 	download_complete;
-        public string 	episode_title;
-        public string 	parent_podcast_name;
+        public double percentage;
+        public int secs_elapsed;
+        public bool download_complete;
+        public string episode_title;
+        public string parent_podcast_name;
 
         private bool signal_has_been_sent;
 
@@ -58,11 +58,11 @@ namespace Vocal {
             string title = episode.title;
             string parent_podcast_name = episode.parent.name;
 
-			// Load the actual cover art
-			var file = GLib.File.new_for_uri(episode.parent.coverart_uri);
-			var icon = new GLib.FileIcon(file);
-			var image = new Gtk.Image.from_gicon(icon, Gtk.IconSize.DIALOG);
-			image.pixel_size = 64;
+            // Load the actual cover art
+            var file = GLib.File.new_for_uri (episode.parent.coverart_uri);
+            var icon = new GLib.FileIcon (file);
+            var image = new Gtk.Image.from_gicon (icon, Gtk.IconSize.DIALOG);
+            image.pixel_size = 64;
 
             this.episode_title = title;
             this.parent_podcast_name = parent_podcast_name;
@@ -80,57 +80,57 @@ namespace Vocal {
             signal_has_been_sent = false;
 
             // Create the widgets
-            title_label = new Gtk.Label("<b>" + title.replace("%27", "'") + "</b>");
-            title_label.set_use_markup(true);
-            title_label.set_justify(Gtk.Justification.RIGHT);
+            title_label = new Gtk.Label ("<b>" + title.replace ("%27", "'") + "</b>");
+            title_label.set_use_markup (true);
+            title_label.set_justify (Gtk.Justification.RIGHT);
             title_label.xalign = 0;
             title_label.max_width_chars = 15;
 
-            podcast_label = new Gtk.Label(parent_podcast_name.replace("%27", "'"));
-            podcast_label.set_justify(Gtk.Justification.LEFT);
+            podcast_label = new Gtk.Label (parent_podcast_name.replace ("%27", "'"));
+            podcast_label.set_justify (Gtk.Justification.LEFT);
             podcast_label.xalign = 0;
             podcast_label.max_width_chars = 15;
 
-            var label_box = new Gtk.Box(Gtk.Orientation.VERTICAL, 0);
-            label_box.add(title_label);
-            label_box.add(podcast_label);
+            var label_box = new Gtk.Box (Gtk.Orientation.VERTICAL, 0);
+            label_box.add (title_label);
+            label_box.add (podcast_label);
 
-            var details_box = new Gtk.Box(Gtk.Orientation.HORIZONTAL, 12);
-            details_box.add(image);
-            details_box.add(label_box);
+            var details_box = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 12);
+            details_box.add (image);
+            details_box.add (label_box);
 
-            var progress_box = new Gtk.Box(Gtk.Orientation.HORIZONTAL, 0);
+            var progress_box = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 0);
 
-            progress_bar = new Gtk.ProgressBar();
+            progress_bar = new Gtk.ProgressBar ();
             progress_bar.show_text = false;
             progress_bar.expand = true;
             progress_bar.valign = Gtk.Align.CENTER;
 
-            var cancel_button = new Gtk.Button.from_icon_name("process-stop-symbolic", Gtk.IconSize.BUTTON);
-            cancel_button.get_style_context().add_class("flat");
-            cancel_button.tooltip_text = _("Cancel Download");
-            cancel_button.clicked.connect( () => {
-                cancel_requested(episode);
+            var cancel_button = new Gtk.Button.from_icon_name ("process-stop-symbolic", Gtk.IconSize.BUTTON);
+            cancel_button.get_style_context ().add_class ("flat");
+            cancel_button.tooltip_text = _ ("Cancel Download");
+            cancel_button.clicked.connect (() => {
+                cancel_requested (episode);
             });
-            progress_box.add(progress_bar);
-            progress_box.add(cancel_button);
+            progress_box.add (progress_bar);
+            progress_box.add (cancel_button);
 
 
-            download_label = new Gtk.Label("");
+            download_label = new Gtk.Label ("");
             download_complete = false;
             download_label.xalign = 0;
 
-            this.add(details_box);
+            this.add (details_box);
 
-            label_box.add(progress_box);
-            label_box.add(download_label);
+            label_box.add (progress_box);
+            label_box.add (download_label);
 
 
             // While the download isn't complete, keep counting seconds elapsed
-            GLib.Timeout.add(1000, () => {
+            GLib.Timeout.add (1000, () => {
                 secs_elapsed += 1;
 
-                if(!download_complete) {
+                if (!download_complete) {
                     return true;
                 } else {
                     return false;
@@ -138,11 +138,11 @@ namespace Vocal {
             });
 
             // Periodically update the time on the label
-            GLib.Timeout.add(1000, () => {
+            GLib.Timeout.add (1000, () => {
 
                 outdated_time_output = time_output;
 
-                if(!download_complete) {
+                if (!download_complete) {
                     return true;
                 } else {
                     return false;
@@ -155,15 +155,15 @@ namespace Vocal {
           /*
          * Sets download progress information when download progress has occurred
          */
-        public void download_delegate(int64 current_num_bytes, int64 total_num_bytes) {
+        public void download_delegate (int64 current_num_bytes, int64 total_num_bytes) {
 
-            if(current_num_bytes == total_num_bytes && !signal_has_been_sent) {
+            if (current_num_bytes == total_num_bytes && !signal_has_been_sent) {
                 // Set percentage to 100% and call new_percentage_available so the launcher progress
                 // bar will see the completed value
                 this.percentage = 1.0;
-                new_percentage_available();
-                download_has_completed_successfully(episode_title, parent_podcast_name);
-                ready_for_removal(this);
+                new_percentage_available ();
+                download_has_completed_successfully (episode_title, parent_podcast_name);
+                ready_for_removal (this);
                 signal_has_been_sent = true;
                 return;
             }
@@ -174,7 +174,7 @@ namespace Vocal {
             double MB_total = (double)total_num_bytes / 1000000;
             double MB_remaining = (MB_total - MB_downloaded);
 
-            progress_bar.set_fraction(percentage);
+            progress_bar.set_fraction (percentage);
 
             double MBPS = (double) MB_downloaded / secs_elapsed;
 
@@ -182,29 +182,29 @@ namespace Vocal {
             int time_val_to_display;
             string units;
 
-            if(num_secs_remaining > 60) {
+            if (num_secs_remaining > 60) {
                 time_val_to_display = num_secs_remaining / 60;
-                units = ngettext("minute", "minutes", time_val_to_display);
+                units = ngettext ("minute", "minutes", time_val_to_display);
             }
             else {
                 time_val_to_display = num_secs_remaining;
-                units = ngettext("second", "seconds", time_val_to_display);
+                units = ngettext ("second", "seconds", time_val_to_display);
             }
 
-            data_output = "%s / %s".printf(GLib.format_size(current_num_bytes), GLib.format_size(total_num_bytes));
-            time_output = """, about %d %s remaining""".printf(time_val_to_display, units);
+            data_output = "%s / %s".printf (GLib.format_size (current_num_bytes), GLib.format_size (total_num_bytes));
+            time_output = """, about %d %s remaining""".printf (time_val_to_display, units);
 
             // When setting the label, always set it to the "outdated" time
             // A separate timer will periodically update the time on the label
             // (this prevents it from being too jarring)
 
-            if(outdated_time_output == null ) {
+            if (outdated_time_output == null ) {
                 outdated_time_output = time_output;
             }
 
-            download_label.set_markup(data_output + outdated_time_output);
+            download_label.set_markup (data_output + outdated_time_output);
 
-            new_percentage_available();
+            new_percentage_available ();
         }
     }
 }

--- a/src/Widgets/DownloadsPopover.vala
+++ b/src/Widgets/DownloadsPopover.vala
@@ -27,93 +27,93 @@ namespace Vocal {
     public class DownloadsPopover : Gtk.Popover {
 
 
-        public signal void 	all_downloads_complete();		// signal that gets fired when all downloads are finished
+        public signal void all_downloads_complete ();   // signal that gets fired when all downloads are finished
 
-        private Gtk.ListBox listbox;						// displays the download details boxes
-        private Gtk.Label 	downloads_complete;				// a label that gets shown when all downloads are finished
+        private Gtk.ListBox listbox;                    // displays the download details boxes
+        private Gtk.Label downloads_complete;           // a label that gets shown when all downloads are finished
 
-        public ArrayList<DownloadDetailBox> downloads;		// stores the download detail boxes
+        public ArrayList<DownloadDetailBox> downloads;  // stores the download detail boxes
 
         /*
          * Constructor for a downloads popover that is relative to a provided parent
          */
-        public DownloadsPopover(Gtk.Widget parent) {
-            this.set_relative_to(parent);
-            this.listbox = new Gtk.ListBox();
+        public DownloadsPopover (Gtk.Widget parent) {
+            this.set_relative_to (parent);
+            this.listbox = new Gtk.ListBox ();
             listbox.selection_mode = SelectionMode.NONE;
             this.width_request = 425;
 
-            downloads = new ArrayList<DownloadDetailBox>();
-            var scroll = new Gtk.ScrolledWindow(null, null);
+            downloads = new ArrayList<DownloadDetailBox> ();
+            var scroll = new Gtk.ScrolledWindow (null, null);
             scroll.hscrollbar_policy = Gtk.PolicyType.NEVER;
             scroll.min_content_height = 200;
 
-            downloads_complete = new Gtk.Label(_("No Active Downloads"));
-            downloads_complete.get_style_context ().add_class("h3");
+            downloads_complete = new Gtk.Label (_ ("No Active Downloads"));
+            downloads_complete.get_style_context ().add_class ("h3");
             downloads_complete.sensitive = false;
             downloads_complete.margin = 12;
-            listbox.prepend(downloads_complete);
+            listbox.prepend (downloads_complete);
 
-            this.add(scroll);
-            scroll.add(listbox);
+            this.add (scroll);
+            scroll.add (listbox);
         }
 
         /*
          * Adds a download to the popover
          */
-        public void add_download(DownloadDetailBox details) {
+        public void add_download (DownloadDetailBox details) {
 
-            if(downloads.size < 1) {
-                hide_downloads_complete();
+            if (downloads.size < 1) {
+                hide_downloads_complete ();
             }
 
-            details.ready_for_removal.connect(remove_details_box);
-            details.cancel_requested.connect(() => {
-                remove_details_box(details);
+            details.ready_for_removal.connect (remove_details_box);
+            details.cancel_requested.connect (() => {
+                remove_details_box (details);
             });
 
             // Add the new download to the queue and listbox
-            downloads.add(details);
-            listbox.prepend(details);
-            details.parent.get_style_context().add_class("download-detail-box");
-            listbox.show_all();
+            downloads.add (details);
+            listbox.prepend (details);
+            details.parent.get_style_context ().add_class ("download-detail-box");
+            listbox.show_all ();
         }
 
 
         /*
-		 * Hides the downloads complete label
-		 */
-        private void hide_downloads_complete() {
-            downloads_complete.set_no_show_all(true);
-            downloads_complete.hide();
-            downloads_complete.show_all();
+         * Hides the downloads complete label
+         */
+        private void hide_downloads_complete () {
+            downloads_complete.set_no_show_all (true);
+            downloads_complete.hide ();
+            downloads_complete.show_all ();
         }
 
 
         /*
          * Removes a download from the popover
          */
-        private void remove_details_box(DownloadDetailBox box) {
-            box.parent.get_style_context().remove_class("download-detail-box");
-            downloads.remove(box);
-            box.destroy();
+        private void remove_details_box (DownloadDetailBox box) {
+            box.parent.get_style_context ().remove_class ("download-detail-box");
+            downloads.remove (box);
+            box.destroy ();
 
-            if(downloads.size < 1) {
-                show_downloads_complete();
+            if (downloads.size < 1) {
+                show_downloads_complete ();
 
                 // If the popover is not currently showing, send a signal to hide the menuitem
-                if(this.visible != true)
-                  all_downloads_complete();
+                if (this.visible != true)
+                  all_downloads_complete ();
             }
         }
 
 
-		/*
-		 * Shows the downloads complete label
-		 */
-        private void show_downloads_complete() {
-            downloads_complete.set_no_show_all(false);
-            downloads_complete.show_all();
+        /*
+         * Shows the downloads complete label
+         */
+        private void show_downloads_complete () {
+            downloads_complete.set_no_show_all (false);
+            downloads_complete.show_all ();
         }
     }
 }

--- a/src/Widgets/EpisodeDetailBox.vala
+++ b/src/Widgets/EpisodeDetailBox.vala
@@ -149,7 +149,7 @@ namespace Vocal {
             // Set up the title and details labels
             var label_box = new Gtk.Box (Gtk.Orientation.VERTICAL, 5);
             label_box.margin = 0;
-            title_label = new Gtk.Label ("<b>%s</b>".printf (GLib.Markup.escape_text (episode.title.replace ("%27", "'").replace ("&amp;", "&"))));
+            title_label = new Gtk.Label ("<b>%s</b>".printf (GLib.Markup.escape_text (episode.title.replace ("%27", "'").replace ("&amp;", "&"))));  // vala-lint=line-length
             title_label.set_use_markup (true);
             title_label.halign = Gtk.Align.START;
             title_label.set_property ("xalign", 0);

--- a/src/Widgets/EpisodeDetailBox.vala
+++ b/src/Widgets/EpisodeDetailBox.vala
@@ -21,7 +21,7 @@
 namespace Vocal {
     public class EpisodeDetailBox : Gtk.Box {
 
-		// Fired when the streaming/play button gets clicked
+        // Fired when the streaming/play button gets clicked
         public signal void streaming_button_clicked ();
 
         private bool unplayed;
@@ -29,30 +29,30 @@ namespace Vocal {
         private bool now_playing;
 
         public Episode episode;
-        public int 	   top_box_width;
+        public int top_box_width;
 
-        private Gtk.Box     top_box;
-        private Gtk.Label   title_label;
-        private Gtk.Label   release_label;
-        private Gtk.Box     unplayed_box;
-        private Gtk.Box     download_box;
-        private Gtk.Box     streaming_box;
-        private Gtk.Image   unplayed_image;
-        private Gtk.Image   now_playing_image;
-        public  Gtk.Button  download_button;
-        public  Gtk.Button  streaming_button;
+        private Gtk.Box top_box;
+        private Gtk.Label title_label;
+        private Gtk.Label release_label;
+        private Gtk.Box unplayed_box;
+        private Gtk.Box download_box;
+        private Gtk.Box streaming_box;
+        private Gtk.Image unplayed_image;
+        private Gtk.Image now_playing_image;
+        public Gtk.Button download_button;
+        public Gtk.Button streaming_button;
         private Gtk.Label description_label;
 
-		/*
-		 * Creates a new episode detail box given an episode.
-		 */
+        /*
+         * Creates a new episode detail box given an episode.
+         */
         public EpisodeDetailBox (Episode episode, Controller controller, bool new_episodes_view = false) {
             this.episode = episode;
-            this.top_box = new Gtk.Box(Gtk.Orientation.HORIZONTAL, 0);
-            pack_start(top_box, false, false, 0);
+            this.top_box = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 0);
+            pack_start (top_box, false, false, 0);
 
             this.orientation = Gtk.Orientation.VERTICAL;
-            this.set_size_request(100, 25);
+            this.set_size_request (100, 25);
 
             this.homogeneous = false;
             this.border_width = 5;
@@ -65,22 +65,22 @@ namespace Vocal {
             string streaming_image = "media-playback-start-symbolic";
             string unplayed = null;
 
-            unplayed_box = new Gtk.Box(Gtk.Orientation.HORIZONTAL, 0);
-            unplayed_box.set_size_request(25, 25);
+            unplayed_box = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 0);
+            unplayed_box.set_size_request (25, 25);
 
-            download_box = new Gtk.Box(Gtk.Orientation.HORIZONTAL, 0);
-            download_box.set_size_request(25, 25);
+            download_box = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 0);
+            download_box.set_size_request (25, 25);
 
-            streaming_box = new Gtk.Box(Gtk.Orientation.HORIZONTAL, 0);
-            streaming_box.set_size_request(25, 25);
+            streaming_box = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 0);
+            streaming_box.set_size_request (25, 25);
 
             // Create the now playing image, but don't actually use it anywhere yet
-            now_playing_image = new Gtk.Image.from_icon_name("media-playback-start-symbolic", Gtk.IconSize.BUTTON);
+            now_playing_image = new Gtk.Image.from_icon_name ("media-playback-start-symbolic", Gtk.IconSize.BUTTON);
             now_playing_image.has_tooltip = true;
-            now_playing_image.tooltip_text = _("This episode is currently being played");
+            now_playing_image.tooltip_text = _ ("This episode is currently being played");
 
             // Determine whether or not the episode has been played
-            if(episode.status == EpisodeStatus.UNPLAYED) {
+            if (episode.status == EpisodeStatus.UNPLAYED) {
                 if (Utils.check_elementary ()) {
                     unplayed = "help-about-symbolic";
                 } else {
@@ -90,73 +90,73 @@ namespace Vocal {
             }
 
             // Determine whether or not the episode has been downloaded
-            if(episode.current_download_status != DownloadStatus.DOWNLOADED) {
-                if(controller.on_elementary)
+            if (episode.current_download_status != DownloadStatus.DOWNLOADED) {
+                if (controller.on_elementary)
                     location_image = "browser-download-symbolic";
                 else
                     location_image = "document-save-symbolic";
-                streaming_image =  "network-wireless-signal-excellent-symbolic";
+                streaming_image = "network-wireless-signal-excellent-symbolic";
             }
 
             // If the episode is unplayed, show an unread icon
-            if(unplayed != null && new_episodes_view == false) {
-                unplayed_image = new Gtk.Image.from_icon_name(unplayed, Gtk.IconSize.BUTTON);
+            if (unplayed != null && new_episodes_view == false) {
+                unplayed_image = new Gtk.Image.from_icon_name (unplayed, Gtk.IconSize.BUTTON);
                 unplayed_image.valign = Gtk.Align.START;
-                unplayed_box.pack_start(unplayed_image, false, false, 0);
+                unplayed_box.pack_start (unplayed_image, false, false, 0);
             }
-            
+
             if (new_episodes_view) {
-			    var file = GLib.File.new_for_uri(episode.parent.coverart_uri);
-			    var icon = new GLib.FileIcon(file);
-			    var image = new Gtk.Image.from_gicon(icon, Gtk.IconSize.DIALOG);
-			    image.margin = 12;
-			    image.margin_top = 0;
-			    image.margin_bottom = 0;
-			    image.pixel_size = 75;
-			    unplayed_box.pack_start (image, false, false, 0);
+                var file = GLib.File.new_for_uri (episode.parent.coverart_uri);
+                var icon = new GLib.FileIcon (file);
+                var image = new Gtk.Image.from_gicon (icon, Gtk.IconSize.DIALOG);
+                image.margin = 12;
+                image.margin_top = 0;
+                image.margin_bottom = 0;
+                image.pixel_size = 75;
+                unplayed_box.pack_start (image, false, false, 0);
             }
 
             // Set up the streaming button
-            streaming_button = new Gtk.Button.from_icon_name(streaming_image, Gtk.IconSize.BUTTON);
+            streaming_button = new Gtk.Button.from_icon_name (streaming_image, Gtk.IconSize.BUTTON);
             streaming_button.expand = false;
             streaming_button.relief = Gtk.ReliefStyle.NONE;
             streaming_button.has_tooltip = true;
-            if(episode.current_download_status == DownloadStatus.DOWNLOADED)
-                streaming_button.tooltip_text = _("Play");
+            if (episode.current_download_status == DownloadStatus.DOWNLOADED)
+                streaming_button.tooltip_text = _ ("Play");
             else
-                streaming_button.tooltip_text = _("Stream Episode");
+                streaming_button.tooltip_text = _ ("Stream Episode");
 
             // Set up to fire a signal when clicked
-            streaming_button.clicked.connect ( () => {
+            streaming_button.clicked.connect (() => {
                 streaming_button_clicked ();
             });
 
-            streaming_box.pack_start(streaming_button, false, false, 0);
+            streaming_box.pack_start (streaming_button, false, false, 0);
 
 
             // If the episode has not been downloaded, show a download button
-            if(location_image != null) {
-                download_button = new Gtk.Button.from_icon_name(location_image, Gtk.IconSize.BUTTON);
+            if (location_image != null) {
+                download_button = new Gtk.Button.from_icon_name (location_image, Gtk.IconSize.BUTTON);
                 download_button.expand = false;
                 download_button.relief = Gtk.ReliefStyle.NONE;
                 download_button.has_tooltip = true;
-                download_button.tooltip_text = _("Download Episode");
-                download_box.pack_start(download_button, false, false, 0);
+                download_button.tooltip_text = _ ("Download Episode");
+                download_box.pack_start (download_button, false, false, 0);
             }
-            
-            top_box.pack_start(unplayed_box, false, false, 0);
+
+            top_box.pack_start (unplayed_box, false, false, 0);
 
             // Set up the title and details labels
-            var label_box = new Gtk.Box(Gtk.Orientation.VERTICAL, 5);
+            var label_box = new Gtk.Box (Gtk.Orientation.VERTICAL, 5);
             label_box.margin = 0;
-            title_label = new Gtk.Label("<b>%s</b>".printf(GLib.Markup.escape_text(episode.title.replace("%27", "'").replace("&amp;", "&"))));
-            title_label.set_use_markup(true);
+            title_label = new Gtk.Label ("<b>%s</b>".printf (GLib.Markup.escape_text (episode.title.replace ("%27", "'").replace ("&amp;", "&"))));
+            title_label.set_use_markup (true);
             title_label.halign = Gtk.Align.START;
-            title_label.set_property("xalign", 0);
+            title_label.set_property ("xalign", 0);
             title_label.justify = Gtk.Justification.LEFT;
             title_label.wrap = true;
-            label_box.pack_start(title_label, true, true, 0);
-            
+            label_box.pack_start (title_label, true, true, 0);
+
             if (new_episodes_view) {
                 var name_label = new Gtk.Label (episode.parent.name);
                 name_label.halign = Gtk.Align.START;
@@ -164,34 +164,34 @@ namespace Vocal {
                 name_label.wrap = true;
                 label_box.pack_start (name_label, true, true, 0);
             }
-            
-            if(episode.datetime_released != null) {
-                release_label = new Gtk.Label(episode.datetime_released.format("%x"));
+
+            if (episode.datetime_released != null) {
+                release_label = new Gtk.Label (episode.datetime_released.format ("%x"));
             } else {
-                release_label = new Gtk.Label(episode.date_released);
+                release_label = new Gtk.Label (episode.date_released);
             }
             release_label.halign = Gtk.Align.START;
             release_label.justify = Gtk.Justification.LEFT;
             label_box.expand = false;
 
-            label_box.pack_start(release_label, true, true, 0);
-            top_box.pack_start(label_box, true, true, 0);
+            label_box.pack_start (release_label, true, true, 0);
+            top_box.pack_start (label_box, true, true, 0);
 
-            if(episode.current_download_status == DownloadStatus.DOWNLOADED)
-                hide_download_button();
+            if (episode.current_download_status == DownloadStatus.DOWNLOADED)
+                hide_download_button ();
 
             top_box_width = top_box.width_request;
 
-            string text = Utils.html_to_markup(episode.description);
+            string text = Utils.html_to_markup (episode.description);
 
             // Remove repeated whitespace from description before adding to label.
-            Regex condense_spaces = new Regex("\\s{2,}");
-            text = condense_spaces.replace(text, -1, 0, " ").strip();
+            Regex condense_spaces = new Regex ("\\s{2,}");
+            text = condense_spaces.replace (text, -1, 0, " ").strip ();
 
-            description_label = new Gtk.Label(text != "(null)" ? text : _("No description available."));
+            description_label = new Gtk.Label (text != " (null)" ? text : _ ("No description available."));
             description_label.justify = Gtk.Justification.LEFT;
-            description_label.set_use_markup(true);
-            description_label.set_ellipsize(Pango.EllipsizeMode.END);
+            description_label.set_use_markup (true);
+            description_label.set_ellipsize (Pango.EllipsizeMode.END);
             description_label.lines = 2;
             description_label.max_width_chars = 10;
             description_label.single_line_mode = true;
@@ -201,20 +201,20 @@ namespace Vocal {
                 description_label.margin_left = 25;
             }
 
-            description_label.set("xalign", 0);
+            description_label.set ("xalign", 0);
 
-            pack_end(description_label);
+            pack_end (description_label);
 
             // set the CSS
-            this.get_style_context().add_class("episode_detail_box");
+            this.get_style_context ().add_class ("episode_detail_box");
         }
 
         /*
          * Removes the now playing image from the box
          */
-        public void clear_now_playing() {
-            if(now_playing) {
-                unplayed_box.remove(now_playing_image);
+        public void clear_now_playing () {
+            if (now_playing) {
+                unplayed_box.remove (now_playing_image);
                 now_playing = false;
             }
         }
@@ -222,31 +222,31 @@ namespace Vocal {
         /*
          * Removes the download button from the box
          */
-        public void hide_download_button() {
-            download_button.set_no_show_all(true);
-            download_button.hide();
-            show_all();
+        public void hide_download_button () {
+            download_button.set_no_show_all (true);
+            download_button.hide ();
+            show_all ();
         }
 
         /*
          * Hides the streaming/playback button
          */
-        public void hide_playback_button() {
-            streaming_button.set_no_show_all(true);
-            streaming_button.hide();
+        public void hide_playback_button () {
+            streaming_button.set_no_show_all (true);
+            streaming_button.hide ();
         }
 
         /*
          * Mark this box as now playing (shows a special image on the left side of the box)
          */
-        public void mark_as_now_playing() {
+        public void mark_as_now_playing () {
 
-            if(unplayed) {
-                unplayed_box.remove(unplayed_image);
+            if (unplayed) {
+                unplayed_box.remove (unplayed_image);
                 unplayed = false;
             }
 
-            if(now_playing)
+            if (now_playing)
                 return;
 
             // It's possible that now_playing_image pointed to the unplayed icon before,
@@ -254,7 +254,7 @@ namespace Vocal {
 
             now_playing_image.icon_name = "media-playback-start-symbolic";
 
-            unplayed_box.pack_start(now_playing_image, false, false, 0);
+            unplayed_box.pack_start (now_playing_image, false, false, 0);
             now_playing = true;
 
         }
@@ -262,67 +262,67 @@ namespace Vocal {
         /*
          * Sets the episode's status and removes the unplayed image
          */
-        public void mark_as_played() {
-            if(unplayed) {
-                unplayed_box.remove(unplayed_image);
+        public void mark_as_played () {
+            if (unplayed) {
+                unplayed_box.remove (unplayed_image);
                 unplayed = false;
             }
-            show_all();
+            show_all ();
         }
 
-		/*
-		 * Sets the episode's status and shows the unplayed image
-		 */
-        public void mark_as_unplayed() {
+        /*
+         * Sets the episode's status and shows the unplayed image
+         */
+        public void mark_as_unplayed () {
 
-            if(!unplayed) {
+            if (!unplayed) {
                 unplayed = true;
 
-                if(now_playing) {
-                    unplayed_box.remove(now_playing_image);
+                if (now_playing) {
+                    unplayed_box.remove (now_playing_image);
                     now_playing = false;
                 }
 
-                unplayed_image = new Gtk.Image.from_icon_name("starred-symbolic", Gtk.IconSize.BUTTON);
-                unplayed_box.pack_start(unplayed_image, false, false, 0);
+                unplayed_image = new Gtk.Image.from_icon_name ("starred-symbolic", Gtk.IconSize.BUTTON);
+                unplayed_box.pack_start (unplayed_image, false, false, 0);
                 unplayed_image.valign = Gtk.Align.START;
 
-                show_all();
+                show_all ();
             }
         }
 
         /*
          * Shows the download button
          */
-        public void show_download_button() {
+        public void show_download_button () {
 
-            download_button.set_no_show_all(false);
-            download_button.show();
+            download_button.set_no_show_all (false);
+            download_button.show ();
         }
 
-		/*
-		 * Shows the play/streaming button
-		 */
-        public void show_playback_button() {
+        /*
+         * Shows the play/streaming button
+         */
+        public void show_playback_button () {
             string streaming_image;
-            if(episode.current_download_status == DownloadStatus.DOWNLOADED) {
-                streaming_image =  "media-playback-start-symbolic";
+            if (episode.current_download_status == DownloadStatus.DOWNLOADED) {
+                streaming_image = "media-playback-start-symbolic";
             } else {
-                streaming_image =  "network-wireless-signal-excellent-symbolic";
+                streaming_image = "network-wireless-signal-excellent-symbolic";
             }
 
-            Gtk.Image image = new Gtk.Image.from_icon_name(streaming_image, Gtk.IconSize.BUTTON);
-            streaming_button.set_image(image);
+            Gtk.Image image = new Gtk.Image.from_icon_name (streaming_image, Gtk.IconSize.BUTTON);
+            streaming_button.set_image (image);
 
-             if(episode.current_download_status == DownloadStatus.DOWNLOADED) {
-                streaming_button.tooltip_text = _("Play");
+             if (episode.current_download_status == DownloadStatus.DOWNLOADED) {
+                streaming_button.tooltip_text = _ ("Play");
 
             } else {
-                streaming_button.tooltip_text = _("Stream Episode");
+                streaming_button.tooltip_text = _ ("Stream Episode");
             }
 
-            streaming_button.set_no_show_all(false);
-            streaming_button.show();
+            streaming_button.set_no_show_all (false);
+            streaming_button.show ();
         }
     }
 }

--- a/src/Widgets/InternetArchiveUploadDialog.vala
+++ b/src/Widgets/InternetArchiveUploadDialog.vala
@@ -21,168 +21,168 @@ using Gtk;
 
 namespace Vocal {
 
-    public class InternetArchiveUploadDialog : Gtk.Dialog{
-        
+    public class InternetArchiveUploadDialog : Gtk.Dialog {
+
         /*
          * Constructor for a settings dialog given the current settings
          * and a parent window the set the dialog relative to
          */
         public InternetArchiveUploadDialog (Gtk.Window parent, Episode episode) {
-            
-            title = _("Upload to Internet Archive");
+
+            title = _ ("Upload to Internet Archive");
 
             get_header_bar ().get_style_context ().remove_class ("header-bar");
 
             this.modal = true;
-            this.set_transient_for(parent);
+            this.set_transient_for (parent);
             var content_box = get_content_area () as Gtk.Box;
             content_box.homogeneous = false;
             content_box.margin_left = 12;
             content_box.margin_right = 12;
-            
+
             var notebook = new Gtk.Notebook ();
             notebook.expand = true;
             notebook.show_tabs = false;
             notebook.show_border = false;
             content_box.add (notebook);
-            
+
             var edit_page = new Gtk.Box (Gtk.Orientation.VERTICAL, 0);
             var confirm_page = new Gtk.Box (Gtk.Orientation.VERTICAL, 0);
             var uploading_page = new Gtk.Box (Gtk.Orientation.VERTICAL, 0);
-            
+
             notebook.append_page (edit_page);
             notebook.append_page (confirm_page);
             notebook.append_page (uploading_page);
-            
-            var verify_label = new Gtk.Label (_("Please verify that the information below is correct before continuing."));
+
+            var verify_label = new Gtk.Label (_ ("Please verify that the information below is correct before continuing."));
             verify_label.wrap = true;
             verify_label.max_width_chars = 50;
             verify_label.get_style_context ().add_class ("h3");
             edit_page.pack_start (verify_label, false, false, 10);
-            
-            var episode_title_label = new Gtk.Label (_("Episode Title"));
+
+            var episode_title_label = new Gtk.Label (_ ("Episode Title"));
             episode_title_label.get_style_context ().add_class ("h4");
             episode_title_label.halign = Gtk.Align.START;
             var episode_title_entry = new Gtk.Entry ();
             episode_title_entry.text = episode.title;
-            
-            var podcast_name_label = new Gtk.Label (_("Podcast Name"));
+
+            var podcast_name_label = new Gtk.Label (_ ("Podcast Name"));
             podcast_name_label.get_style_context ().add_class ("h4");
             podcast_name_label.halign = Gtk.Align.START;
             var podcast_name_entry = new Gtk.Entry ();
             podcast_name_entry.text = episode.parent.name;
-            
-            var podcast_description_label = new Gtk.Label (_("Podcast Description"));
+
+            var podcast_description_label = new Gtk.Label (_ ("Podcast Description"));
             podcast_description_label.get_style_context ().add_class ("h4");
             podcast_description_label.halign = Gtk.Align.START;
             var podcast_description_entry = new Gtk.TextView ();
             podcast_description_entry.set_wrap_mode (Gtk.WrapMode.WORD);
             podcast_description_entry.buffer.text = episode.parent.description;
-            
+
             edit_page.pack_start (episode_title_label, false, false, 5);
             edit_page.pack_start (episode_title_entry, false, false, 0);
             edit_page.pack_start (podcast_name_label, false, false, 5);
             edit_page.pack_start (podcast_name_entry, false, false, 0);
             edit_page.pack_start (podcast_description_label, false, false, 5);
             edit_page.pack_start (podcast_description_entry, false, false, 0);
-            
-            var next_button = new Gtk.Button.with_label (_("Next…"));
+
+            var next_button = new Gtk.Button.with_label (_ ("Next…"));
             next_button.halign = Gtk.Align.END;
             next_button.get_style_context ().add_class ("suggested-action");
             edit_page.pack_end (next_button, false, false, 10);
             next_button.clicked.connect (() => {
                 notebook.next_page ();
             });
-            
-            var warning_label = new Gtk.Label (_("Legal warning: uploading copyrighted materials to the Internet Archvie is illegal. Please make sure you are uploading a copylefted (Creative Commons) episode that you are legally entitled to redistribute."));
+
+            var warning_label = new Gtk.Label (_ ("Legal warning: uploading copyrighted materials to the Internet Archvie is illegal. Please make sure you are uploading a copylefted (Creative Commons) episode that you are legally entitled to redistribute."));
             warning_label.wrap = true;
             warning_label.max_width_chars = 50;
             warning_label.get_style_context ().add_class ("h4");
-            
-            var upload_button = new Gtk.Button.with_label(_("Upload to the Internet Archive"));
+
+            var upload_button = new Gtk.Button.with_label (_ ("Upload to the Internet Archive"));
             upload_button.get_style_context ().add_class ("suggested-action");
-            
+
             confirm_page.pack_start (warning_label, false, false, 10);
             confirm_page.pack_end (upload_button, false, false, 10);
-            
-            var uploading_message = new Gtk.Label (_("Uploading episode…")); 
+
+            var uploading_message = new Gtk.Label (_ ("Uploading episode…"));
             uploading_message.get_style_context ().add_class ("h2");
-            
-            var thanks_message = new Gtk.Label (_("Thanks for contributing to the Internet Archive and the Podcast Archival Project"));
+
+            var thanks_message = new Gtk.Label (_ ("Thanks for contributing to the Internet Archive and the Podcast Archival Project"));
             thanks_message.wrap = true;
             thanks_message.justify = Gtk.Justification.CENTER;
             thanks_message.max_width_chars = 50;
             thanks_message.get_style_context ().add_class ("h3");
             thanks_message.set_no_show_all (true);
             thanks_message.hide ();
-            
+
             var spinner = new Gtk.Spinner ();
             spinner.active = true;
-            
+
             var upload_complete_image = new Gtk.Image.from_icon_name ("face-cool-symbolic", Gtk.IconSize.DIALOG);
             upload_complete_image.set_no_show_all (true);
             upload_complete_image.hide ();
-            
+
             uploading_page.pack_start (uploading_message, false, false, 10);
             uploading_page.pack_start (thanks_message, false, false, 10);
             uploading_page.pack_start (spinner, false, false, 25);
             uploading_page.pack_start (upload_complete_image, false, false, 25);
-            
-            var finish = new Gtk.Button.with_label (_("Finish"));
+
+            var finish = new Gtk.Button.with_label (_ ("Finish"));
             finish.get_style_context ().add_class ("suggested-action");
             finish.halign = Gtk.Align.END;
             uploading_page.pack_end (finish, false, false, 10);
-            finish.clicked.connect( () => {
+            finish.clicked.connect (() => {
                 this.destroy ();
             });
             finish.set_no_show_all (true);
             finish.hide ();
-            
+
             upload_button.clicked.connect (() => {
                 notebook.next_page ();
-                var loop = new MainLoop();
-                
+                var loop = new MainLoop ();
+
                 Utils.upload_to_internet_archive (episode.local_uri, episode_title_entry.text, podcast_name_entry.text, podcast_description_entry.buffer.text, (obj, res) => {
-                    bool success = Utils.upload_to_internet_archive.end(res);
+                    bool success = Utils.upload_to_internet_archive.end (res);
                     if (success) {
                         spinner.active = false;
                         spinner.set_no_show_all (true);
-                        spinner.hide();
-                        
+                        spinner.hide ();
+
                         upload_complete_image.set_no_show_all (false);
                         upload_complete_image.show ();
-                        uploading_message.set_text (_("Upload Complete"));
-                        
+                        uploading_message.set_text (_ ("Upload Complete"));
+
                         thanks_message.set_no_show_all (false);
                         thanks_message.show ();
-                        
+
                         finish.set_no_show_all (false);
                         finish.show ();
                     } else {
                         spinner.active = false;
                         spinner.set_no_show_all (true);
-                        spinner.hide();
-                        
+                        spinner.hide ();
+
                         upload_complete_image.set_no_show_all (false);
                         upload_complete_image.show ();
-                        uploading_message.set_text (_("Upload Failed"));
-                        
-                        thanks_message.set_text (_("Be sure to check your network connection and API keys, then try again later."));
+                        uploading_message.set_text (_ ("Upload Failed"));
+
+                        thanks_message.set_text (_ ("Be sure to check your network connection and API keys, then try again later."));
                         upload_complete_image.set_from_icon_name ("face-confused-symbolic", Gtk.IconSize.DIALOG);
-                        
+
                         thanks_message.set_no_show_all (false);
                         thanks_message.show ();
-                        
+
                         finish.set_no_show_all (false);
                         finish.show ();
                     }
                     loop.quit ();
                 });
 
-                loop.run();   
+                loop.run ();
             });
         }
-        
-        
+
+
     }
 }

--- a/src/Widgets/InternetArchiveUploadDialog.vala
+++ b/src/Widgets/InternetArchiveUploadDialog.vala
@@ -54,7 +54,9 @@ namespace Vocal {
             notebook.append_page (confirm_page);
             notebook.append_page (uploading_page);
 
-            var verify_label = new Gtk.Label (_ ("Please verify that the information below is correct before continuing."));
+            var verify_label = new Gtk.Label (
+                _ ("Please verify that the information below is correct before continuing.")
+            );
             verify_label.wrap = true;
             verify_label.max_width_chars = 50;
             verify_label.get_style_context ().add_class ("h3");
@@ -94,7 +96,9 @@ namespace Vocal {
                 notebook.next_page ();
             });
 
-            var warning_label = new Gtk.Label (_ ("Legal warning: uploading copyrighted materials to the Internet Archvie is illegal. Please make sure you are uploading a copylefted (Creative Commons) episode that you are legally entitled to redistribute."));
+            var warning_label = new Gtk.Label (
+                _ ("Legal warning: uploading copyrighted materials to the Internet Archvie is illegal. Please make sure you are uploading a copylefted (Creative Commons) episode that you are legally entitled to redistribute.")  // vala-lint=line-length
+            );
             warning_label.wrap = true;
             warning_label.max_width_chars = 50;
             warning_label.get_style_context ().add_class ("h4");
@@ -108,7 +112,9 @@ namespace Vocal {
             var uploading_message = new Gtk.Label (_ ("Uploading episode…"));
             uploading_message.get_style_context ().add_class ("h2");
 
-            var thanks_message = new Gtk.Label (_ ("Thanks for contributing to the Internet Archive and the Podcast Archival Project"));
+            var thanks_message = new Gtk.Label (
+                _ ("Thanks for contributing to the Internet Archive and the Podcast Archival Project")
+            );
             thanks_message.wrap = true;
             thanks_message.justify = Gtk.Justification.CENTER;
             thanks_message.max_width_chars = 50;
@@ -142,7 +148,7 @@ namespace Vocal {
                 notebook.next_page ();
                 var loop = new MainLoop ();
 
-                Utils.upload_to_internet_archive (episode.local_uri, episode_title_entry.text, podcast_name_entry.text, podcast_description_entry.buffer.text, (obj, res) => {
+                Utils.upload_to_internet_archive (episode.local_uri, episode_title_entry.text, podcast_name_entry.text, podcast_description_entry.buffer.text, (obj, res) => {  // vala-lint=line-length
                     bool success = Utils.upload_to_internet_archive.end (res);
                     if (success) {
                         spinner.active = false;
@@ -167,7 +173,9 @@ namespace Vocal {
                         upload_complete_image.show ();
                         uploading_message.set_text (_ ("Upload Failed"));
 
-                        thanks_message.set_text (_ ("Be sure to check your network connection and API keys, then try again later."));
+                        thanks_message.set_text (
+                            _ ("Be sure to check your network connection and API keys, then try again later.")
+                        );
                         upload_complete_image.set_from_icon_name ("face-confused-symbolic", Gtk.IconSize.DIALOG);
 
                         thanks_message.set_no_show_all (false);

--- a/src/Widgets/NewEpisodesView.vala
+++ b/src/Widgets/NewEpisodesView.vala
@@ -26,7 +26,7 @@ namespace Vocal {
 
         private Controller controller;
         private ListBox new_episodes_listbox;
-        GLib.ListStore episodeListModel = new GLib.ListStore ( typeof (Episode) );
+        GLib.ListStore episodeListModel = new GLib.ListStore ( typeof (Episode) );  // vala-lint=naming-convention
         public signal void go_back ();
         public signal void play_episode_requested (Episode episode);
         public signal void add_all_new_to_queue (GLib.List<Episode> episodes);

--- a/src/Widgets/NewEpisodesView.vala
+++ b/src/Widgets/NewEpisodesView.vala
@@ -27,53 +27,53 @@ namespace Vocal {
         private Controller controller;
         private ListBox new_episodes_listbox;
         GLib.ListStore episodeListModel = new GLib.ListStore ( typeof (Episode) );
-        public signal void go_back();
+        public signal void go_back ();
         public signal void play_episode_requested (Episode episode);
         public signal void add_all_new_to_queue (GLib.List<Episode> episodes);
-        
+
         public NewEpisodesView (Controller cont) {
             controller = cont;
-            
-            var toolbar = new Gtk.Box(Gtk.Orientation.HORIZONTAL, 0);
-            toolbar.get_style_context().add_class("toolbar");
-            toolbar.get_style_context().add_class("library-toolbar");
 
-            var go_back_button = new Gtk.Button.with_label(_("Your Podcasts"));
-            go_back_button.clicked.connect(() => { go_back(); });
-            go_back_button.get_style_context().add_class("back-button");
+            var toolbar = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 0);
+            toolbar.get_style_context ().add_class ("toolbar");
+            toolbar.get_style_context ().add_class ("library-toolbar");
+
+            var go_back_button = new Gtk.Button.with_label (_ ("Your Podcasts"));
+            go_back_button.clicked.connect (() => { go_back (); });
+            go_back_button.get_style_context ().add_class ("back-button");
             go_back_button.margin = 6;
-            
-            toolbar.pack_start(go_back_button, false, false, 0);
-            this.pack_start(toolbar, false, true, 0);
-            
-            var new_episodes_label = new Gtk.Label (_("New Episodes"));
+
+            toolbar.pack_start (go_back_button, false, false, 0);
+            this.pack_start (toolbar, false, true, 0);
+
+            var new_episodes_label = new Gtk.Label (_ ("New Episodes"));
             new_episodes_label.get_style_context ().add_class ("h2");
             new_episodes_label.margin_top = 12;
-            this.pack_start(new_episodes_label, false, true, 0);
-            
+            this.pack_start (new_episodes_label, false, true, 0);
+
             var new_episodes_scrolled = new Gtk.ScrolledWindow (null, null);
             new_episodes_scrolled.margin_left = 50;
             new_episodes_scrolled.margin_right = 50;
             new_episodes_listbox = new Gtk.ListBox ();
-            var add_all_to_queue_button = new Gtk.Button.with_label (_("Add all new episodes to the queue"));
+            var add_all_to_queue_button = new Gtk.Button.with_label (_ ("Add all new episodes to the queue"));
             add_all_to_queue_button.halign = Gtk.Align.CENTER;
-            add_all_to_queue_button.clicked.connect ( () => {
-                GLib.List<Episode> episodes = new GLib.List<Episode>();
+            add_all_to_queue_button.clicked.connect (() => {
+                GLib.List<Episode> episodes = new GLib.List<Episode> ();
                 for (int x = 0; ; x++) {
-                    var e = (Episode) episodeListModel.get_item(x);
+                    var e = (Episode) episodeListModel.get_item (x);
                     if (e == null) { break; } // No more items
-                    episodes.append(e);
+                    episodes.append (e);
                 }
-                add_all_new_to_queue(episodes);
+                add_all_new_to_queue (episodes);
             });
             this.orientation = Gtk.Orientation.VERTICAL;
-            
+
             new_episodes_scrolled.add (new_episodes_listbox);
             this.pack_start (new_episodes_scrolled, true, true, 15);
             this.pack_start (add_all_to_queue_button, false, false, 15);
             new_episodes_listbox.activate_on_single_click = false;
-            new_episodes_listbox.row_activated.connect(on_row_activated);
-            
+            new_episodes_listbox.row_activated.connect (on_row_activated);
+
         }
 
 
@@ -93,17 +93,17 @@ namespace Vocal {
                                     }
                                     return -1;
                                 }
-                                return  e2.datetime_released.compare(e1.datetime_released);
+                                return e2.datetime_released.compare (e1.datetime_released);
                         });
                     }
                 }
             }
 
-            GLib.Idle.add ( () => {
+            GLib.Idle.add (() => {
 
                 this.episodeListModel = elm;
-                new_episodes_listbox.bind_model(elm, (item) => {
-                        return  new EpisodeDetailBox( (Episode) item, controller, true);
+                new_episodes_listbox.bind_model (elm, (item) => {
+                        return new EpisodeDetailBox ((Episode) item, controller, true);
                 });
 
                 show_all ();
@@ -115,8 +115,8 @@ namespace Vocal {
 
         public void on_row_activated (Gtk.ListBoxRow row) {
             var index = row.get_index ();
-            info("Index: %d".printf(index));
-            Episode ep = (Episode) episodeListModel.get_item(index);
+            info ("Index: %d".printf (index));
+            Episode ep = (Episode) episodeListModel.get_item (index);
             play_episode_requested (ep);
         }
     }

--- a/src/Widgets/PlaybackBox.vala
+++ b/src/Widgets/PlaybackBox.vala
@@ -22,57 +22,56 @@ using Gtk;
 
 namespace Vocal {
     public class PlaybackBox : Gtk.VBox {
-        
-        public signal void scale_changed();		// Fired when the scale changes (when the user seeks position)
-    
-        public Gtk.Label 		info_label;
+
+        public signal void scale_changed ();        // Fired when the scale changes (when the user seeks position)
+
+        public Gtk.Label info_label;
         private Gtk.ProgressBar progress_bar;
-        private Gtk.Scale 		scale;
-        private Gtk.Grid 		scale_grid;
-        private Gtk.Label 		left_time;
-        private Gtk.Label 		right_time;
-   
+        private Gtk.Scale scale;
+        private Gtk.Grid scale_grid;
+        private Gtk.Label left_time;
+        private Gtk.Label right_time;
+
         /*
          * Default constructor for a PlaybackBox
          */
         public PlaybackBox () {
 
-            this.get_style_context().add_class("seek-bar");
-            
-            this.width_request  = 300;
-            this.info_label = new Gtk.Label(_("<b>Select an episode to start playing…</b>"));
-            this.info_label.set_use_markup(true);
-            this.info_label.width_chars = 20;
-            this.info_label.set_ellipsize(Pango.EllipsizeMode.END);
-            this.info_label.margin_top = 12;
+            this.get_style_context ().add_class ("seek-bar");
 
-            this.progress_bar = new Gtk.ProgressBar();
-            
+            this.width_request = 300;
+            this.info_label = new Gtk.Label (_ ("<b>Select an episode to start playing…</b>"));
+            this.info_label.set_use_markup (true);
+            this.info_label.width_chars = 20;
+            this.info_label.set_ellipsize (Pango.EllipsizeMode.END);
+            this.info_label.margin_top = 12;
+            this.progress_bar = new Gtk.ProgressBar ();
+
             scale = new Gtk.Scale.with_range (Gtk.Orientation.HORIZONTAL, 0, 1, 0.1);
-            scale.set_value(0.0);
+            scale.set_value (0.0);
             scale.hexpand = true;
             scale.draw_value = false;
             scale.get_style_context ().add_class ("seekbar");
             left_time = new Gtk.Label ("0:00");
             right_time = new Gtk.Label ("0:00");
-            
-            scale.change_value.connect(on_slide);
-                  
-            // Create the scale, and attach the time labels to the appropriate sides 
-                  
+
+            scale.change_value.connect (on_slide);
+
+            // Create the scale, and attach the time labels to the appropriate sides
+
             scale_grid = new Gtk.Grid ();
-            
+
             left_time.margin_right = right_time.margin_left = 3;
 
             scale_grid.attach (left_time, 0, 0, 1, 1);
             scale_grid.attach (scale, 1, 0, 1, 1);
             scale_grid.attach (right_time, 2, 0, 1, 1);
-            
+
             this.hexpand = false;
 
             // Add the components to the box
-            this.add(info_label);
-            this.add(scale_grid);
+            this.add (info_label);
+            this.add (scale_grid);
         }
 
         public override void get_preferred_width (out int minimum_width, out int natural_width) {
@@ -82,108 +81,108 @@ namespace Vocal {
                 natural_width = 600;
             }
         }
-        
+
         /*
          * Returns the percentage that the progress bar has been filled
          */
-        public double get_progress_bar_fill() {
-            return scale.get_value();
+        public double get_progress_bar_fill () {
+            return scale.get_value ();
         }
-        
+
         /*
          * Called when the user slides the slider in order to change position in the stream
          */
-        private bool on_slide(ScrollType scroll, double new_value) {
-            scale.set_value(new_value);
-            scale_changed();
+        private bool on_slide (ScrollType scroll, double new_value) {
+            scale.set_value (new_value);
+            scale_changed ();
             return false;
         }
-        
+
         /*
          * Sets the information for the current episode
          */
-        public void set_info_title(string episode, string podcast_name) {
-            this.info_label.set_text("<b>" + GLib.Markup.escape_text(episode) + "</b>" + " from " + "<b><i>" + GLib.Markup.escape_text(podcast_name) + "</i></b>");
-            this.info_label.set_use_markup(true);
+        public void set_info_title (string episode, string podcast_name) {
+            this.info_label.set_text ("<b>" + GLib.Markup.escape_text (episode) + "</b>" + " from " + "<b><i>" + GLib.Markup.escape_text (podcast_name) + "</i></b>");
+            this.info_label.set_use_markup (true);
         }
-        
+
         /*
- 		 * Sets the message on the info label
- 		 */
-        public void set_message(string message) {
-        
+          * Sets the message on the info label
+          */
+        public void set_message (string message) {
+
             // Hide the left and right time
-            this.left_time.set_no_show_all(true);
-            left_time.hide();
-            
-            this.right_time.set_no_show_all(true);
-            right_time.hide();
-            
-            this.scale.set_no_show_all(true);
-            scale.hide();
-            
-            this.info_label.set_text(message);
-            this.info_label.set_use_markup(true);
-             
+            this.left_time.set_no_show_all (true);
+            left_time.hide ();
+
+            this.right_time.set_no_show_all (true);
+            right_time.hide ();
+
+            this.scale.set_no_show_all (true);
+            scale.hide ();
+
+            this.info_label.set_text (message);
+            this.info_label.set_use_markup (true);
+
         }
-        
-		/*
-		 * Sets both the message and the percentage
-		 */
-        public void set_message_and_percentage(string message, double? new_value = -1) {
-        
+
+        /*
+         * Sets both the message and the percentage
+         */
+        public void set_message_and_percentage (string message, double? new_value = -1) {
+
             // Hide the left and right time
-            this.left_time.set_no_show_all(true);
-            left_time.hide();
-            
-            this.right_time.set_no_show_all(true);
-            right_time.hide();
-            
+            this.left_time.set_no_show_all (true);
+            left_time.hide ();
+
+            this.right_time.set_no_show_all (true);
+            right_time.hide ();
+
             // Set the message
-            this.info_label.set_text(message);
-            this.info_label.set_use_markup(true);
-            
+            this.info_label.set_text (message);
+            this.info_label.set_use_markup (true);
+
             // Set the progress percentage
-            if(new_value != -1) {
-                scale.set_value(new_value);
+            if (new_value != -1) {
+                scale.set_value (new_value);
             }
         }
-        
+
         /*
          * Sets the progress information for the current stream to be displayed
          */
-        public void set_progress(double progress, int mins_remaining, int secs_remaining, int mins_elapsed, int secs_elapsed) {
-            
-            scale.set_value(progress);
-            
+        public void set_progress (double progress, int mins_remaining, int secs_remaining, int mins_elapsed, int secs_elapsed) {
+
+            scale.set_value (progress);
+
             // Set the labels on either side of the scale
-            if(mins_remaining > 59) {
+            if (mins_remaining > 59) {
                 int hours_remaining = mins_remaining / 60;
                 mins_remaining = mins_remaining % 60;
-                right_time.set_text("%02d:%02d:%02d".printf(hours_remaining, mins_remaining, secs_remaining));
+                right_time.set_text ("%02d:%02d:%02d".printf (hours_remaining, mins_remaining, secs_remaining));
             }
             else {
-                right_time.set_text("%02d:%02d".printf(mins_remaining, secs_remaining));
+                right_time.set_text ("%02d:%02d".printf (mins_remaining, secs_remaining));
             }
-            
-            if(mins_elapsed > 59) {
+
+            if (mins_elapsed > 59) {
                 int hours_elapsed = mins_elapsed / 60;
                 mins_elapsed = mins_elapsed % 60;
-                left_time.set_text("%02d:%02d:%02d".printf(hours_elapsed, mins_elapsed, secs_elapsed));
+                left_time.set_text ("%02d:%02d:%02d".printf (hours_elapsed, mins_elapsed, secs_elapsed));
             }
             else {
-                left_time.set_text("%02d:%02d".printf(mins_elapsed, secs_elapsed));
+                left_time.set_text ("%02d:%02d".printf (mins_elapsed, secs_elapsed));
             }
-            
+
             // Show the left and right labels
-            this.left_time.set_no_show_all(false);
-            left_time.show();
-            
-            this.right_time.set_no_show_all(false);
-            right_time.show();
-            
-            this.scale.set_no_show_all(false);
-            scale.show();
+            this.left_time.set_no_show_all (false);
+            left_time.show ();
+
+            this.right_time.set_no_show_all (false);
+            right_time.show ();
+
+            this.scale.set_no_show_all (false);
+            scale.show ();
         }
     }
 }

--- a/src/Widgets/PlaybackBox.vala
+++ b/src/Widgets/PlaybackBox.vala
@@ -102,7 +102,15 @@ namespace Vocal {
          * Sets the information for the current episode
          */
         public void set_info_title (string episode, string podcast_name) {
-            this.info_label.set_text ("<b>" + GLib.Markup.escape_text (episode) + "</b>" + " from " + "<b><i>" + GLib.Markup.escape_text (podcast_name) + "</i></b>");
+            this.info_label.set_text (
+                "<b>"
+                + GLib.Markup.escape_text (episode)
+                + "</b>"
+                + " from "
+                + "<b><i>"
+                + GLib.Markup.escape_text (podcast_name)
+                + "</i></b>"
+            );
             this.info_label.set_use_markup (true);
         }
 
@@ -151,7 +159,13 @@ namespace Vocal {
         /*
          * Sets the progress information for the current stream to be displayed
          */
-        public void set_progress (double progress, int mins_remaining, int secs_remaining, int mins_elapsed, int secs_elapsed) {
+        public void set_progress (
+            double progress,
+            int mins_remaining,
+            int secs_remaining,
+            int mins_elapsed,
+            int secs_elapsed
+        ) {
 
             scale.set_value (progress);
 

--- a/src/Widgets/PodcastView.vala
+++ b/src/Widgets/PodcastView.vala
@@ -26,20 +26,20 @@ namespace Vocal {
 
         /* Signals */
 
-    	public signal void play_episode_requested(Episode e);
-        public signal void enqueue_episode(Episode episode);
-    	public signal void download_episode_requested(Episode episode);
-        public signal void delete_local_episode_requested(Episode episode);
-        public signal void mark_all_episodes_as_played_requested();
-        public signal void mark_episode_as_played_requested(Episode episode);
-        public signal void mark_episode_as_unplayed_requested(Episode episode);
-    	public signal void pane_should_hide();
-        public signal void download_all_requested();
-        public signal void delete_podcast_requested();
-        public signal void unplayed_count_changed(int n);
-        public signal void go_back();
-        
-        public signal void new_cover_art_set(string path);
+        public signal void play_episode_requested (Episode e);
+        public signal void enqueue_episode (Episode episode);
+        public signal void download_episode_requested (Episode episode);
+        public signal void delete_local_episode_requested (Episode episode);
+        public signal void mark_all_episodes_as_played_requested ();
+        public signal void mark_episode_as_played_requested (Episode episode);
+        public signal void mark_episode_as_unplayed_requested (Episode episode);
+        public signal void pane_should_hide ();
+        public signal void download_all_requested ();
+        public signal void delete_podcast_requested ();
+        public signal void unplayed_count_changed (int n);
+        public signal void go_back ();
+
+        public signal void new_cover_art_set (string path);
 
 
         public Podcast podcast;
@@ -57,46 +57,46 @@ namespace Vocal {
 
         private Gtk.Menu right_click_menu;
 
-		public  Gee.ArrayList<EpisodeDetailBox> boxes;
-		private EpisodeDetailBox previously_selected_box;
+        public Gee.ArrayList<EpisodeDetailBox> boxes;
+        private EpisodeDetailBox previously_selected_box;
         private EpisodeDetailBox previously_activated_box;
-		private Gtk.ScrolledWindow scrolled;
-		private int largest_box_size;
-		public  int unplayed_count;
+        private Gtk.ScrolledWindow scrolled;
+        private int largest_box_size;
+        public int unplayed_count;
 
-		private Gtk.Box image_box;
-		private Gtk.Box details_box;
-		private Gtk.Box actions_box;
-		private Gtk.Box label_box;
+        private Gtk.Box image_box;
+        private Gtk.Box details_box;
+        private Gtk.Box actions_box;
+        private Gtk.Box label_box;
 
-		private Gtk.Image image = null;
+        private Gtk.Image image = null;
         public Shownotes shownotes;
-        
+
         private Gtk.Box show_more_episodes_box;
         private Gtk.Image cc_image;
 
-		/*
-		 * Constructor for a Sidepane given a parent window and pocast
-		 */
+        /*
+         * Constructor for a Sidepane given a parent window and pocast
+         */
         public PodcastView (Controller controller) {
             this.controller = controller;
 
             largest_box_size = 500;
 
-			this.orientation = Gtk.Orientation.VERTICAL;
-            var horizontal_box = new Gtk.Box(Gtk.Orientation.HORIZONTAL, 0);
+            this.orientation = Gtk.Orientation.VERTICAL;
+            var horizontal_box = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 0);
 
-			count_string = null;
+            count_string = null;
 
-            var toolbar = new Gtk.Box(Gtk.Orientation.HORIZONTAL, 0);
-            toolbar.get_style_context().add_class("toolbar");
-            toolbar.get_style_context().add_class("library-toolbar");
+            var toolbar = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 0);
+            toolbar.get_style_context ().add_class ("toolbar");
+            toolbar.get_style_context ().add_class ("library-toolbar");
 
-            var go_back_button = new Gtk.Button.with_label(_("Your Podcasts"));
-            go_back_button.clicked.connect(() => { go_back(); });
-            go_back_button.get_style_context().add_class("back-button");
+            var go_back_button = new Gtk.Button.with_label (_ ("Your Podcasts"));
+            go_back_button.clicked.connect (() => { go_back (); });
+            go_back_button.get_style_context ().add_class ("back-button");
             go_back_button.margin = 6;
-            
+
             string newest_icon_name = null;
             if (controller.settings.newest_episodes_first) {
                 newest_icon_name = "view-sort-ascending-symbolic";
@@ -106,252 +106,252 @@ namespace Vocal {
             var newest_episodes_first_button = new Gtk.Button.from_icon_name (newest_icon_name, Gtk.IconSize.MENU);
             newest_episodes_first_button.margin = 6;
             if (controller.settings.newest_episodes_first) {
-                newest_episodes_first_button.tooltip_text = _("Show newer episodes at the top of the list");
+                newest_episodes_first_button.tooltip_text = _ ("Show newer episodes at the top of the list");
             } else {
-                newest_episodes_first_button.tooltip_text = _("Show older episodes at the top of the list");
+                newest_episodes_first_button.tooltip_text = _ ("Show older episodes at the top of the list");
             }
-            newest_episodes_first_button.clicked.connect ( () => {
+            newest_episodes_first_button.clicked.connect (() => {
                 if (controller.settings.newest_episodes_first) {
                     controller.settings.newest_episodes_first = false;
                     var image = new Gtk.Image.from_icon_name ("view-sort-descending-symbolic", Gtk.IconSize.MENU);
                     newest_episodes_first_button.image = image;
-                    newest_episodes_first_button.tooltip_text = _("Show older episodes at the top of the list");
+                    newest_episodes_first_button.tooltip_text = _ ("Show older episodes at the top of the list");
                 } else {
                     controller.settings.newest_episodes_first = true;
                     var image = new Gtk.Image.from_icon_name ("view-sort-ascending-symbolic", Gtk.IconSize.MENU);
                     newest_episodes_first_button.image = image;
-                    newest_episodes_first_button.tooltip_text = _("Show newer episodes at the top of the list");
+                    newest_episodes_first_button.tooltip_text = _ ("Show newer episodes at the top of the list");
                 }
-                
+
                 reset_episode_list ();
                 populate_episodes ();
             });
 
-            var add_unplayed_to_queue = new Gtk.Button.with_label(_("Add New Episodes to Queue"));
+            var add_unplayed_to_queue = new Gtk.Button.with_label (_ ("Add New Episodes to Queue"));
             add_unplayed_to_queue.margin = 6;
-            add_unplayed_to_queue.clicked.connect ( () => {
+            add_unplayed_to_queue.clicked.connect (() => {
                 foreach (EpisodeDetailBox b in boxes) {
                     if (b.episode.status == EpisodeStatus.UNPLAYED) {
                         enqueue_episode (b.episode);
                     }
                 }
             });
-            
-            var download_all = new Gtk.Button.from_icon_name(Utils.check_elementary() ? "browser-download-symbolic" : "document-save-symbolic", Gtk.IconSize.MENU);
+
+            var download_all = new Gtk.Button.from_icon_name (Utils.check_elementary () ? "browser-download-symbolic" : "document-save-symbolic", Gtk.IconSize.MENU);
             download_all.margin = 6;
-            download_all.tooltip_text = _("Download all episodes");
-            download_all.clicked.connect(() => {
-                download_all_requested();
+            download_all.tooltip_text = _ ("Download all episodes");
+            download_all.clicked.connect (() => {
+                download_all_requested ();
             });
-            
-            var mark_as_played = new Gtk.Button.with_label(_("Mark All Played"));
-            mark_as_played.clicked.connect(() => {
-                mark_all_episodes_as_played_requested();
+
+            var mark_as_played = new Gtk.Button.with_label (_ ("Mark All Played"));
+            mark_as_played.clicked.connect (() => {
+                mark_all_episodes_as_played_requested ();
             });
             mark_as_played.margin = 6;
-            
-            toolbar.pack_start(go_back_button, false, false, 0);
-            toolbar.pack_end(mark_as_played, false, false, 0);
+
+            toolbar.pack_start (go_back_button, false, false, 0);
+            toolbar.pack_end (mark_as_played, false, false, 0);
             toolbar.pack_end (add_unplayed_to_queue, false, false, 0);
             toolbar.pack_end (newest_episodes_first_button, false, false, 0);
             toolbar.pack_end (download_all, false, false, 0);
-            this.pack_start(toolbar, false, true, 0);
+            this.pack_start (toolbar, false, true, 0);
 
-            var edit = new Gtk.Button.from_icon_name(Utils.check_elementary() ? "edit-symbolic" : "document-properties-symbolic",Gtk.IconSize.MENU);
-            edit.tooltip_text = _("Edit podcast details");
-            edit.button_press_event.connect((e) => {
-                var edit_menu = new Gtk.Menu();
-                var change_cover_art_item = new Gtk.MenuItem.with_label(_("Select different cover art"));
-                var creative_commons_override_button = new Gtk.MenuItem.with_label (_("Set podcast license to Creative Commons"));
-                change_cover_art_item.activate.connect(on_change_album_art);
+            var edit = new Gtk.Button.from_icon_name (Utils.check_elementary () ? "edit-symbolic" : "document-properties-symbolic",Gtk.IconSize.MENU);
+            edit.tooltip_text = _ ("Edit podcast details");
+            edit.button_press_event.connect ((e) => {
+                var edit_menu = new Gtk.Menu ();
+                var change_cover_art_item = new Gtk.MenuItem.with_label (_ ("Select different cover art"));
+                var creative_commons_override_button = new Gtk.MenuItem.with_label (_ ("Set podcast license to Creative Commons"));
+                change_cover_art_item.activate.connect (on_change_album_art);
                 creative_commons_override_button.activate.connect (on_creative_commons_override);
-                edit_menu.add(change_cover_art_item);
+                edit_menu.add (change_cover_art_item);
                 edit_menu.add (creative_commons_override_button);
-                edit_menu.attach_to_widget(edit, null);
-                edit_menu.show_all();
-                edit_menu.popup(null, null, null, e.button, e.time);
+                edit_menu.attach_to_widget (edit, null);
+                edit_menu.show_all ();
+                edit_menu.popup (null, null, null, e.button, e.time);
                 return true;
             });
 
-            var remove = new Gtk.Button.with_label(_("Unsubscribe"));
+            var remove = new Gtk.Button.with_label (_ ("Unsubscribe"));
             remove.clicked.connect (() => {
-               delete_podcast_requested();
+               delete_podcast_requested ();
             });
-            remove.set_no_show_all(false);
-            remove.get_style_context().add_class("destructive-action");
-            remove.show();
+            remove.set_no_show_all (false);
+            remove.get_style_context ().add_class ("destructive-action");
+            remove.show ();
 
-            image_box = new Gtk.Box(Gtk.Orientation.HORIZONTAL, 0);
-            
+            image_box = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 0);
 
-            details_box = new Gtk.Box(Gtk.Orientation.VERTICAL, 0);
-            actions_box = new Gtk.Box(Gtk.Orientation.HORIZONTAL, 2);
-            label_box = new Gtk.Box(Gtk.Orientation.VERTICAL, 0);
 
-			name_label = new Gtk.Label("Name");
-			count_label = new Gtk.Label(count_string);
-			name_label.max_width_chars = 15;
-			name_label.wrap = true;
-			name_label.justify = Gtk.Justification.CENTER;
+            details_box = new Gtk.Box (Gtk.Orientation.VERTICAL, 0);
+            actions_box = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 2);
+            label_box = new Gtk.Box (Gtk.Orientation.VERTICAL, 0);
+
+            name_label = new Gtk.Label ("Name");
+            count_label = new Gtk.Label (count_string);
+            name_label.max_width_chars = 15;
+            name_label.wrap = true;
+            name_label.justify = Gtk.Justification.CENTER;
             name_label.margin_bottom = 15;
 
-            description_label = new Gtk.Label("Description");
+            description_label = new Gtk.Label ("Description");
             description_label.max_width_chars = 15;
             description_label.wrap = true;
             description_label.wrap_mode = Pango.WrapMode.WORD;
             description_label.valign = Gtk.Align.START;
-            description_label.get_style_context().add_class("podcast-view-description");
+            description_label.get_style_context ().add_class ("podcast-view-description");
 
             // Set up a scrolled window
-            var description_window = new Gtk.ScrolledWindow(null, null);
-            description_window.add(description_label);
+            var description_window = new Gtk.ScrolledWindow (null, null);
+            description_window.add (description_label);
             description_window.height_request = 130;
             description_window.hscrollbar_policy = Gtk.PolicyType.NEVER;
 
-			name_label.get_style_context().add_class("h2");
-            count_label.get_style_context().add_class("h4");
+            name_label.get_style_context ().add_class ("h2");
+            count_label.get_style_context ().add_class ("h4");
 
-			label_box.pack_start(name_label, false, false, 5);
-            label_box.pack_start(description_window, true, true, 0);
+            label_box.pack_start (name_label, false, false, 5);
+            label_box.pack_start (description_window, true, true, 0);
 
-			label_box.pack_start(count_label, false, false, 0);
-			
-			            
+            label_box.pack_start (count_label, false, false, 0);
+
+
             // Creative commons
             // Load the album artwork
             var ccicon_name = "";
-            if (Gtk.Settings.get_default().gtk_application_prefer_dark_theme == true) {
+            if (Gtk.Settings.get_default ().gtk_application_prefer_dark_theme == true) {
                 ccicon_name = "/com/github/needleandthread/vocal/creativecommons-light.png";
             } else {
                 ccicon_name = "/com/github/needleandthread/vocal/creativecommons-dark.png";
             }
-            var cc_pb = new Gdk.Pixbuf.from_resource_at_scale(ccicon_name, 151, 36, true);
+            var cc_pb = new Gdk.Pixbuf.from_resource_at_scale (ccicon_name, 151, 36, true);
             cc_image = new Gtk.Image.from_pixbuf (cc_pb);
             cc_image.margin = 12;
             cc_image.expand = false;
             cc_image.pixel_size = 32;
-            
+
             label_box.pack_start (cc_image, false, false, 0);
 
-            actions_box.pack_start(edit, true, true, 0);
-            actions_box.pack_start(remove, true, true, 0);
+            actions_box.pack_start (edit, true, true, 0);
+            actions_box.pack_start (remove, true, true, 0);
 
-            var vertical_box = new Gtk.Box(Gtk.Orientation.VERTICAL, 5);
-            vertical_box.pack_start(label_box, true, true, 0);
-            vertical_box.pack_start(actions_box, false, false, 0);
+            var vertical_box = new Gtk.Box (Gtk.Orientation.VERTICAL, 5);
+            vertical_box.pack_start (label_box, true, true, 0);
+            vertical_box.pack_start (actions_box, false, false, 0);
             vertical_box.margin = 12;
             vertical_box.margin_bottom = 0;
 
-            details_box.pack_start(vertical_box, true, true, 12);
-			details_box.pack_start(image_box, false, false, 0);
+            details_box.pack_start (vertical_box, true, true, 12);
+            details_box.pack_start (image_box, false, false, 0);
             details_box.valign = Gtk.Align.FILL;
             details_box.hexpand = false;
             details_box.margin = 0;
 
-			horizontal_box.pack_start(details_box, false, true, 0);
+            horizontal_box.pack_start (details_box, false, true, 0);
 
-			var separator = new Gtk.Separator (Gtk.Orientation.VERTICAL);
-			separator.margin = 0;
-			horizontal_box.pack_start(separator, false, false, 0);
+            var separator = new Gtk.Separator (Gtk.Orientation.VERTICAL);
+            separator.margin = 0;
+            horizontal_box.pack_start (separator, false, false, 0);
 
-			paned = new Gtk.Paned(Gtk.Orientation.HORIZONTAL);
-			paned.expand = true;
-			horizontal_box.pack_start(paned, true, true, 0);
+            paned = new Gtk.Paned (Gtk.Orientation.HORIZONTAL);
+            paned.expand = true;
+            horizontal_box.pack_start (paned, true, true, 0);
 
-			shownotes = new Shownotes();
-            shownotes.play_button.clicked.connect(() => { play_episode_requested(null); });
-            shownotes.queue_button.clicked.connect(() => { enqueue_episode_internal(); });
-            shownotes.download_button.clicked.connect(() => { download_episode_requested_internal(); });
-            shownotes.mark_as_played_button.clicked.connect(() => { mark_episode_as_played_requested_internal(); });
-            shownotes.mark_as_new_button.clicked.connect(() => { mark_episode_as_new_requested_internal(); });
-            shownotes.internet_archive_upload_requested.connect (() => { 
+            shownotes = new Shownotes ();
+            shownotes.play_button.clicked.connect (() => { play_episode_requested (null); });
+            shownotes.queue_button.clicked.connect (() => { enqueue_episode_internal (); });
+            shownotes.download_button.clicked.connect (() => { download_episode_requested_internal (); });
+            shownotes.mark_as_played_button.clicked.connect (() => { mark_episode_as_played_requested_internal (); });
+            shownotes.mark_as_new_button.clicked.connect (() => { mark_episode_as_new_requested_internal (); });
+            shownotes.internet_archive_upload_requested.connect (() => {
                 var settings = VocalSettings.get_default_instance ();
                 if (settings.archive_access_key.length < 1 || settings.archive_secret_key.length < 1) {
-                    Gtk.MessageDialog msg = new Gtk.MessageDialog (controller.window, Gtk.DialogFlags.MODAL, Gtk.MessageType.WARNING, Gtk.ButtonsType.OK, _("Before you can upload to the Internet Archive you must add your archive.org account's API keys. Visit https://archive.org/account/s3.php to see your keys, then paste them in the settings."));
-                    
-                    var image = new Gtk.Image.from_icon_name("dialog-warning", Gtk.IconSize.DIALOG);
+                    Gtk.MessageDialog msg = new Gtk.MessageDialog (controller.window, Gtk.DialogFlags.MODAL, Gtk.MessageType.WARNING, Gtk.ButtonsType.OK, _ ("Before you can upload to the Internet Archive you must add your archive.org account's API keys. Visit https://archive.org/account/s3.php to see your keys, then paste them in the settings."));
+
+                    var image = new Gtk.Image.from_icon_name ("dialog-warning", Gtk.IconSize.DIALOG);
                     msg.image = image;
-                    msg.image.show_all();
+                    msg.image.show_all ();
 
                     msg.response.connect ((response_id) => {
-			            msg.destroy();
-		            });
-		            msg.show ();
+                        msg.destroy ();
+                    });
+                    msg.show ();
                 } else if (current_episode.current_download_status == DownloadStatus.DOWNLOADED) {
-                
+
                     var internet_archive_dialog = new InternetArchiveUploadDialog (controller.window, current_episode);
                     internet_archive_dialog.show_all ();
-                    
+
                 } else {
-                
-                    Gtk.MessageDialog msg = new Gtk.MessageDialog (controller.window, Gtk.DialogFlags.MODAL, Gtk.MessageType.WARNING, Gtk.ButtonsType.YES_NO, _("You must download this episode first before uploading to the Internet Archive. Would you like to download this episode?"));
-                    
-                    var image = new Gtk.Image.from_icon_name("dialog-question", Gtk.IconSize.DIALOG);
+
+                    Gtk.MessageDialog msg = new Gtk.MessageDialog (controller.window, Gtk.DialogFlags.MODAL, Gtk.MessageType.WARNING, Gtk.ButtonsType.YES_NO, _ ("You must download this episode first before uploading to the Internet Archive. Would you like to download this episode?"));
+
+                    var image = new Gtk.Image.from_icon_name ("dialog-question", Gtk.IconSize.DIALOG);
                     msg.image = image;
-                    msg.image.show_all();
+                    msg.image.show_all ();
 
-			        msg.response.connect ((response_id) => {
-			            switch (response_id) {
-				            case Gtk.ResponseType.YES:
-                                download_episode_requested(current_episode);
-					            break;
-				            case Gtk.ResponseType.NO:
-					            break;
-			            }
+                    msg.response.connect ((response_id) => {
+                        switch (response_id) {
+                            case Gtk.ResponseType.YES:
+                                download_episode_requested (current_episode);
+                                break;
+                            case Gtk.ResponseType.NO:
+                                break;
+                        }
 
-			            msg.destroy();
-		            });
-		            msg.show ();
-	            }
+                        msg.destroy ();
+                    });
+                    msg.show ();
+                }
             });
 
-            shownotes.copy_shareable_link.connect(on_copy_shareable_link);
-            shownotes.send_tweet.connect(on_tweet);
-            shownotes.copy_direct_link.connect(on_link_to_file);
+            shownotes.copy_shareable_link.connect (on_copy_shareable_link);
+            shownotes.send_tweet.connect (on_tweet);
+            shownotes.copy_direct_link.connect (on_link_to_file);
 
-            paned.pack2(shownotes, true, true);
+            paned.pack2 (shownotes, true, true);
 
-            boxes = new Gee.ArrayList<EpisodeDetailBox>();
+            boxes = new Gee.ArrayList<EpisodeDetailBox> ();
             scrolled = new Gtk.ScrolledWindow (null, null);
 
-            listbox = new Gtk.ListBox();
-            listbox.button_press_event.connect(on_button_press_event);
-            listbox.row_selected.connect(on_row_selected);
-            listbox.row_activated.connect(on_row_activated);
+            listbox = new Gtk.ListBox ();
+            listbox.button_press_event.connect (on_button_press_event);
+            listbox.row_selected.connect (on_row_selected);
+            listbox.row_activated.connect (on_row_activated);
             listbox.activate_on_single_click = false;
             listbox.selection_mode = Gtk.SelectionMode.MULTIPLE;
             listbox.expand = true;
-            listbox.get_style_context().add_class("sidepane_listbox");
-            listbox.get_style_context().add_class("view");
+            listbox.get_style_context ().add_class ("sidepane_listbox");
+            listbox.get_style_context ().add_class ("view");
 
-            show_more_episodes_box = new Gtk.Box(Gtk.Orientation.VERTICAL, 0);
-            show_more_episodes_box.pack_start(listbox, true, true, 0);
+            show_more_episodes_box = new Gtk.Box (Gtk.Orientation.VERTICAL, 0);
+            show_more_episodes_box.pack_start (listbox, true, true, 0);
 
-            scrolled.add(show_more_episodes_box);
-            
-            paned.pack1(scrolled, true, true);
+            scrolled.add (show_more_episodes_box);
 
-            this.pack_start(horizontal_box, true, true, 0);
+            paned.pack1 (scrolled, true, true);
+
+            this.pack_start (horizontal_box, true, true, 0);
         }
 
         // Convenience method for triggering the signal
-        private void download_episode_requested_internal() {
-            download_episode_requested(current_episode);
+        private void download_episode_requested_internal () {
+            download_episode_requested (current_episode);
         }
 
-        private void enqueue_episode_internal() {
-            enqueue_episode(current_episode);
+        private void enqueue_episode_internal () {
+            enqueue_episode (current_episode);
         }
 
-        private void mark_episode_as_played_requested_internal() {
-            if(current_episode.status != EpisodeStatus.PLAYED) {
+        private void mark_episode_as_played_requested_internal () {
+            if (current_episode.status != EpisodeStatus.PLAYED) {
                 unplayed_count--;
-                set_unplayed_text();
+                set_unplayed_text ();
 
-                Gtk.ListBoxRow selected_row = listbox.get_selected_row();
-                boxes[selected_row.get_index()].mark_as_played();
+                Gtk.ListBoxRow selected_row = listbox.get_selected_row ();
+                boxes[selected_row.get_index ()].mark_as_played ();
 
-                mark_episode_as_played_requested(current_episode);
+                mark_episode_as_played_requested (current_episode);
             }
 
             if (shownotes.episode != null && current_episode == shownotes.episode) {
@@ -359,13 +359,13 @@ namespace Vocal {
             }
         }
 
-        private void mark_episode_as_new_requested_internal() {
-            if(current_episode.status != EpisodeStatus.UNPLAYED) {
+        private void mark_episode_as_new_requested_internal () {
+            if (current_episode.status != EpisodeStatus.UNPLAYED) {
                 unplayed_count++;
-                set_unplayed_text();
+                set_unplayed_text ();
 
-                Gtk.ListBoxRow selected_row = listbox.get_selected_row();
-                boxes[selected_row.get_index()].mark_as_unplayed();
+                Gtk.ListBoxRow selected_row = listbox.get_selected_row ();
+                boxes[selected_row.get_index ()].mark_as_unplayed ();
 
                 mark_episode_as_unplayed_requested (current_episode);
             }
@@ -378,11 +378,11 @@ namespace Vocal {
         /*
          * Gets an episode's corresponding box index in the list of EpisodeDetailBoxes
          */
-        public int get_box_index_from_episode(Episode e) {
+        public int get_box_index_from_episode (Episode e) {
 
             int index = 0;
-            foreach(EpisodeDetailBox b in boxes) {
-                if(b.episode == e) {
+            foreach (EpisodeDetailBox b in boxes) {
+                if (b.episode == e) {
                     return index;
                 } else {
                     index++;
@@ -395,81 +395,81 @@ namespace Vocal {
         /*
          * Marks each episode detail box in the list as played
          */
-        public void mark_all_played() {
-            foreach(EpisodeDetailBox b in boxes) {
-                b.mark_as_played();
+        public void mark_all_played () {
+            foreach (EpisodeDetailBox b in boxes) {
+                b.mark_as_played ();
             }
         }
 
-		/*
-		 * Handler for when a box has a button press event
-		 */
-        private bool on_button_press_event(Gdk.EventButton e) {
-            if(e.button == 3 && podcast.episodes.size > 0) {
+        /*
+         * Handler for when a box has a button press event
+         */
+        private bool on_button_press_event (Gdk.EventButton e) {
+            if (e.button == 3 && podcast.episodes.size > 0) {
 
-                GLib.List<weak ListBoxRow> selected_rows = listbox.get_selected_rows();
+                GLib.List<weak ListBoxRow> selected_rows = listbox.get_selected_rows ();
 
-                if(selected_rows.length() > 1) {
+                if (selected_rows.length () > 1) {
                     // Multiple rows selected
-                    right_click_menu = new Gtk.Menu();
+                    right_click_menu = new Gtk.Menu ();
 
-                    var add_to_queue_menu_item = new Gtk.MenuItem.with_label(_("Add selected episodes to queue"));
-                    add_to_queue_menu_item.activate.connect(() => {
+                    var add_to_queue_menu_item = new Gtk.MenuItem.with_label (_ ("Add selected episodes to queue"));
+                    add_to_queue_menu_item.activate.connect (() => {
 
-                        foreach(ListBoxRow row in selected_rows) {
-                            EpisodeDetailBox b = row.get_child() as EpisodeDetailBox;
+                        foreach (ListBoxRow row in selected_rows) {
+                            EpisodeDetailBox b = row.get_child () as EpisodeDetailBox;
                             enqueue_episode (b.episode);
                         }
                     });
-                    right_click_menu.add(add_to_queue_menu_item);
+                    right_click_menu.add (add_to_queue_menu_item);
 
-                    var mark_played_menuitem = new Gtk.MenuItem.with_label(_("Mark selected episodes as played"));
-                    mark_played_menuitem.activate.connect(() => {
-                            
-                            foreach(ListBoxRow row in selected_rows) {
-                                EpisodeDetailBox b = row.get_child() as EpisodeDetailBox;
+                    var mark_played_menuitem = new Gtk.MenuItem.with_label (_ ("Mark selected episodes as played"));
+                    mark_played_menuitem.activate.connect (() => {
+
+                            foreach (ListBoxRow row in selected_rows) {
+                                EpisodeDetailBox b = row.get_child () as EpisodeDetailBox;
                                 mark_episode_as_played_requested (b.episode);
                                 b.mark_as_played ();
                             }
 
-                            reset_unplayed_count();
+                            reset_unplayed_count ();
 
                     });
-                    right_click_menu.add(mark_played_menuitem);
+                    right_click_menu.add (mark_played_menuitem);
 
 
-                    var mark_unplayed_menuitem = new Gtk.MenuItem.with_label(_("Mark selected episodes as new"));
-                    mark_unplayed_menuitem.activate.connect(() => {
+                    var mark_unplayed_menuitem = new Gtk.MenuItem.with_label (_ ("Mark selected episodes as new"));
+                    mark_unplayed_menuitem.activate.connect (() => {
 
-                        foreach(ListBoxRow row in selected_rows) {
-                            EpisodeDetailBox b = row.get_child() as EpisodeDetailBox;
+                        foreach (ListBoxRow row in selected_rows) {
+                            EpisodeDetailBox b = row.get_child () as EpisodeDetailBox;
                             mark_episode_as_unplayed_requested (b.episode);
                             b.mark_as_unplayed ();
                         }
 
-                        reset_unplayed_count();
+                        reset_unplayed_count ();
                     });
-                    right_click_menu.add(mark_unplayed_menuitem);
+                    right_click_menu.add (mark_unplayed_menuitem);
 
 
-                    var delete_menuitem = new Gtk.MenuItem.with_label(_("Delete local files for selected episodes"));
-                    delete_menuitem.activate.connect(() => {
+                    var delete_menuitem = new Gtk.MenuItem.with_label (_ ("Delete local files for selected episodes"));
+                    delete_menuitem.activate.connect (() => {
                         Gtk.MessageDialog msg = new Gtk.MessageDialog (controller.window, Gtk.DialogFlags.MODAL, Gtk.MessageType.WARNING, Gtk.ButtonsType.NONE,
-                             _("Are you sure you want to delete the downloaded files for the selected episodes?"));
+                             _ ("Are you sure you want to delete the downloaded files for the selected episodes?"));
 
                         msg.add_button ("_No", Gtk.ResponseType.CANCEL);
-                        Gtk.Button delete_button = (Gtk.Button) msg.add_button("_Yes", Gtk.ResponseType.YES);
-                        delete_button.get_style_context().add_class("destructive-action");
+                        Gtk.Button delete_button = (Gtk.Button) msg.add_button ("_Yes", Gtk.ResponseType.YES);
+                        delete_button.get_style_context ().add_class ("destructive-action");
 
-                        var image = new Gtk.Image.from_icon_name("dialog-question", Gtk.IconSize.DIALOG);
+                        var image = new Gtk.Image.from_icon_name ("dialog-question", Gtk.IconSize.DIALOG);
                         msg.image = image;
-                        msg.image.show_all();
+                        msg.image.show_all ();
                         msg.response.connect ((response_id) => {
                             switch (response_id) {
                                 case Gtk.ResponseType.YES:
 
-                                    foreach(ListBoxRow row in selected_rows) {
-                                        EpisodeDetailBox b = row.get_child() as EpisodeDetailBox;
+                                    foreach (ListBoxRow row in selected_rows) {
+                                        EpisodeDetailBox b = row.get_child () as EpisodeDetailBox;
                                         delete_local_episode_requested (b.episode);
                                     }
 
@@ -477,122 +477,122 @@ namespace Vocal {
                                 case Gtk.ResponseType.NO:
                                     break;
                             }
-                            msg.destroy();
+                            msg.destroy ();
                         });
                         msg.show ();
 
                     });
-                    right_click_menu.add(delete_menuitem);
+                    right_click_menu.add (delete_menuitem);
                 } else {
 
                     // Only a single row selected
-                    ListBoxRow selected_row = listbox.get_row_at_y((int)e.y);
-                    EpisodeDetailBox b = selected_row.get_child() as EpisodeDetailBox;
+                    ListBoxRow selected_row = listbox.get_row_at_y ((int)e.y);
+                    EpisodeDetailBox b = selected_row.get_child () as EpisodeDetailBox;
                     current_episode = b.episode;
 
                     /*
-                    if(current_episode_index >= 0 && current_episode_index < boxes.size) {
-                        previously_selected_box = boxes[selected_row.get_index()];
+                    if (current_episode_index >= 0 && current_episode_index < boxes.size) {
+                        previously_selected_box = boxes[selected_row.get_index ()];
                     }
                     */
 
                     // Populate the right click menu based on the current conditions
-                    right_click_menu = new Gtk.Menu();
+                    right_click_menu = new Gtk.Menu ();
 
                     // Mark as played
-                    if(current_episode.status == EpisodeStatus.UNPLAYED) {
-                        var mark_played_menuitem = new Gtk.MenuItem.with_label(_("Mark as played"));
-                        mark_played_menuitem.activate.connect(() => {
-                            mark_episode_as_played_requested_internal();
+                    if (current_episode.status == EpisodeStatus.UNPLAYED) {
+                        var mark_played_menuitem = new Gtk.MenuItem.with_label (_ ("Mark as played"));
+                        mark_played_menuitem.activate.connect (() => {
+                            mark_episode_as_played_requested_internal ();
                         });
-                        right_click_menu.add(mark_played_menuitem);
+                        right_click_menu.add (mark_played_menuitem);
 
                     // Mark as unplayed
                     } else {
-                        var mark_unplayed_menuitem = new Gtk.MenuItem.with_label(_("Mark as new"));
-                        mark_unplayed_menuitem.activate.connect(() => {
-                            mark_episode_as_new_requested_internal();
+                        var mark_unplayed_menuitem = new Gtk.MenuItem.with_label (_ ("Mark as new"));
+                        mark_unplayed_menuitem.activate.connect (() => {
+                            mark_episode_as_new_requested_internal ();
                         });
-                        right_click_menu.add(mark_unplayed_menuitem);
+                        right_click_menu.add (mark_unplayed_menuitem);
                     }
 
-                    if(current_episode.current_download_status == DownloadStatus.DOWNLOADED) {
-                        var delete_menuitem = new Gtk.MenuItem.with_label(_("Delete Local File"));
+                    if (current_episode.current_download_status == DownloadStatus.DOWNLOADED) {
+                        var delete_menuitem = new Gtk.MenuItem.with_label (_ ("Delete Local File"));
 
-                        delete_menuitem.activate.connect(() => {
+                        delete_menuitem.activate.connect (() => {
                             Gtk.MessageDialog msg = new Gtk.MessageDialog (controller.window, Gtk.DialogFlags.MODAL, Gtk.MessageType.WARNING, Gtk.ButtonsType.NONE,
-                                 _("Are you sure you want to delete the downloaded episode '%s'?").printf(current_episode.title.replace("%27", "'")));
+                                 _ ("Are you sure you want to delete the downloaded episode '%s'?").printf (current_episode.title.replace ("%27", "'")));
 
 
                             msg.add_button ("_No", Gtk.ResponseType.CANCEL);
-                            Gtk.Button delete_button = (Gtk.Button) msg.add_button("_Yes", Gtk.ResponseType.YES);
-                            delete_button.get_style_context().add_class("destructive-action");
+                            Gtk.Button delete_button = (Gtk.Button) msg.add_button ("_Yes", Gtk.ResponseType.YES);
+                            delete_button.get_style_context ().add_class ("destructive-action");
 
-                            var image = new Gtk.Image.from_icon_name("dialog-question", Gtk.IconSize.DIALOG);
+                            var image = new Gtk.Image.from_icon_name ("dialog-question", Gtk.IconSize.DIALOG);
                             msg.image = image;
-                            msg.image.show_all();
+                            msg.image.show_all ();
 
                             msg.response.connect ((response_id) => {
                                 switch (response_id) {
                                     case Gtk.ResponseType.YES:
-                                        delete_local_episode_requested(current_episode);
+                                        delete_local_episode_requested (current_episode);
                                         break;
                                     case Gtk.ResponseType.NO:
                                         break;
                                 }
 
-                                msg.destroy();
+                                msg.destroy ();
                             });
                             msg.show ();
 
                         });
 
-                        right_click_menu.add(delete_menuitem);
+                        right_click_menu.add (delete_menuitem);
                     }
                 }
 
-                right_click_menu.show_all();
-                right_click_menu.popup(null, null, null, e.button, e.time);
+                right_click_menu.show_all ();
+                right_click_menu.popup (null, null, null, e.button, e.time);
             }
 
             return false;
         }
 
-        public void set_podcast(Podcast podcast) {
-            if(this.podcast == podcast) {
+        public void set_podcast (Podcast podcast) {
+            if (this.podcast == podcast) {
                 return;
             }
 
             this.podcast = podcast;
 
-        	if(image != null) {
-        		image_box.remove(image);
-        		image = null;
-        	}
-
-        	try {
-			    var cover = GLib.File.new_for_uri(podcast.coverart_uri);
-                var icon = new GLib.FileIcon(cover);
-				image = new Gtk.Image.from_gicon(icon, Gtk.IconSize.DIALOG);
-                image.pixel_size = 250;
-                image.margin = 0;
-                if(controller.on_elementary) {
-                    image.get_style_context ().add_class ("card");
-                } else {
-                    image.get_style_context().add_class("podcast-view-coverart");
-                }
-
-            	image_box.pack_start(image, true, true, 0);
-            } catch (Error e) {
-                error(e.message);
+            if (image != null) {
+                image_box.remove (image);
+                image = null;
             }
 
-			name_label.set_text(podcast.name.replace("%27", "'"));
-            description_label.set_text(podcast.description.replace("""\n""",""));
+            try {
+                var cover = GLib.File.new_for_uri (podcast.coverart_uri);
+                var icon = new GLib.FileIcon (cover);
+                image = new Gtk.Image.from_gicon (icon, Gtk.IconSize.DIALOG);
+                image.pixel_size = 250;
+                image.margin = 0;
+                if (controller.on_elementary) {
+                    image.get_style_context ().add_class ("card");
+                } else {
+                    image.get_style_context ().add_class ("podcast-view-coverart");
+                }
 
-            reset_episode_list();
-            populate_episodes();
-            
+                image_box.pack_start (image, true, true, 0);
+            } catch (Error e) {
+                error (e.message);
+            }
+
+            name_label.set_text (podcast.name.replace ("%27", "'"));
+            description_label.set_text (podcast.description.replace ("""\n""",""));
+
+            reset_episode_list ();
+            populate_episodes ();
+
             if (podcast.license == License.CC) {
                 cc_image.no_show_all = false;
                 cc_image.show ();
@@ -602,18 +602,18 @@ namespace Vocal {
             }
 
             // Select the first podcast
-            var first_row = listbox.get_row_at_index(0);
-            listbox.select_row(first_row);
+            var first_row = listbox.get_row_at_index (0);
+            listbox.select_row (first_row);
 
-            show_all();
+            show_all ();
         }
 
         /*
          * When a row is activated, clear the unplayed icon if there is one and request
          * the corresponding episode be played
          */
-        private void on_row_activated(ListBoxRow? row) {
-        
+        private void on_row_activated (ListBoxRow? row) {
+
             play_episode_requested (current_episode);
             foreach (EpisodeDetailBox b in boxes) {
                 if (b.episode == current_episode) {
@@ -629,58 +629,58 @@ namespace Vocal {
         /*
          * When a row is selected, highlight it and show the details
          */
-        private void on_row_selected() {
-        
-            GLib.List<weak ListBoxRow> rows = listbox.get_selected_rows();
-            if(rows.length() < 1) {
+        private void on_row_selected () {
+
+            GLib.List<weak ListBoxRow> rows = listbox.get_selected_rows ();
+            if (rows.length () < 1) {
                 return;
             }
 
-            ListBoxRow new_row = listbox.get_selected_row();
+            ListBoxRow new_row = listbox.get_selected_row ();
             if (controller.settings.newest_episodes_first) {
-                current_episode = boxes[new_row.get_index()].episode;
+                current_episode = boxes[new_row.get_index ()].episode;
             } else {
-                int new_index = boxes.size - new_row.get_index() - 1;
+                int new_index = boxes.size - new_row.get_index () - 1;
                 current_episode = boxes[new_index].episode;
             }
-            
+
             shownotes.episode = current_episode;
-            shownotes.set_html(current_episode.description != "(null)" ? Utils.html_to_markup(current_episode.description) : _("No show notes available."));
-            shownotes.set_title(current_episode.title);
-            shownotes.set_date(current_episode.datetime_released);
+            shownotes.set_html (current_episode.description != " (null)" ? Utils.html_to_markup (current_episode.description) : _ ("No show notes available."));
+            shownotes.set_title (current_episode.title);
+            shownotes.set_date (current_episode.datetime_released);
 
             // Check to see if the episode has been downloaded or not
-            if(current_episode.current_download_status == DownloadStatus.DOWNLOADED) {
-                shownotes.hide_download_button();
+            if (current_episode.current_download_status == DownloadStatus.DOWNLOADED) {
+                shownotes.hide_download_button ();
             } else {
-                shownotes.show_download_button();
+                shownotes.show_download_button ();
             }
-            
+
             // Check to see if the episode can be uploaded to the archive or not
-            if(current_episode.parent.license == License.CC) {
+            if (current_episode.parent.license == License.CC) {
                 shownotes.show_internet_archive_button ();
             } else {
                 shownotes.hide_internet_archive_button ();
             }
 
             // Check the playback status
-            if(current_episode.status == EpisodeStatus.PLAYED) {
-                shownotes.show_mark_as_new_button();
+            if (current_episode.status == EpisodeStatus.PLAYED) {
+                shownotes.show_mark_as_new_button ();
             } else {
-                shownotes.show_mark_as_played_button();
+                shownotes.show_mark_as_played_button ();
             }
 
-            show_all();
+            show_all ();
         }
 
         /*
          * Handler for when a single episode needs to be marked as remote (needs downloading)
          */
-        public void on_single_delete(Episode e) {
-            int index = get_box_index_from_episode(e);
-            if(index != -1) {
-                boxes[index].show_playback_button();
-                boxes[index].show_download_button();
+        public void on_single_delete (Episode e) {
+            int index = get_box_index_from_episode (e);
+            if (index != -1) {
+                boxes[index].show_playback_button ();
+                boxes[index].show_download_button ();
             }
         }
 
@@ -689,37 +689,37 @@ namespace Vocal {
          * it like a row has been activated
          */
         private void on_streaming_button_clicked (Episode episode) {
-            on_row_activated(null);
+            on_row_activated (null);
         }
 
-        private void reset_episode_list() {
-            foreach (var item in listbox.get_children()) {
-                listbox.remove(item);
+        private void reset_episode_list () {
+            foreach (var item in listbox.get_children ()) {
+                listbox.remove (item);
             }
 
-            boxes.clear();
+            boxes.clear ();
         }
 
         /*
          * Creates an EpisodeDetailBox for each episode and adds it to the window
          */
-        public void populate_episodes() {
-        
+        public void populate_episodes () {
+
             // If there are episodes, create an episode detail box for each of them
             if (this.podcast.episodes.size > 0) {
-            
+
                 unplayed_count = 0;
                 foreach (Episode current_episode in podcast.episodes) {
-                                   
+
                     EpisodeDetailBox current_episode_box = new EpisodeDetailBox (current_episode, controller, false);
-                    boxes.add(current_episode_box);
-                    
+                    boxes.add (current_episode_box);
+
                     // Determine whether or not the episode has been played
-                    if(current_episode.status == EpisodeStatus.UNPLAYED) {
+                    if (current_episode.status == EpisodeStatus.UNPLAYED) {
                         unplayed_count++;
                     }
                 }
-                
+
                 if (controller.settings.newest_episodes_first) {
                     foreach (EpisodeDetailBox box in boxes) {
                         listbox.add (box);
@@ -731,156 +731,156 @@ namespace Vocal {
                         box.show_all ();
                     }
                 }
-                
-                
+
+
             } else {
                 // Otherwise, simply create a new label to tell user that the feed is empty
-                var empty_label = new Gtk.Label(_("No episodes available."));
+                var empty_label = new Gtk.Label (_ ("No episodes available."));
                 empty_label.justify = Gtk.Justification.CENTER;
                 empty_label.margin = 10;
 
-                empty_label.get_style_context().add_class("h3");
-                listbox.prepend(empty_label);
+                empty_label.get_style_context ().add_class ("h3");
+                listbox.prepend (empty_label);
             }
 
-            listbox.get_children().foreach((child) => {
-                child.get_style_context().add_class("episode-list");
+            listbox.get_children ().foreach ((child) => {
+                child.get_style_context ().add_class ("episode-list");
             });
 
-            set_unplayed_text();
+            set_unplayed_text ();
         }
 
         /*
          * Resets the unplayed count and iterates through the boxes to obtain a new one
          */
-        public void reset_unplayed_count() {
+        public void reset_unplayed_count () {
 
             int previous_count = unplayed_count;
 
             unplayed_count = 0;
 
-            foreach(Episode e in podcast.episodes) {
-                if(e.status == EpisodeStatus.UNPLAYED)
+            foreach (Episode e in podcast.episodes) {
+                if (e.status == EpisodeStatus.UNPLAYED)
                     unplayed_count++;
             }
 
-            set_unplayed_text();
+            set_unplayed_text ();
 
             // Is the number of unplayed episodes now different?
-            if(previous_count != unplayed_count)
-                unplayed_count_changed(unplayed_count);
+            if (previous_count != unplayed_count)
+                unplayed_count_changed (unplayed_count);
         }
-        
-        private void on_change_album_art() {
-            var file_chooser = new Gtk.FileChooserDialog (_("Select Album Art"),
+
+        private void on_change_album_art () {
+            var file_chooser = new Gtk.FileChooserDialog (_ ("Select Album Art"),
                  controller.window,
                  Gtk.FileChooserAction.OPEN,
-                 _("Cancel"), Gtk.ResponseType.CANCEL,
-                 _("Open"), Gtk.ResponseType.ACCEPT);
+                 _ ("Cancel"), Gtk.ResponseType.CANCEL,
+                 _ ("Open"), Gtk.ResponseType.ACCEPT);
 
-            var all_files_filter = new Gtk.FileFilter();
-            all_files_filter.set_filter_name(_("All files"));
-            all_files_filter.add_pattern("*");
+            var all_files_filter = new Gtk.FileFilter ();
+            all_files_filter.set_filter_name (_ ("All files"));
+            all_files_filter.add_pattern ("*");
 
-            var opml_filter = new Gtk.FileFilter();
-            opml_filter.set_filter_name(_("Image Files"));
-            opml_filter.add_mime_type("image/png");
-            opml_filter.add_mime_type("image/jpeg");
+            var opml_filter = new Gtk.FileFilter ();
+            opml_filter.set_filter_name (_ ("Image Files"));
+            opml_filter.add_mime_type ("image/png");
+            opml_filter.add_mime_type ("image/jpeg");
 
-            file_chooser.add_filter(opml_filter);
-            file_chooser.add_filter(all_files_filter);
+            file_chooser.add_filter (opml_filter);
+            file_chooser.add_filter (all_files_filter);
 
             file_chooser.modal = true;
 
-            int decision = file_chooser.run();
-            string file_name = file_chooser.get_filename();
+            int decision = file_chooser.run ();
+            string file_name = file_chooser.get_filename ();
 
-            file_chooser.destroy();
+            file_chooser.destroy ();
 
             //If the user selects a file, get the name and parse it
             if (decision == Gtk.ResponseType.ACCEPT) {
-                GLib.File cover = GLib.File.new_for_path(file_name);
-                var icon = new GLib.FileIcon(cover);
-				image.gicon = icon;
-				image.pixel_size = 250;
-                
-                new_cover_art_set(file_name);
+                GLib.File cover = GLib.File.new_for_path (file_name);
+                var icon = new GLib.FileIcon (cover);
+                image.gicon = icon;
+                image.pixel_size = 250;
+
+                new_cover_art_set (file_name);
             }
         }
-        
+
         /*
          * Overrides the autodetected creative commons setting to unlock Internet Archive features
          */
         private void on_creative_commons_override () {
             Gtk.MessageDialog msg = new Gtk.MessageDialog (controller.window, Gtk.DialogFlags.MODAL, Gtk.MessageType.WARNING, Gtk.ButtonsType.YES_NO,
-                     _("Vocal did not detect that this podcast is licensed as Creative Commons. Changing this will unlock Internet Archive integration for this podcast. Please make sure this change is correct before proceeding. Do you wish to make this change?"));
-            var image = new Gtk.Image.from_icon_name("dialog-question", Gtk.IconSize.DIALOG);
+                     _ ("Vocal did not detect that this podcast is licensed as Creative Commons. Changing this will unlock Internet Archive integration for this podcast. Please make sure this change is correct before proceeding. Do you wish to make this change?"));
+            var image = new Gtk.Image.from_icon_name ("dialog-question", Gtk.IconSize.DIALOG);
             msg.image = image;
-            msg.image.show_all();
+            msg.image.show_all ();
 
-		    msg.response.connect ((response_id) => {
-		        switch (response_id) {
-			        case Gtk.ResponseType.YES:
-			            podcast.license = License.CC;
-			            controller.library.write_podcast_to_database (podcast);
-			            cc_image.no_show_all = false;
+            msg.response.connect ((response_id) => {
+                switch (response_id) {
+                    case Gtk.ResponseType.YES:
+                        podcast.license = License.CC;
+                        controller.library.write_podcast_to_database (podcast);
+                        cc_image.no_show_all = false;
                         cc_image.show ();
-				        break;
-			        case Gtk.ResponseType.NO:
-				        break;
-		        }
+                        break;
+                    case Gtk.ResponseType.NO:
+                        break;
+                }
 
-		        msg.destroy();
-	        });
-	        msg.show ();
+                msg.destroy ();
+            });
+            msg.show ();
         }
 
-		/*
- 		 * Sets the unplayed text (assumes the unplayed count has already been set)
- 		 */
-        public void set_unplayed_text() {
+        /*
+          * Sets the unplayed text (assumes the unplayed count has already been set)
+          */
+        public void set_unplayed_text () {
             string count_string = null;
-            if(unplayed_count > 0) {
-                count_string = _("%d unplayed episodes".printf(unplayed_count));
+            if (unplayed_count > 0) {
+                count_string = _ ("%d unplayed episodes".printf (unplayed_count));
             } else {
                 count_string = "";
             }
-            count_label.set_text(count_string);
+            count_label.set_text (count_string);
         }
 
-        public void select_episode(Episode e) {
-            reset_episode_list();
+        public void select_episode (Episode e) {
+            reset_episode_list ();
             populate_episodes ();
 
-            for(int i = 0; i < boxes.size; i++) {
-                ListBoxRow r = listbox.get_row_at_index(i);
-                EpisodeDetailBox b = r.get_child() as EpisodeDetailBox;
-                if(b.episode.title == e.title) {
-                    listbox.select_row(r);
+            for (int i = 0; i < boxes.size; i++) {
+                ListBoxRow r = listbox.get_row_at_index (i);
+                EpisodeDetailBox b = r.get_child () as EpisodeDetailBox;
+                if (b.episode.title == e.title) {
+                    listbox.select_row (r);
                     i = boxes.size;
                 }
             }
         }
 
-        private void on_link_to_file() {
+        private void on_link_to_file () {
             Gdk.Display display = controller.window.get_display ();
             Gtk.Clipboard clipboard = Gtk.Clipboard.get_for_display (display, Gdk.SELECTION_CLIPBOARD);
             string uri = current_episode.uri;
-            clipboard.set_text(uri,uri.length);
+            clipboard.set_text (uri,uri.length);
         }
 
-        private void on_tweet() {
-            string uri = Utils.get_shareable_link_for_episode(current_episode);
-            string message_text = GLib.Uri.escape_string(_("I'm listening to %s from %s").printf(current_episode.title,current_episode.parent.name));
-            string new_tweet_uri = "https://twitter.com/intent/tweet?text=%s&url=%s".printf(message_text, GLib.Uri.escape_string(uri));
+        private void on_tweet () {
+            string uri = Utils.get_shareable_link_for_episode (current_episode);
+            string message_text = GLib.Uri.escape_string (_ ("I'm listening to %s from %s").printf (current_episode.title,current_episode.parent.name));
+            string new_tweet_uri = "https://twitter.com/intent/tweet?text=%s&url=%s".printf (message_text, GLib.Uri.escape_string (uri));
             Gtk.show_uri (null, new_tweet_uri, 0);
         }
 
-        private void on_copy_shareable_link() {
+        private void on_copy_shareable_link () {
             Gdk.Display display = controller.window.get_display ();
             Gtk.Clipboard clipboard = Gtk.Clipboard.get_for_display (display, Gdk.SELECTION_CLIPBOARD);
-            string uri = Utils.get_shareable_link_for_episode(current_episode);
-            clipboard.set_text(uri,uri.length);
+            string uri = Utils.get_shareable_link_for_episode (current_episode);
+            clipboard.set_text (uri,uri.length);
         }
     }
 }

--- a/src/Widgets/PodcastView.vala
+++ b/src/Widgets/PodcastView.vala
@@ -137,7 +137,10 @@ namespace Vocal {
                 }
             });
 
-            var download_all = new Gtk.Button.from_icon_name (Utils.check_elementary () ? "browser-download-symbolic" : "document-save-symbolic", Gtk.IconSize.MENU);
+            var download_all = new Gtk.Button.from_icon_name (
+                Utils.check_elementary () ? "browser-download-symbolic" : "document-save-symbolic",
+                Gtk.IconSize.MENU
+            );
             download_all.margin = 6;
             download_all.tooltip_text = _ ("Download all episodes");
             download_all.clicked.connect (() => {
@@ -157,12 +160,17 @@ namespace Vocal {
             toolbar.pack_end (download_all, false, false, 0);
             this.pack_start (toolbar, false, true, 0);
 
-            var edit = new Gtk.Button.from_icon_name (Utils.check_elementary () ? "edit-symbolic" : "document-properties-symbolic",Gtk.IconSize.MENU);
+            var edit = new Gtk.Button.from_icon_name (
+                Utils.check_elementary () ? "edit-symbolic" : "document-properties-symbolic",
+                Gtk.IconSize.MENU
+            );
             edit.tooltip_text = _ ("Edit podcast details");
             edit.button_press_event.connect ((e) => {
                 var edit_menu = new Gtk.Menu ();
                 var change_cover_art_item = new Gtk.MenuItem.with_label (_ ("Select different cover art"));
-                var creative_commons_override_button = new Gtk.MenuItem.with_label (_ ("Set podcast license to Creative Commons"));
+                var creative_commons_override_button = new Gtk.MenuItem.with_label (
+                    _ ("Set podcast license to Creative Commons")
+                );
                 change_cover_art_item.activate.connect (on_change_album_art);
                 creative_commons_override_button.activate.connect (on_creative_commons_override);
                 edit_menu.add (change_cover_art_item);
@@ -267,7 +275,13 @@ namespace Vocal {
             shownotes.internet_archive_upload_requested.connect (() => {
                 var settings = VocalSettings.get_default_instance ();
                 if (settings.archive_access_key.length < 1 || settings.archive_secret_key.length < 1) {
-                    Gtk.MessageDialog msg = new Gtk.MessageDialog (controller.window, Gtk.DialogFlags.MODAL, Gtk.MessageType.WARNING, Gtk.ButtonsType.OK, _ ("Before you can upload to the Internet Archive you must add your archive.org account's API keys. Visit https://archive.org/account/s3.php to see your keys, then paste them in the settings."));
+                    Gtk.MessageDialog msg = new Gtk.MessageDialog (
+                        controller.window,
+                        Gtk.DialogFlags.MODAL,
+                        Gtk.MessageType.WARNING,
+                        Gtk.ButtonsType.OK,
+                        _ ("Before you can upload to the Internet Archive you must add your archive.org account's API keys. Visit https://archive.org/account/s3.php to see your keys, then paste them in the settings.")  // vala-lint=line-length
+                    );
 
                     var image = new Gtk.Image.from_icon_name ("dialog-warning", Gtk.IconSize.DIALOG);
                     msg.image = image;
@@ -284,7 +298,13 @@ namespace Vocal {
 
                 } else {
 
-                    Gtk.MessageDialog msg = new Gtk.MessageDialog (controller.window, Gtk.DialogFlags.MODAL, Gtk.MessageType.WARNING, Gtk.ButtonsType.YES_NO, _ ("You must download this episode first before uploading to the Internet Archive. Would you like to download this episode?"));
+                    Gtk.MessageDialog msg = new Gtk.MessageDialog (
+                        controller.window,
+                        Gtk.DialogFlags.MODAL,
+                        Gtk.MessageType.WARNING,
+                        Gtk.ButtonsType.YES_NO,
+                        _ ("You must download this episode first before uploading to the Internet Archive. Would you like to download this episode?")  // vala-lint=line-length
+                    );
 
                     var image = new Gtk.Image.from_icon_name ("dialog-question", Gtk.IconSize.DIALOG);
                     msg.image = image;
@@ -454,8 +474,13 @@ namespace Vocal {
 
                     var delete_menuitem = new Gtk.MenuItem.with_label (_ ("Delete local files for selected episodes"));
                     delete_menuitem.activate.connect (() => {
-                        Gtk.MessageDialog msg = new Gtk.MessageDialog (controller.window, Gtk.DialogFlags.MODAL, Gtk.MessageType.WARNING, Gtk.ButtonsType.NONE,
-                             _ ("Are you sure you want to delete the downloaded files for the selected episodes?"));
+                        Gtk.MessageDialog msg = new Gtk.MessageDialog (
+                            controller.window,
+                            Gtk.DialogFlags.MODAL,
+                            Gtk.MessageType.WARNING,
+                            Gtk.ButtonsType.NONE,
+                            _ ("Are you sure you want to delete the downloaded files for the selected episodes?")
+                        );
 
                         msg.add_button ("_No", Gtk.ResponseType.CANCEL);
                         Gtk.Button delete_button = (Gtk.Button) msg.add_button ("_Yes", Gtk.ResponseType.YES);
@@ -520,9 +545,15 @@ namespace Vocal {
                         var delete_menuitem = new Gtk.MenuItem.with_label (_ ("Delete Local File"));
 
                         delete_menuitem.activate.connect (() => {
-                            Gtk.MessageDialog msg = new Gtk.MessageDialog (controller.window, Gtk.DialogFlags.MODAL, Gtk.MessageType.WARNING, Gtk.ButtonsType.NONE,
-                                 _ ("Are you sure you want to delete the downloaded episode '%s'?").printf (current_episode.title.replace ("%27", "'")));
-
+                            Gtk.MessageDialog msg = new Gtk.MessageDialog (
+                                controller.window,
+                                Gtk.DialogFlags.MODAL,
+                                Gtk.MessageType.WARNING,
+                                Gtk.ButtonsType.NONE,
+                                _ ("Are you sure you want to delete the downloaded episode '%s'?").printf (
+                                     current_episode.title.replace ("%27", "'")
+                                )
+                            );
 
                             msg.add_button ("_No", Gtk.ResponseType.CANCEL);
                             Gtk.Button delete_button = (Gtk.Button) msg.add_button ("_Yes", Gtk.ResponseType.YES);
@@ -588,7 +619,7 @@ namespace Vocal {
             }
 
             name_label.set_text (podcast.name.replace ("%27", "'"));
-            description_label.set_text (podcast.description.replace ("""\n""",""));
+            description_label.set_text (podcast.description.replace ("""\n""", ""));
 
             reset_episode_list ();
             populate_episodes ();
@@ -645,7 +676,7 @@ namespace Vocal {
             }
 
             shownotes.episode = current_episode;
-            shownotes.set_html (current_episode.description != " (null)" ? Utils.html_to_markup (current_episode.description) : _ ("No show notes available."));
+            shownotes.set_html (current_episode.description != " (null)" ? Utils.html_to_markup (current_episode.description) : _ ("No show notes available."));  // vala-lint=line-length
             shownotes.set_title (current_episode.title);
             shownotes.set_date (current_episode.datetime_released);
 
@@ -812,8 +843,13 @@ namespace Vocal {
          * Overrides the autodetected creative commons setting to unlock Internet Archive features
          */
         private void on_creative_commons_override () {
-            Gtk.MessageDialog msg = new Gtk.MessageDialog (controller.window, Gtk.DialogFlags.MODAL, Gtk.MessageType.WARNING, Gtk.ButtonsType.YES_NO,
-                     _ ("Vocal did not detect that this podcast is licensed as Creative Commons. Changing this will unlock Internet Archive integration for this podcast. Please make sure this change is correct before proceeding. Do you wish to make this change?"));
+            Gtk.MessageDialog msg = new Gtk.MessageDialog (
+                controller.window,
+                Gtk.DialogFlags.MODAL,
+                Gtk.MessageType.WARNING,
+                Gtk.ButtonsType.YES_NO,
+                _ ("Vocal did not detect that this podcast is licensed as Creative Commons. Changing this will unlock Internet Archive integration for this podcast. Please make sure this change is correct before proceeding. Do you wish to make this change?")  // vala-lint=line-length
+            );
             var image = new Gtk.Image.from_icon_name ("dialog-question", Gtk.IconSize.DIALOG);
             msg.image = image;
             msg.image.show_all ();
@@ -866,13 +902,21 @@ namespace Vocal {
             Gdk.Display display = controller.window.get_display ();
             Gtk.Clipboard clipboard = Gtk.Clipboard.get_for_display (display, Gdk.SELECTION_CLIPBOARD);
             string uri = current_episode.uri;
-            clipboard.set_text (uri,uri.length);
+            clipboard.set_text (uri, uri.length);
         }
 
         private void on_tweet () {
             string uri = Utils.get_shareable_link_for_episode (current_episode);
-            string message_text = GLib.Uri.escape_string (_ ("I'm listening to %s from %s").printf (current_episode.title,current_episode.parent.name));
-            string new_tweet_uri = "https://twitter.com/intent/tweet?text=%s&url=%s".printf (message_text, GLib.Uri.escape_string (uri));
+            string message_text = GLib.Uri.escape_string (
+                _ ("I'm listening to %s from %s").printf (
+                    current_episode.title,
+                    current_episode.parent.name
+                )
+            );
+            string new_tweet_uri = "https://twitter.com/intent/tweet?text=%s&url=%s".printf (
+                message_text,
+                GLib.Uri.escape_string (uri)
+            );
             Gtk.show_uri (null, new_tweet_uri, 0);
         }
 
@@ -880,7 +924,7 @@ namespace Vocal {
             Gdk.Display display = controller.window.get_display ();
             Gtk.Clipboard clipboard = Gtk.Clipboard.get_for_display (display, Gdk.SELECTION_CLIPBOARD);
             string uri = Utils.get_shareable_link_for_episode (current_episode);
-            clipboard.set_text (uri,uri.length);
+            clipboard.set_text (uri, uri.length);
         }
     }
 }

--- a/src/Widgets/QueuePopover.vala
+++ b/src/Widgets/QueuePopover.vala
@@ -18,125 +18,125 @@
 ***/
 
 namespace Vocal {
-	public class QueuePopover : Gtk.Popover {
-		public signal void update_queue(int oldPos, int newPos);
-		public signal void move_up(Episode e);
-		public signal void move_down(Episode e);
-		public signal void remove_episode(Episode e);
-		public signal void play_episode_from_queue_immediately(Episode e);
+    public class QueuePopover : Gtk.Popover {
+        public signal void update_queue (int oldPos, int newPos);
+        public signal void move_up (Episode e);
+        public signal void move_down (Episode e);
+        public signal void remove_episode (Episode e);
+        public signal void play_episode_from_queue_immediately (Episode e);
 
-		private QueueList episodes;
+        private QueueList episodes;
 
-		private Gtk.Label label;
-		private Gtk.ScrolledWindow scrolled_window;
-		private Gtk.Box scrolled_box;
+        private Gtk.Label label;
+        private Gtk.ScrolledWindow scrolled_window;
+        private Gtk.Box scrolled_box;
 
-		public QueuePopover(Gtk.Widget parent) {
-			this.set_relative_to(parent);
+        public QueuePopover (Gtk.Widget parent) {
+            this.set_relative_to (parent);
 
-			label = new Gtk.Label(_("No episodes in queue"));
-			label.get_style_context().add_class("h3");
-			label.margin  = 12;
+            label = new Gtk.Label (_ ("No episodes in queue"));
+            label.get_style_context ().add_class ("h3");
+            label.margin = 12;
 
-			scrolled_window = new Gtk.ScrolledWindow(null, null);
-			scrolled_window.set_size_request(400, 50);
+            scrolled_window = new Gtk.ScrolledWindow (null, null);
+            scrolled_window.set_size_request (400, 50);
 
-			scrolled_box = new Gtk.Box(Gtk.Orientation.VERTICAL, 15);
-			scrolled_window.add(scrolled_box);
+            scrolled_box = new Gtk.Box (Gtk.Orientation.VERTICAL, 15);
+            scrolled_window.add (scrolled_box);
 
-			scrolled_box.add(label);
+            scrolled_box.add (label);
 
-			this.add(scrolled_window);
-		}
+            this.add (scrolled_window);
+        }
 
-		/*
-		 * Sets the current queue
-		 */
-		public void set_queue(Gee.ArrayList<Episode> queue) {
+        /*
+         * Sets the current queue
+         */
+        public void set_queue (Gee.ArrayList<Episode> queue) {
 
-			if (episodes != null) {
-				scrolled_box.remove(episodes);
-			}
+            if (episodes != null) {
+                scrolled_box.remove (episodes);
+            }
 
-			if(queue.size > 0) {
-				hide_label();
+            if (queue.size > 0) {
+                hide_label ();
 
-				episodes = new QueueList(queue);
-				episodes.vadjustment = scrolled_window.vadjustment;
-				episodes.update_queue.connect((oldPos, newPos) => { update_queue(oldPos, newPos); });
-				episodes.row_activated.connect(on_row_activated);
-				episodes.remove_episode.connect((e) => { remove_episode(e); });
-				scrolled_box.add(episodes);
+                episodes = new QueueList (queue);
+                episodes.vadjustment = scrolled_window.vadjustment;
+                episodes.update_queue.connect ((oldPos, newPos) => { update_queue (oldPos, newPos); });
+                episodes.row_activated.connect (on_row_activated);
+                episodes.remove_episode.connect ((e) => { remove_episode (e); });
+                scrolled_box.add (episodes);
 
-			} else {
-				show_label();
-			}
-		}
-
-
-		/*
-		 * Show the "no episodes in queue" label
-		 */
-		private void show_label() {
-			label.set_no_show_all(false);
-			label.show();
-			scrolled_window.set_size_request(400, 60);
-		}
+            } else {
+                show_label ();
+            }
+        }
 
 
-		/*
-		 * Hide the "no episodes in queue" label
-		 */
-		private void hide_label() {
-			label.set_no_show_all(true);
-			label.hide();
-			scrolled_window.set_size_request(400, 225);
-		}
+        /*
+         * Show the "no episodes in queue" label
+         */
+        private void show_label () {
+            label.set_no_show_all (false);
+            label.show ();
+            scrolled_window.set_size_request (400, 60);
+        }
 
 
-		/*
-		 * Called whenever the row is activated (when the user clicks it)
-		 */
-		public void on_row_activated(Gtk.ListBoxRow row) {
-			print("\n\nrow activated\n\n");
-			int index = row.get_index();
-			QueueListRow q = (QueueListRow) row;
+        /*
+         * Hide the "no episodes in queue" label
+         */
+        private void hide_label () {
+            label.set_no_show_all (true);
+            label.hide ();
+            scrolled_window.set_size_request (400, 225);
+        }
 
-			play_episode_from_queue_immediately(q.episode);
-		}
+
+        /*
+         * Called whenever the row is activated (when the user clicks it)
+         */
+        public void on_row_activated (Gtk.ListBoxRow row) {
+            print ("\n\nrow activated\n\n");
+            int index = row.get_index ();
+            QueueListRow q = (QueueListRow) row;
+
+            play_episode_from_queue_immediately (q.episode);
+        }
   }
 
-	class QueueList : Gtk.ListBox {
-		public signal void update_queue(int oldPos, int newPos);
-		public signal void remove_episode(Episode e);
+    class QueueList : Gtk.ListBox {
+        public signal void update_queue (int oldPos, int newPos);
+        public signal void remove_episode (Episode e);
 
-		public Gee.ArrayList<QueueListRow> rows; 
+        public Gee.ArrayList<QueueListRow> rows;
 
-		private const Gtk.TargetEntry targetEntries[] = {
-		  { "GTK_LIST_BOX_ROW", Gtk.TargetFlags.SAME_APP, 0 }
+        private const Gtk.TargetEntry targetEntries[] = {
+          { "GTK_LIST_BOX_ROW", Gtk.TargetFlags.SAME_APP, 0 }
     };
 
-		public QueueList(Gee.ArrayList<Episode> queue) {
-			selection_mode = Gtk.SelectionMode.NONE;
-			rows = new Gee.ArrayList<QueueListRow>();
+        public QueueList (Gee.ArrayList<Episode> queue) {
+            selection_mode = Gtk.SelectionMode.NONE;
+            rows = new Gee.ArrayList<QueueListRow> ();
 
-			Gtk.drag_dest_set(this, Gtk.DestDefaults.ALL, targetEntries, Gdk.DragAction.MOVE);
-      drag_data_received.connect(on_drag_data_received);
+            Gtk.drag_dest_set (this, Gtk.DestDefaults.ALL, targetEntries, Gdk.DragAction.MOVE);
+      drag_data_received.connect (on_drag_data_received);
 
-			foreach(Episode e in queue) {
-				QueueListRow listRow = new QueueListRow(e);
+            foreach (Episode e in queue) {
+                QueueListRow listRow = new QueueListRow (e);
 
-				listRow.remove_episode.connect((e) => { remove_episode(e); });
+                listRow.remove_episode.connect ((e) => { remove_episode (e); });
 
-				listRow.update_queue.connect((oldPos, newPos) => { update_queue(oldPos, newPos); });
+                listRow.update_queue.connect ((oldPos, newPos) => { update_queue (oldPos, newPos); });
 
-				add(listRow);
-				rows.add(listRow);
-			}
-		}
+                add (listRow);
+                rows.add (listRow);
+            }
+        }
 
-		private bool scroll_up = false;
-		private bool scrolling = false;
+        private bool scroll_up = false;
+        private bool scrolling = false;
     private bool should_scroll = false;
     public Gtk.Adjustment vadjustment;
 
@@ -144,40 +144,40 @@ namespace Vocal {
     private const int SCROLL_DISTANCE = 30;
     private const int SCROLL_DELAY = 50;
 
-		public override bool drag_motion(Gdk.DragContext context, int x, int y, uint time) {
-			check_scroll (y);
-			if(should_scroll && !scrolling) {
-				scrolling = true;
-				Timeout.add (SCROLL_DELAY, scroll);
-			}
+        public override bool drag_motion (Gdk.DragContext context, int x, int y, uint time) {
+            check_scroll (y);
+            if (should_scroll && !scrolling) {
+                scrolling = true;
+                Timeout.add (SCROLL_DELAY, scroll);
+            }
 
-			return true;
-		}
+            return true;
+        }
 
-		private void check_scroll (int y) {
-			if (vadjustment == null) {
-				return;
-			}
+        private void check_scroll (int y) {
+            if (vadjustment == null) {
+                return;
+            }
 
-			double vadjustment_min = vadjustment.value;
-			double vadjustment_max = vadjustment.page_size + vadjustment_min;
-			double show_min = double.max(0, y - SCROLL_DISTANCE);
-			double show_max = double.min(vadjustment.upper, y + SCROLL_DISTANCE);
+            double vadjustment_min = vadjustment.value;
+            double vadjustment_max = vadjustment.page_size + vadjustment_min;
+            double show_min = double.max (0, y - SCROLL_DISTANCE);
+            double show_max = double.min (vadjustment.upper, y + SCROLL_DISTANCE);
 
-			if(vadjustment_min > show_min) {
-				should_scroll = true;
-				scroll_up = true;
-			} else if (vadjustment_max < show_max){
-				should_scroll = true;
-				scroll_up = false;
-			} else {
-				should_scroll = false;
-			}
-		}
+            if (vadjustment_min > show_min) {
+                should_scroll = true;
+                scroll_up = true;
+            } else if (vadjustment_max < show_max) {
+                should_scroll = true;
+                scroll_up = false;
+            } else {
+                should_scroll = false;
+            }
+        }
 
     private bool scroll () {
       if (should_scroll) {
-        if(scroll_up) {
+        if (scroll_up) {
           vadjustment.value -= SCROLL_STEP_SIZE;
         } else {
           vadjustment.value += SCROLL_STEP_SIZE;
@@ -189,27 +189,27 @@ namespace Vocal {
       return should_scroll;
     }
 
-    private void on_drag_data_received(Gdk.DragContext context, int x, int y, Gtk.SelectionData selection_data, uint target_type, uint time) {
+    private void on_drag_data_received (Gdk.DragContext context, int x, int y, Gtk.SelectionData selection_data, uint target_type, uint time) {
       QueueListRow target;
       Gtk.Widget row;
       QueueListRow source;
       int newPos;
       int oldPos;
 
-      target  = (QueueListRow) get_row_at_y(y);
+      target = (QueueListRow) get_row_at_y (y);
 
-      newPos = target.get_index();
-      row = ((Gtk.Widget[]) selection_data.get_data())[0];
-      source = (QueueListRow) row.get_ancestor(typeof(QueueListRow));
-      oldPos = source.get_index();
+      newPos = target.get_index ();
+      row = ((Gtk.Widget[]) selection_data.get_data ())[0];
+      source = (QueueListRow) row.get_ancestor (typeof (QueueListRow));
+      oldPos = source.get_index ();
 
-      if(source == target) {
+      if (source == target) {
         return;
       }
 
-      remove(source);
-      insert(source, newPos);
-      update_queue(oldPos, newPos);
+      remove (source);
+      insert (source, newPos);
+      update_queue (oldPos, newPos);
     }
-	}
+    }
 }

--- a/src/Widgets/QueuePopover.vala
+++ b/src/Widgets/QueuePopover.vala
@@ -19,7 +19,7 @@
 
 namespace Vocal {
     public class QueuePopover : Gtk.Popover {
-        public signal void update_queue (int oldPos, int newPos);
+        public signal void update_queue (int oldPos, int newPos);  // vala-lint=naming-convention
         public signal void move_up (Episode e);
         public signal void move_down (Episode e);
         public signal void remove_episode (Episode e);
@@ -107,12 +107,12 @@ namespace Vocal {
   }
 
     class QueueList : Gtk.ListBox {
-        public signal void update_queue (int oldPos, int newPos);
+        public signal void update_queue (int oldPos, int newPos);  // vala-lint=naming-convention
         public signal void remove_episode (Episode e);
 
         public Gee.ArrayList<QueueListRow> rows;
 
-        private const Gtk.TargetEntry targetEntries[] = {
+        private const Gtk.TargetEntry targetEntries[] = {  // vala-lint=naming-convention
           { "GTK_LIST_BOX_ROW", Gtk.TargetFlags.SAME_APP, 0 }
     };
 
@@ -189,27 +189,34 @@ namespace Vocal {
       return should_scroll;
     }
 
-    private void on_drag_data_received (Gdk.DragContext context, int x, int y, Gtk.SelectionData selection_data, uint target_type, uint time) {
-      QueueListRow target;
-      Gtk.Widget row;
-      QueueListRow source;
-      int newPos;
-      int oldPos;
+    private void on_drag_data_received (
+        Gdk.DragContext context,
+        int x,
+        int y,
+        Gtk.SelectionData selection_data,
+        uint target_type,
+        uint time
+    ) {
+        QueueListRow target;
+        Gtk.Widget row;
+        QueueListRow source;
+        int newPos;
+        int oldPos;
 
-      target = (QueueListRow) get_row_at_y (y);
+        target = (QueueListRow) get_row_at_y (y);
 
-      newPos = target.get_index ();
-      row = ((Gtk.Widget[]) selection_data.get_data ())[0];
-      source = (QueueListRow) row.get_ancestor (typeof (QueueListRow));
-      oldPos = source.get_index ();
+        newPos = target.get_index ();
+        row = ((Gtk.Widget[]) selection_data.get_data ())[0];
+        source = (QueueListRow) row.get_ancestor (typeof (QueueListRow));
+        oldPos = source.get_index ();
 
-      if (source == target) {
-        return;
-      }
+        if (source == target) {
+            return;
+        }
 
-      remove (source);
-      insert (source, newPos);
-      update_queue (oldPos, newPos);
+        remove (source);
+        insert (source, newPos);
+        update_queue (oldPos, newPos);
     }
     }
 }

--- a/src/Widgets/QueueRow.vala
+++ b/src/Widgets/QueueRow.vala
@@ -25,77 +25,77 @@ namespace Vocal {
            { "GTK_LIST_BOX_ROW", Gtk.TargetFlags.SAME_APP, 0 }
         };
 
-        public signal void update_queue(int oldPos, int newPos);
-        public signal void move_up(Episode e);
-        public signal void move_down(Episode e);
-        public signal void remove_episode(Episode e);
+        public signal void update_queue (int oldPos, int newPos);
+        public signal void move_up (Episode e);
+        public signal void move_down (Episode e);
+        public signal void remove_episode (Episode e);
 
         public Episode episode;
         public Gtk.Box box;
 
-        public QueueListRow(Episode episode) {
+        public QueueListRow (Episode episode) {
             this.episode = episode;
 
-            box = new Gtk.Box(Gtk.Orientation.HORIZONTAL, 10);
+            box = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 10);
             box.margin_start = 10;
             box.margin_end = 10;
-            this.add(box);
+            this.add (box);
 
-            var handle = new Gtk.EventBox();
-            var dnd_icon = new Gtk.Image.from_icon_name("view-list-symbolic", Gtk.IconSize.BUTTON);
-            handle.add(dnd_icon);
-            box.pack_start(handle, false, false, 0);
+            var handle = new Gtk.EventBox ();
+            var dnd_icon = new Gtk.Image.from_icon_name ("view-list-symbolic", Gtk.IconSize.BUTTON);
+            handle.add (dnd_icon);
+            box.pack_start (handle, false, false, 0);
 
-            Gtk.drag_source_set(handle, Gdk.ModifierType.BUTTON1_MASK, targetEntries, Gdk.DragAction.MOVE);
-            handle.drag_begin.connect(on_drag_begin);
-            handle.drag_data_get.connect(on_drag_data_get);
+            Gtk.drag_source_set (handle, Gdk.ModifierType.BUTTON1_MASK, targetEntries, Gdk.DragAction.MOVE);
+            handle.drag_begin.connect (on_drag_begin);
+            handle.drag_data_get.connect (on_drag_data_get);
 
             try {
                 // Load the actual cover art
-				var file = GLib.File.new_for_uri(episode.parent.coverart_uri);
-				var icon = new GLib.FileIcon(file);
-				var image = new Gtk.Image.from_gicon(icon, Gtk.IconSize.DIALOG);
-				image.pixel_size = 64;
+                var file = GLib.File.new_for_uri (episode.parent.coverart_uri);
+                var icon = new GLib.FileIcon (file);
+                var image = new Gtk.Image.from_gicon (icon, Gtk.IconSize.DIALOG);
+                image.pixel_size = 64;
                 image.margin = 0;
                 image.expand = false;
-                image.get_style_context().add_class("album-artwork");
+                image.get_style_context ().add_class ("album-artwork");
 
-                box.pack_start(image, false, false, 0);
+                box.pack_start (image, false, false, 0);
             } catch (Error e) {}
 
-            Gtk.Label title_label = new Gtk.Label(Utils.truncate_string(episode.title.replace("%27", "'"), 35) + "...");
-            box.pack_start(title_label, false, false, 0);
+            Gtk.Label title_label = new Gtk.Label (Utils.truncate_string (episode.title.replace ("%27", "'"), 35) + "...");
+            box.pack_start (title_label, false, false, 0);
 
-            Gtk.Button remove_button = new Gtk.Button.from_icon_name("process-stop-symbolic", Gtk.IconSize.SMALL_TOOLBAR);
-            remove_button.get_style_context().add_class("flat");
-            remove_button.set_tooltip_text(_("Remove episode from queue"));
+            Gtk.Button remove_button = new Gtk.Button.from_icon_name ("process-stop-symbolic", Gtk.IconSize.SMALL_TOOLBAR);
+            remove_button.get_style_context ().add_class ("flat");
+            remove_button.set_tooltip_text (_ ("Remove episode from queue"));
 
-            remove_button.clicked.connect(() => { remove_episode(episode); });
+            remove_button.clicked.connect (() => { remove_episode (episode); });
 
-            box.pack_end(remove_button, false, false, 0);
+            box.pack_end (remove_button, false, false, 0);
         }
 
-        private void on_drag_begin(Gtk.Widget widget, Gdk.DragContext context){
-          var row = (QueueListRow) widget.get_ancestor(typeof(QueueListRow));
+        private void on_drag_begin (Gtk.Widget widget, Gdk.DragContext context) {
+          var row = (QueueListRow) widget.get_ancestor (typeof (QueueListRow));
 
           Gtk.Allocation alloc;
-          row.get_allocation(out alloc);
+          row.get_allocation (out alloc);
 
-          var surface = new Cairo.ImageSurface(Cairo.Format.ARGB32, alloc.width, alloc.height);
-          var cr = new Cairo.Context(surface);
+          var surface = new Cairo.ImageSurface (Cairo.Format.ARGB32, alloc.width, alloc.height);
+          var cr = new Cairo.Context (surface);
 
-          row.get_style_context().add_class("drag-icon");
-          row.draw(cr);
-          row.get_style_context().remove_class("drag-icon");
+          row.get_style_context ().add_class ("drag-icon");
+          row.draw (cr);
+          row.get_style_context ().remove_class ("drag-icon");
 
           int x, y;
-          widget.translate_coordinates(row, 0, 0, out x, out y);
-          surface.set_device_offset(-x, -y);
-          Gtk.drag_set_icon_surface(context, surface);
+          widget.translate_coordinates (row, 0, 0, out x, out y);
+          surface.set_device_offset (-x, -y);
+          Gtk.drag_set_icon_surface (context, surface);
         }
 
-        private void on_drag_data_get(Gtk.Widget widget, Gdk.DragContext context, Gtk.SelectionData selection_data, uint target_type, uint time) {
-          uchar[] data = new uchar[(sizeof (QueueListRow))];
+        private void on_drag_data_get (Gtk.Widget widget, Gdk.DragContext context, Gtk.SelectionData selection_data, uint target_type, uint time) {
+          uchar[] data = new uchar[ (sizeof (QueueListRow))];
           ((Gtk.Widget[])data)[0] = widget;
 
           selection_data.set (

--- a/src/Widgets/QueueRow.vala
+++ b/src/Widgets/QueueRow.vala
@@ -21,11 +21,11 @@
 namespace Vocal {
 
     public class QueueListRow : Gtk.ListBoxRow {
-        private const Gtk.TargetEntry targetEntries[] = {
+        private const Gtk.TargetEntry targetEntries[] = {  // vala-lint=naming-convention
            { "GTK_LIST_BOX_ROW", Gtk.TargetFlags.SAME_APP, 0 }
         };
 
-        public signal void update_queue (int oldPos, int newPos);
+        public signal void update_queue (int oldPos, int newPos);  // vala-lint=naming-convention
         public signal void move_up (Episode e);
         public signal void move_down (Episode e);
         public signal void remove_episode (Episode e);
@@ -63,10 +63,18 @@ namespace Vocal {
                 box.pack_start (image, false, false, 0);
             } catch (Error e) {}
 
-            Gtk.Label title_label = new Gtk.Label (Utils.truncate_string (episode.title.replace ("%27", "'"), 35) + "...");
+            Gtk.Label title_label = new Gtk.Label (
+                Utils.truncate_string (
+                    episode.title.replace ("%27", "'"),
+                    35
+                ) + "..."  // vala-lint=ellipsis
+            );
             box.pack_start (title_label, false, false, 0);
 
-            Gtk.Button remove_button = new Gtk.Button.from_icon_name ("process-stop-symbolic", Gtk.IconSize.SMALL_TOOLBAR);
+            Gtk.Button remove_button = new Gtk.Button.from_icon_name (
+                "process-stop-symbolic",
+                Gtk.IconSize.SMALL_TOOLBAR
+            );
             remove_button.get_style_context ().add_class ("flat");
             remove_button.set_tooltip_text (_ ("Remove episode from queue"));
 
@@ -94,13 +102,19 @@ namespace Vocal {
           Gtk.drag_set_icon_surface (context, surface);
         }
 
-        private void on_drag_data_get (Gtk.Widget widget, Gdk.DragContext context, Gtk.SelectionData selection_data, uint target_type, uint time) {
-          uchar[] data = new uchar[ (sizeof (QueueListRow))];
-          ((Gtk.Widget[])data)[0] = widget;
+        private void on_drag_data_get (
+            Gtk.Widget widget,
+            Gdk.DragContext context,
+            Gtk.SelectionData selection_data,
+            uint target_type,
+            uint time
+        ) {
+            uchar[] data = new uchar[(sizeof (QueueListRow))];
+            ((Gtk.Widget[])data)[0] = widget;
 
-          selection_data.set (
-              Gdk.Atom.intern_static_string ("GTK_LIST_BOX_ROW"), 32, data
-          );
+            selection_data.set (
+                Gdk.Atom.intern_static_string ("GTK_LIST_BOX_ROW"), 32, data
+            );
         }
     }
 }

--- a/src/Widgets/SearchResultBox.vala
+++ b/src/Widgets/SearchResultBox.vala
@@ -22,7 +22,7 @@ using Gtk;
 namespace Vocal {
     public class SearchResultBox : Gtk.Box {
 
-        public signal void subscribe_to_podcast(string itunes_url);
+        public signal void subscribe_to_podcast (string itunes_url);
 
         private Episode episode;
         private Podcast podcast;
@@ -38,10 +38,10 @@ namespace Vocal {
 
 
         /*
-         * Constructor for a box that contains a search result. SRs can be for a library episode, a library podcast, or 
+         * Constructor for a box that contains a search result. SRs can be for a library episode, a library podcast, or
          * content on the iTunes Store
          */
-        public SearchResultBox(Podcast? podcast, Episode? episode, string? details = null, string? subscribe_url = null) {
+        public SearchResultBox (Podcast? podcast, Episode? episode, string? details = null, string? subscribe_url = null) {
 
             this.episode = episode;
             this.podcast = podcast;
@@ -51,142 +51,142 @@ namespace Vocal {
             this.orientation = Gtk.Orientation.VERTICAL;
 
             // If it's an iTunes URL, find its matching generic RSS URL and set that for the subscribe link
-            if(subscribe_url != null && subscribe_url.contains("itunes.apple")) {
-                var itunes = new iTunesProvider();
-                rss_url = itunes.get_rss_from_itunes_url(subscribe_url);
+            if (subscribe_url != null && subscribe_url.contains ("itunes.apple")) {
+                var itunes = new iTunesProvider ();
+                rss_url = itunes.get_rss_from_itunes_url (subscribe_url);
             } else if (subscribe_url != null) {
                 rss_url = subscribe_url;
-            } 
+            }
 
-            var content_box = new Gtk.Box(Gtk.Orientation.HORIZONTAL, 5);
+            var content_box = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 5);
 
             // Do we only have a podcast?
-            if(episode == null) {
-                var missing_pixbuf = new Gdk.Pixbuf.from_resource_at_scale("/com/github/needleandthread/vocal/missing.png", 32, 32, true);
-                var image = new Gtk.Image.from_pixbuf(missing_pixbuf);
+            if (episode == null) {
+                var missing_pixbuf = new Gdk.Pixbuf.from_resource_at_scale ("/com/github/needleandthread/vocal/missing.png", 32, 32, true);
+                var image = new Gtk.Image.from_pixbuf (missing_pixbuf);
                 image.margin = 0;
                 image.expand = false;
-                image.get_style_context().add_class("album-artwork");
-                content_box.pack_start(image, false, false, 5);
+                image.get_style_context ().add_class ("album-artwork");
+                content_box.pack_start (image, false, false, 5);
 
-                var image_cache = new ImageCache();
-                image_cache.get_image.begin(podcast.coverart_uri, (obj, res) => {
-                    Gdk.Pixbuf pixbuf = image_cache.get_image.end(res);
+                var image_cache = new ImageCache ();
+                image_cache.get_image.begin (podcast.coverart_uri, (obj, res) => {
+                    Gdk.Pixbuf pixbuf = image_cache.get_image.end (res);
                     if (pixbuf != null) {
-                        image.clear();
-                        pixbuf = pixbuf.scale_simple(32, 32, Gdk.InterpType.BILINEAR);
-                        image.set_from_pixbuf(pixbuf);
+                        image.clear ();
+                        pixbuf = pixbuf.scale_simple (32, 32, Gdk.InterpType.BILINEAR);
+                        image.set_from_pixbuf (pixbuf);
                     }
                 });
-                var label = new Gtk.Label(podcast.name.replace("%27", "'"));
-                label.set_property("xalign", 0);
+                var label = new Gtk.Label (podcast.name.replace ("%27", "'"));
+                label.set_property ("xalign", 0);
                 label.ellipsize = Pango.EllipsizeMode.END;
                 label.max_width_chars = 30;
-                content_box.pack_start(label,true, true, 0);
+                content_box.pack_start (label,true, true, 0);
 
             // If not, then we have an episode, which requires more info to be displayed
             } else {
 
                 try {
-                    GLib.File cover = GLib.File.new_for_uri(podcast.coverart_uri);
-                    InputStream input_stream = cover.read();
-                    var pixbuf = new Gdk.Pixbuf.from_stream_at_scale(input_stream, 32, 32, true);
-                    var image = new Gtk.Image.from_pixbuf(pixbuf);
+                    GLib.File cover = GLib.File.new_for_uri (podcast.coverart_uri);
+                    InputStream input_stream = cover.read ();
+                    var pixbuf = new Gdk.Pixbuf.from_stream_at_scale (input_stream, 32, 32, true);
+                    var image = new Gtk.Image.from_pixbuf (pixbuf);
                     image.margin = 0;
                     image.expand = false;
-                    image.get_style_context().add_class("album-artwork");
+                    image.get_style_context ().add_class ("album-artwork");
 
-                    content_box.pack_start(image, false, false, 5);
+                    content_box.pack_start (image, false, false, 5);
                 } catch (Error e) {}
 
-                var box = new Gtk.Box(Gtk.Orientation.VERTICAL, 5);
-                var title_label = new Gtk.Label(episode.title);
-                var parent_label = new Gtk.Label(podcast.name.replace("%27", "'"));
-                title_label.set_property("xalign", 0);
-                parent_label.set_property("xalign", 0);
+                var box = new Gtk.Box (Gtk.Orientation.VERTICAL, 5);
+                var title_label = new Gtk.Label (episode.title);
+                var parent_label = new Gtk.Label (podcast.name.replace ("%27", "'"));
+                title_label.set_property ("xalign", 0);
+                parent_label.set_property ("xalign", 0);
                 title_label.ellipsize = Pango.EllipsizeMode.END;
                 parent_label.ellipsize = Pango.EllipsizeMode.END;
                 title_label.max_width_chars = 30;
                 parent_label.max_width_chars = 30;
-                box.add(title_label);
-                box.add(parent_label);
-                content_box.pack_start(box, true, true, 0);
+                box.add (title_label);
+                box.add (parent_label);
+                content_box.pack_start (box, true, true, 0);
             }
 
-            var details_box = new Gtk.Box(Gtk.Orientation.VERTICAL, 5);
-            details_box.set_no_show_all(true);
-            details_box.hide();
+            var details_box = new Gtk.Box (Gtk.Orientation.VERTICAL, 5);
+            details_box.set_no_show_all (true);
+            details_box.hide ();
 
             // Show a details button
-            if(details != null) {
-                var details_button = new Gtk.Button.from_icon_name(Utils.check_elementary() ? "help-info-symbolic" : "system-help-symbolic", Gtk.IconSize.SMALL_TOOLBAR);
+            if (details != null) {
+                var details_button = new Gtk.Button.from_icon_name (Utils.check_elementary () ? "help-info-symbolic" : "system-help-symbolic", Gtk.IconSize.SMALL_TOOLBAR);
                 details_button.relief = Gtk.ReliefStyle.NONE;
                 summary_label = new Gtk.Label ("");
-                details_button.tooltip_text = _("Summary");
+                details_button.tooltip_text = _ ("Summary");
                 summary_label.wrap = true;
                 summary_label.max_width_chars = 30;
-                details_box.add(summary_label);
+                details_box.add (summary_label);
 
-                details_button.clicked.connect(() => {
-                    if(!details_visible) {
-                        var feed_parser = new FeedParser();
-                        string summary =  feed_parser.find_description_from_file(rss_url);
-                        summary_label.set_text(summary.length > 0 ? summary : _("No summary available."));
+                details_button.clicked.connect (() => {
+                    if (!details_visible) {
+                        var feed_parser = new FeedParser ();
+                        string summary = feed_parser.find_description_from_file (rss_url);
+                        summary_label.set_text (summary.length > 0 ? summary : _ ("No summary available."));
                         feed_parser = null;
-                        details_box.set_no_show_all(false);
-                        details_box.show();
-                        show_all();
+                        details_box.set_no_show_all (false);
+                        details_box.show ();
+                        show_all ();
                         details_visible = true;
                     } else {
-                        details_box.set_no_show_all(true);
-                        details_box.hide();
+                        details_box.set_no_show_all (true);
+                        details_box.hide ();
                         details_visible = false;
                     }
-                }); 
+                });
 
                 details_button.can_focus = false;
                 summary_label.can_focus = false;
                 details_box.can_focus = false;
 
-                content_box.pack_start(details_button, false, false, 0);
+                content_box.pack_start (details_button, false, false, 0);
             }
-            
+
 
             // Show a subscribe button
-            if(subscribe_url != null) {
-                subscribe_button = new Gtk.Button.from_icon_name("list-add-symbolic", Gtk.IconSize.SMALL_TOOLBAR);
+            if (subscribe_url != null) {
+                subscribe_button = new Gtk.Button.from_icon_name ("list-add-symbolic", Gtk.IconSize.SMALL_TOOLBAR);
                 subscribe_button.relief = Gtk.ReliefStyle.NONE;
-                subscribe_button.tooltip_text = _("Subscribe to podcast");
+                subscribe_button.tooltip_text = _ ("Subscribe to podcast");
 
-                subscribe_button.clicked.connect(() => {
-                    var working_image = new Gtk.Image.from_icon_name("process-working-symbolic", Gtk.IconSize.SMALL_TOOLBAR);
+                subscribe_button.clicked.connect (() => {
+                    var working_image = new Gtk.Image.from_icon_name ("process-working-symbolic", Gtk.IconSize.SMALL_TOOLBAR);
                     subscribe_button.image = working_image;
-                    subscribe_to_podcast(subscribe_url);
-                }); 
+                    subscribe_to_podcast (subscribe_url);
+                });
 
-                content_box.pack_start(subscribe_button, false, false, 0);
+                content_box.pack_start (subscribe_button, false, false, 0);
             }
-            this.add(content_box);
-            this.add(details_box);
+            this.add (content_box);
+            this.add (details_box);
         }
-        
+
 
         /*
          * Gets the episode
          */
-        public Episode get_episode() {
+        public Episode get_episode () {
             return episode;
         }
 
         /*
          * Gets the podcast
          */
-        public Podcast get_podcast() {
+        public Podcast get_podcast () {
             return podcast;
         }
-        
-        public void set_button_icon(string icon_name) {
-            var new_image = new Gtk.Image.from_icon_name(icon_name, Gtk.IconSize.SMALL_TOOLBAR);
+
+        public void set_button_icon (string icon_name) {
+            var new_image = new Gtk.Image.from_icon_name (icon_name, Gtk.IconSize.SMALL_TOOLBAR);
             subscribe_button.image = new_image;
         }
     }

--- a/src/Widgets/SearchResultBox.vala
+++ b/src/Widgets/SearchResultBox.vala
@@ -41,7 +41,12 @@ namespace Vocal {
          * Constructor for a box that contains a search result. SRs can be for a library episode, a library podcast, or
          * content on the iTunes Store
          */
-        public SearchResultBox (Podcast? podcast, Episode? episode, string? details = null, string? subscribe_url = null) {
+        public SearchResultBox (
+            Podcast? podcast,
+            Episode? episode,
+            string? details = null,
+            string? subscribe_url = null
+        ) {
 
             this.episode = episode;
             this.podcast = podcast;
@@ -62,7 +67,12 @@ namespace Vocal {
 
             // Do we only have a podcast?
             if (episode == null) {
-                var missing_pixbuf = new Gdk.Pixbuf.from_resource_at_scale ("/com/github/needleandthread/vocal/missing.png", 32, 32, true);
+                var missing_pixbuf = new Gdk.Pixbuf.from_resource_at_scale (
+                    "/com/github/needleandthread/vocal/missing.png",
+                    32,
+                    32,
+                    true
+                );
                 var image = new Gtk.Image.from_pixbuf (missing_pixbuf);
                 image.margin = 0;
                 image.expand = false;
@@ -82,7 +92,7 @@ namespace Vocal {
                 label.set_property ("xalign", 0);
                 label.ellipsize = Pango.EllipsizeMode.END;
                 label.max_width_chars = 30;
-                content_box.pack_start (label,true, true, 0);
+                content_box.pack_start (label, true, true, 0);
 
             // If not, then we have an episode, which requires more info to be displayed
             } else {
@@ -119,7 +129,10 @@ namespace Vocal {
 
             // Show a details button
             if (details != null) {
-                var details_button = new Gtk.Button.from_icon_name (Utils.check_elementary () ? "help-info-symbolic" : "system-help-symbolic", Gtk.IconSize.SMALL_TOOLBAR);
+                var details_button = new Gtk.Button.from_icon_name (
+                    Utils.check_elementary () ? "help-info-symbolic" : "system-help-symbolic",
+                    Gtk.IconSize.SMALL_TOOLBAR
+                );
                 details_button.relief = Gtk.ReliefStyle.NONE;
                 summary_label = new Gtk.Label ("");
                 details_button.tooltip_text = _ ("Summary");
@@ -159,7 +172,10 @@ namespace Vocal {
                 subscribe_button.tooltip_text = _ ("Subscribe to podcast");
 
                 subscribe_button.clicked.connect (() => {
-                    var working_image = new Gtk.Image.from_icon_name ("process-working-symbolic", Gtk.IconSize.SMALL_TOOLBAR);
+                    var working_image = new Gtk.Image.from_icon_name (
+                        "process-working-symbolic",
+                        Gtk.IconSize.SMALL_TOOLBAR
+                    );
                     subscribe_button.image = working_image;
                     subscribe_to_podcast (subscribe_url);
                 });

--- a/src/Widgets/SearchResultsView.vala
+++ b/src/Widgets/SearchResultsView.vala
@@ -56,7 +56,8 @@ namespace Vocal {
         private Gtk.Revealer cloud_results_revealer;
 
         /*
-         * Constructor for the full search results view. Shows all matches from the local library and across the iTunes ecosystem
+         * Constructor for the full search results view.
+         * Shows all matches from the local library and across the iTunes ecosystem.
          */
         public SearchResultsView (Library library) {
 

--- a/src/Widgets/SearchResultsView.vala
+++ b/src/Widgets/SearchResultsView.vala
@@ -22,11 +22,11 @@ namespace Vocal {
 
     public class SearchResultsView : Gtk.Box {
 
-        public signal void on_new_subscription(string url);
-        public signal void return_to_library(); 
+        public signal void on_new_subscription (string url);
+        public signal void return_to_library ();
 
-        public signal void episode_selected(Podcast podcast, Episode episode);
-        public signal void podcast_selected(Podcast podcast);
+        public signal void episode_selected (Podcast podcast, Episode episode);
+        public signal void podcast_selected (Podcast podcast);
 
         public Gtk.SearchEntry search_entry;
 
@@ -35,9 +35,9 @@ namespace Vocal {
         private Gtk.Label title_label;
         private iTunesProvider itunes;
 
-        private Gtk.ListBox     local_episodes_listbox;
-        private Gtk.ListBox     local_podcasts_listbox;
-        private Gtk.FlowBox     cloud_results_flowbox;
+        private Gtk.ListBox local_episodes_listbox;
+        private Gtk.ListBox local_podcasts_listbox;
+        private Gtk.FlowBox cloud_results_flowbox;
 
         private Gee.ArrayList<Widget> local_episodes_widgets;
         private Gee.ArrayList<Widget> local_podcasts_widgets;
@@ -50,7 +50,7 @@ namespace Vocal {
 
         private Gtk.Label no_local_episodes_label;
         private Gtk.Label no_local_podcasts_label;
-        
+
         private Gtk.Revealer local_podcasts_revealer;
         private Gtk.Revealer local_episodes_revealer;
         private Gtk.Revealer cloud_results_revealer;
@@ -58,55 +58,55 @@ namespace Vocal {
         /*
          * Constructor for the full search results view. Shows all matches from the local library and across the iTunes ecosystem
          */
-        public SearchResultsView(Library library) {
+        public SearchResultsView (Library library) {
 
             string query = "";
-            this.set_orientation(Gtk.Orientation.VERTICAL);
-            this.itunes = new iTunesProvider();
+            this.set_orientation (Gtk.Orientation.VERTICAL);
+            this.itunes = new iTunesProvider ();
             this.library = library;
 
-            var return_button = new Gtk.Button.with_label(_("Return to Library"));
-            return_button.clicked.connect(() => { return_to_library (); });
-            
-            return_button.get_style_context().add_class("back-button");
+            var return_button = new Gtk.Button.with_label (_ ("Return to Library"));
+            return_button.clicked.connect (() => { return_to_library (); });
+
+            return_button.get_style_context ().add_class ("back-button");
             return_button.margin = 6;
             return_button.hexpand = true;
             return_button.halign = Gtk.Align.START;
 
             // Set up the title
 
-            title_label = new Gtk.Label("");
+            title_label = new Gtk.Label ("");
             title_label.margin_top = 5;
             title_label.margin_bottom = 5;
             title_label.justify = Gtk.Justification.CENTER;
             title_label.expand = false;
             title_label.use_markup = true;
-            title_label.get_style_context ().add_class("h2");
+            title_label.get_style_context ().add_class ("h2");
 
-            var local_episodes_label = new Gtk.Label(_("Episodes from Your Library"));
-            var local_podcasts_label = new Gtk.Label(_("Podcasts from Your Library"));
-            var cloud_results_label = new Gtk.Label(_("iTunes Podcast Results"));
-            
+            var local_episodes_label = new Gtk.Label (_ ("Episodes from Your Library"));
+            var local_podcasts_label = new Gtk.Label (_ ("Podcasts from Your Library"));
+            var cloud_results_label = new Gtk.Label (_ ("iTunes Podcast Results"));
+
             local_episodes_label.margin_right = 12;
             local_episodes_label.margin_left = 12;
             local_podcasts_label.margin_right = 12;
             local_podcasts_label.margin_left = 12;
 
-            local_episodes_label.get_style_context().add_class("h3");
-            local_episodes_label.set_property("xalign", 0);
-            local_podcasts_label.get_style_context().add_class("h3");
-            local_podcasts_label.set_property("xalign", 0);
-            cloud_results_label.get_style_context().add_class("h3");
-            cloud_results_label.set_property("xalign", 0);
+            local_episodes_label.get_style_context ().add_class ("h3");
+            local_episodes_label.set_property ("xalign", 0);
+            local_podcasts_label.get_style_context ().add_class ("h3");
+            local_podcasts_label.set_property ("xalign", 0);
+            cloud_results_label.get_style_context ().add_class ("h3");
+            cloud_results_label.set_property ("xalign", 0);
 
-            var iTunes_box = new  Gtk.Box(Gtk.Orientation.HORIZONTAL, 5);
-            spinner = new Gtk.Spinner();
+            var iTunes_box = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 5);
+            spinner = new Gtk.Spinner ();
 
-            var return_button_box = new Gtk.Box(Gtk.Orientation.HORIZONTAL, 0);
+            var return_button_box = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 0);
             return_button_box.homogeneous = true;
-            return_button_box.get_style_context().add_class("toolbar");
-            return_button_box.get_style_context().add_class("library-toolbar");
-            return_button_box.add(return_button);
+            return_button_box.get_style_context ().add_class ("toolbar");
+            return_button_box.get_style_context ().add_class ("library-toolbar");
+            return_button_box.add (return_button);
 
             search_entry = new Gtk.SearchEntry ();
             search_entry.valign = Gtk.Align.CENTER;
@@ -114,8 +114,8 @@ namespace Vocal {
             search_entry.max_width_chars = 40;
             search_entry.activate.connect (() => {
                 this.search_term = search_entry.text;
-                title_label.label = _("Search Results for <i>%s</i>".printf(search_term));
-		search_entry.grab_focus_without_selecting ();
+                title_label.label = _ ("Search Results for <i>%s</i>".printf (search_term));
+        search_entry.grab_focus_without_selecting ();
                 reset ();
                 show_spinner ();
                 load_from_itunes ();
@@ -124,77 +124,77 @@ namespace Vocal {
             return_button_box.add (search_entry);
             return_button_box.add (new Gtk.Label (""));
 
-            this.add(return_button_box);
+            this.add (return_button_box);
 
             // Create the lists container
-            content_box = new Gtk.Box(Gtk.Orientation.VERTICAL, 10);
-            var scrolled = new Gtk.ScrolledWindow(null, null);
-            content_box.add(title_label);
-            scrolled.add(content_box);
-            this.add(scrolled);
+            content_box = new Gtk.Box (Gtk.Orientation.VERTICAL, 10);
+            var scrolled = new Gtk.ScrolledWindow (null, null);
+            content_box.add (title_label);
+            scrolled.add (content_box);
+            this.add (scrolled);
 
-            local_episodes_listbox = new Gtk.ListBox();
-            local_podcasts_listbox = new Gtk.ListBox();
-            cloud_results_flowbox = new Gtk.FlowBox();
+            local_episodes_listbox = new Gtk.ListBox ();
+            local_podcasts_listbox = new Gtk.ListBox ();
+            cloud_results_flowbox = new Gtk.FlowBox ();
 
             local_episodes_listbox.activate_on_single_click = true;
             local_podcasts_listbox.activate_on_single_click = true;
 
-            local_episodes_listbox.button_press_event.connect(on_episode_activated);
-            local_podcasts_listbox.button_press_event.connect(on_podcast_activated);
+            local_episodes_listbox.button_press_event.connect (on_episode_activated);
+            local_podcasts_listbox.button_press_event.connect (on_podcast_activated);
             local_episodes_listbox.expand = true;
             local_podcasts_listbox.expand = true;
             cloud_results_flowbox.expand = true;
 
-            local_episodes_widgets = new Gee.ArrayList<Widget>();
-            local_podcasts_widgets = new Gee.ArrayList<Widget>();
-            cloud_results_widgets = new Gee.ArrayList<Widget>();
-            
-            no_local_episodes_label = new Gtk.Label (_("No matching episodes found in your library."));
-            no_local_podcasts_label = new Gtk.Label (_("No matching podcasts found in your library."));
+            local_episodes_widgets = new Gee.ArrayList<Widget> ();
+            local_podcasts_widgets = new Gee.ArrayList<Widget> ();
+            cloud_results_widgets = new Gee.ArrayList<Widget> ();
+
+            no_local_episodes_label = new Gtk.Label (_ ("No matching episodes found in your library."));
+            no_local_podcasts_label = new Gtk.Label (_ ("No matching podcasts found in your library."));
             no_local_episodes_label.halign = Gtk.Align.CENTER;
             no_local_podcasts_label.halign = Gtk.Align.CENTER;
             no_local_episodes_label.get_style_context ().add_class ("h3");
             no_local_podcasts_label.get_style_context ().add_class ("h3");
 
-            
-            local_podcasts_revealer = new Gtk.Revealer();
-            local_episodes_revealer = new Gtk.Revealer();
-            cloud_results_revealer = new Gtk.Revealer();
-            
-            var local_podcasts_container = new Gtk.Box(Gtk.Orientation.VERTICAL, 12);
+
+            local_podcasts_revealer = new Gtk.Revealer ();
+            local_episodes_revealer = new Gtk.Revealer ();
+            cloud_results_revealer = new Gtk.Revealer ();
+
+            var local_podcasts_container = new Gtk.Box (Gtk.Orientation.VERTICAL, 12);
             local_podcasts_container.margin_left = 12;
             local_podcasts_container.margin_right = 12;
-            local_podcasts_container.add(no_local_podcasts_label);
-            local_podcasts_container.add(local_podcasts_listbox);
-            local_podcasts_revealer.add(local_podcasts_container);
-            
-            var local_episodes_container = new Gtk.Box(Gtk.Orientation.VERTICAL, 12);
+            local_podcasts_container.add (no_local_podcasts_label);
+            local_podcasts_container.add (local_podcasts_listbox);
+            local_podcasts_revealer.add (local_podcasts_container);
+
+            var local_episodes_container = new Gtk.Box (Gtk.Orientation.VERTICAL, 12);
             local_episodes_container.margin_left = 12;
             local_episodes_container.margin_right = 12;
-            local_episodes_container.add(no_local_episodes_label);
-            local_episodes_container.add(local_episodes_listbox);
-            local_episodes_revealer.add(local_episodes_container);
-            
-            var cloud_results_container = new Gtk.Box(Gtk.Orientation.VERTICAL, 12);
+            local_episodes_container.add (no_local_episodes_label);
+            local_episodes_container.add (local_episodes_listbox);
+            local_episodes_revealer.add (local_episodes_container);
+
+            var cloud_results_container = new Gtk.Box (Gtk.Orientation.VERTICAL, 12);
             cloud_results_container.margin_left = 12;
             cloud_results_container.margin_right = 12;
-            cloud_results_container.add(iTunes_box);
-            cloud_results_container.add(cloud_results_flowbox);
-            cloud_results_revealer.add(cloud_results_container);
-            
+            cloud_results_container.add (iTunes_box);
+            cloud_results_container.add (cloud_results_flowbox);
+            cloud_results_revealer.add (cloud_results_container);
+
             var cloud_title_spinner_box = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 12);
             cloud_title_spinner_box.margin_left = 12;
             cloud_title_spinner_box.margin_right = 12;
             cloud_title_spinner_box.pack_start (cloud_results_label, false, false);
             cloud_title_spinner_box.pack_start (spinner, false, false);
-            
+
             content_box.add (local_podcasts_label);
-            content_box.add(local_podcasts_revealer);
+            content_box.add (local_podcasts_revealer);
             content_box.add (local_episodes_label);
-            content_box.add(local_episodes_revealer);
+            content_box.add (local_episodes_revealer);
             content_box.add (cloud_title_spinner_box);
-            content_box.add(cloud_results_revealer);
+            content_box.add (cloud_results_revealer);
 
             hide_no_local_podcasts ();
             hide_no_local_episodes ();
@@ -224,40 +224,40 @@ namespace Vocal {
         /*
          * Loads the full list of iTunes store matches (popover limited to top 5 only, for both speed and size concerns)
          */
-        private async void load_from_itunes() {
+        private async void load_from_itunes () {
 
             SourceFunc callback = load_from_itunes.callback;
-            show_spinner();
+            show_spinner ();
 
             ThreadFunc<void*> run = () => {
-                Gee.ArrayList<DirectoryEntry> c_matches = itunes.search_by_term(search_term);
-                foreach(DirectoryEntry c in c_matches) {
-                    DirectoryArt a = new DirectoryArt(c.itunesUrl, c.title, c.artist, c.summary, c.artworkUrl600);
-                    a.subscribe_button_clicked.connect((url) => {
-                        on_new_subscription(url);
+                Gee.ArrayList<DirectoryEntry> c_matches = itunes.search_by_term (search_term);
+                foreach (DirectoryEntry c in c_matches) {
+                    DirectoryArt a = new DirectoryArt (c.itunesUrl, c.title, c.artist, c.summary, c.artworkUrl600);
+                    a.subscribe_button_clicked.connect ((url) => {
+                        on_new_subscription (url);
                     });
-                    cloud_results_widgets.add(a);
+                    cloud_results_widgets.add (a);
 
                 }
 
-                Idle.add((owned) callback);
+                Idle.add ((owned) callback);
                 return null;
             };
-            Thread.create<void*>(run, false);
+            Thread.create<void*> (run, false);
 
             yield;
 
-            foreach(Widget w in cloud_results_widgets) {
-                cloud_results_flowbox.add(w);
+            foreach (Widget w in cloud_results_widgets) {
+                cloud_results_flowbox.add (w);
             }
-            
-            show_all();
+
+            show_all ();
             if (cloud_results_widgets.size < 1) {
                 cloud_results_revealer.reveal_child = false;
             } else {
                 cloud_results_revealer.reveal_child = true;
             }
-            
+
             hide_spinner ();
 
         }
@@ -268,25 +268,25 @@ namespace Vocal {
         private async void load_local_results () {
 
             SourceFunc callback = load_local_results.callback;
-            Gee.ArrayList<Podcast> p_matches = new Gee.ArrayList<Podcast>();
-            Gee.ArrayList<Episode> e_matches = new Gee.ArrayList<Episode>();
+            Gee.ArrayList<Podcast> p_matches = new Gee.ArrayList<Podcast> ();
+            Gee.ArrayList<Episode> e_matches = new Gee.ArrayList<Episode> ();
 
             ThreadFunc<void*> run = () => {
 
-                if(search_term.length > 0) {
+                if (search_term.length > 0) {
 
-					p_matches.clear();
-					p_matches.add_all(library.find_matching_podcasts(search_term));
+                    p_matches.clear ();
+                    p_matches.add_all (library.find_matching_podcasts (search_term));
 
-					e_matches.clear();
-					e_matches.add_all(library.find_matching_episodes(search_term));
-				}
+                    e_matches.clear ();
+                    e_matches.add_all (library.find_matching_episodes (search_term));
+                }
 
 
-                Idle.add((owned) callback);
+                Idle.add ((owned) callback);
                 return null;
             };
-            Thread.create<void*>(run, false);
+            Thread.create<void*> (run, false);
 
             yield;
 
@@ -294,13 +294,13 @@ namespace Vocal {
 
 
             // Actually load and show the results
-            foreach(Podcast p in p_matches) {
-                SearchResultBox srb = new SearchResultBox(p, null);
-                local_podcasts_widgets.add(srb);
-                local_podcasts_listbox.add(srb);
+            foreach (Podcast p in p_matches) {
+                SearchResultBox srb = new SearchResultBox (p, null);
+                local_podcasts_widgets.add (srb);
+                local_podcasts_listbox.add (srb);
             }
 
-            if(p_matches.size == 0) {
+            if (p_matches.size == 0) {
                 show_no_local_podcasts ();
                 hide_local_podcasts_listbox ();
 
@@ -309,22 +309,22 @@ namespace Vocal {
                 show_local_podcasts_listbox ();
             }
 
-            foreach(Episode e in e_matches) {
+            foreach (Episode e in e_matches) {
                 Podcast parent = null;
-                foreach(Podcast p in library.podcasts) {
-                    if(e.parent.name == p.name) {
+                foreach (Podcast p in library.podcasts) {
+                    if (e.parent.name == p.name) {
                         parent = p;
                     }
                 }
 
-                if(parent != null) {
-                    SearchResultBox srb = new SearchResultBox(parent, e);
-                    local_episodes_widgets.add(srb);
-                    local_episodes_listbox.add(srb);
+                if (parent != null) {
+                    SearchResultBox srb = new SearchResultBox (parent, e);
+                    local_episodes_widgets.add (srb);
+                    local_episodes_listbox.add (srb);
                 }
             }
 
-            if(e_matches.size == 0) {
+            if (e_matches.size == 0) {
                 show_no_local_episodes ();
                 hide_local_episodes_listbox ();
             } else {
@@ -339,22 +339,22 @@ namespace Vocal {
         /*
          * Called when a matching episode is selected by the user
          */
-        private bool on_episode_activated(Gdk.EventButton button) {
-            var row = local_episodes_listbox.get_row_at_y((int)button.y);
-            int index = row.get_index();
+        private bool on_episode_activated (Gdk.EventButton button) {
+            var row = local_episodes_listbox.get_row_at_y ((int)button.y);
+            int index = row.get_index ();
             SearchResultBox selected = local_episodes_widgets[index] as SearchResultBox;
-            episode_selected(selected.get_podcast(), selected.get_episode());
+            episode_selected (selected.get_podcast (), selected.get_episode ());
             return false;
         }
 
         /*
          * Called when a matching podcast is selected by the user
          */
-        private bool on_podcast_activated(Gdk.EventButton button) {
-            var row = local_podcasts_listbox.get_row_at_y((int)button.y);
-            int index = row.get_index();
+        private bool on_podcast_activated (Gdk.EventButton button) {
+            var row = local_podcasts_listbox.get_row_at_y ((int)button.y);
+            int index = row.get_index ();
             SearchResultBox selected = local_podcasts_widgets[index] as SearchResultBox;
-            podcast_selected(selected.get_podcast());
+            podcast_selected (selected.get_podcast ());
             return false;
         }
 

--- a/src/Widgets/SettingsDialog.vala
+++ b/src/Widgets/SettingsDialog.vala
@@ -198,7 +198,7 @@ namespace Vocal {
             foreach (string s in cc.values) {
                 list.append (s);
             }
-            list.sort ((a,b) => {
+            list.sort ((a, b) => {
                 int pos;
                 if (a < b) { pos = 0; } else { pos = 1; }
                 return pos;
@@ -254,7 +254,10 @@ namespace Vocal {
             content_box.add (archive_spacer);
 
 
-            var archive_api_key_linkbutton = new Gtk.LinkButton.with_label ("https://archive.org/account/s3.php", "See your archive.org API keys");
+            var archive_api_key_linkbutton = new Gtk.LinkButton.with_label (
+                "https://archive.org/account/s3.php",
+                "See your archive.org API keys"
+            );
 
             archive_access_key_label = new Gtk.Label (_ ("Archive.org S3 Access Key"));
             archive_access_key_label.justify = Gtk.Justification.LEFT;

--- a/src/Widgets/SettingsDialog.vala
+++ b/src/Widgets/SettingsDialog.vala
@@ -21,268 +21,268 @@ using Gtk;
 
 namespace Vocal {
 
-    public class SettingsDialog : Gtk.Dialog{
+    public class SettingsDialog : Gtk.Dialog {
 
-        public signal void      show_name_label_toggled();
-        
-        private Gtk.Label       keep_playing_in_background_label;
-        private Gtk.Switch      keep_playing_in_background_switch;
-    
-        private Gtk.Label       autodownload_new_label;
-        private Gtk.Switch      autodownload_new;
-        
-        private Gtk.Label       autoclean_label;
-        private Gtk.Switch      autoclean;
+        public signal void show_name_label_toggled ();
 
-        private Gtk.Label       show_name_label_label;
-        private Gtk.Switch      show_name_label_switch;
-        
-        private Gtk.Label       backward_interval_label;
-        private Gtk.SpinButton  backward_spinner;
-        
-        private Gtk.Label       forward_interval_label;
-        private Gtk.SpinButton  forward_spinner;
-        
-        private Gtk.Label       archive_access_key_label;
-        private Gtk.Entry       archive_access_key_entry;
-        
-        private Gtk.Label       archive_secret_key_label;
-        private Gtk.Entry       archive_secret_key_entry;
-        
-        
+        private Gtk.Label keep_playing_in_background_label;
+        private Gtk.Switch keep_playing_in_background_switch;
+
+        private Gtk.Label autodownload_new_label;
+        private Gtk.Switch autodownload_new;
+
+        private Gtk.Label autoclean_label;
+        private Gtk.Switch autoclean;
+
+        private Gtk.Label show_name_label_label;
+        private Gtk.Switch show_name_label_switch;
+
+        private Gtk.Label backward_interval_label;
+        private Gtk.SpinButton backward_spinner;
+
+        private Gtk.Label forward_interval_label;
+        private Gtk.SpinButton forward_spinner;
+
+        private Gtk.Label archive_access_key_label;
+        private Gtk.Entry archive_access_key_entry;
+
+        private Gtk.Label archive_secret_key_label;
+        private Gtk.Entry archive_secret_key_entry;
+
+
         public Gtk.Box content_box;
         private VocalSettings settings;
-        
+
         /*
          * Constructor for a settings dialog given the current settings
          * and a parent window the set the dialog relative to
          */
-        public SettingsDialog(VocalSettings settings, Gtk.Window parent) {
-            
-            title = _("Preferences");
-            this.settings = settings; 
-            
+        public SettingsDialog (VocalSettings settings, Gtk.Window parent) {
+
+            title = _ ("Preferences");
+            this.settings = settings;
+
 
             (get_header_bar () as Gtk.HeaderBar).show_close_button = false;
             get_header_bar ().get_style_context ().remove_class ("header-bar");
 
             this.modal = true;
             this.resizable = false;
-            this.set_transient_for(parent);
+            this.set_transient_for (parent);
             content_box = get_content_area () as Gtk.Box;
             content_box.homogeneous = false;
             content_box.margin = 12;
             content_box.spacing = 6;
-            
+
             // Keep playing in background option
             keep_playing_in_background_label = new Gtk.Label (_("Keep playing podcasts when the window is closed:"));
             keep_playing_in_background_label.justify = Gtk.Justification.LEFT;
             keep_playing_in_background_label.set_property ("xalign", 0);
-            
+
             keep_playing_in_background_switch = new Gtk.Switch ();
             keep_playing_in_background_switch.set_active (settings.keep_playing_in_background);
             keep_playing_in_background_switch.notify["active"].connect (() => {
                 settings.keep_playing_in_background = keep_playing_in_background_switch.active;
-		    });
-            
+            });
+
             var keep_playing_box = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 0);
             keep_playing_box.spacing = 5;
             keep_playing_box.pack_start (keep_playing_in_background_label, true, true, 0);
             keep_playing_box.pack_start (keep_playing_in_background_switch, false, false, 0);
             content_box.add (keep_playing_box);
-            
+
             // Autodownload option
-            autodownload_new_label = new Gtk.Label(_("Automatically download new episodes:"));
+            autodownload_new_label = new Gtk.Label (_ ("Automatically download new episodes:"));
             autodownload_new_label.justify = Gtk.Justification.LEFT;
-            autodownload_new_label.set_property("xalign", 0);
-            
-            autodownload_new = new Gtk.Switch();
-            
-            autodownload_new.set_active(settings.auto_download);
+            autodownload_new_label.set_property ("xalign", 0);
+
+            autodownload_new = new Gtk.Switch ();
+
+            autodownload_new.set_active (settings.auto_download);
             autodownload_new.notify["active"].connect (() => {
                 settings.auto_download = autodownload_new.active;
-		    });
-            
+            });
+
             var autodownload_box = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 0);
             autodownload_box.spacing = 5;
-            autodownload_box.pack_start(autodownload_new_label, true, true, 0);
-            autodownload_box.pack_start(autodownload_new, false, false, 0);
-            content_box.add(autodownload_box);
-            
+            autodownload_box.pack_start (autodownload_new_label, true, true, 0);
+            autodownload_box.pack_start (autodownload_new, false, false, 0);
+            content_box.add (autodownload_box);
+
             // Autoclean option
-            autoclean_label = new Gtk.Label(_("Keep my library clean:"));
+            autoclean_label = new Gtk.Label (_ ("Keep my library clean:"));
             autoclean_label.justify = Gtk.Justification.LEFT;
-            autoclean_label.set_property("xalign", 0);
-            
-            autoclean = new Gtk.Switch();
-            
-            autoclean.set_active(settings.autoclean_library);
+            autoclean_label.set_property ("xalign", 0);
+
+            autoclean = new Gtk.Switch ();
+
+            autoclean.set_active (settings.autoclean_library);
             autoclean.notify["active"].connect (() => {
                 settings.autoclean_library = autoclean.active;
-		    });
-            
+            });
+
             var autoclean_box = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 0);
             autoclean_box.spacing = 5;
-            autoclean_box.pack_start(autoclean_label, true, true, 0);
-            autoclean_box.pack_start(autoclean, false, false, 0);
-            content_box.add(autoclean_box);
+            autoclean_box.pack_start (autoclean_label, true, true, 0);
+            autoclean_box.pack_start (autoclean, false, false, 0);
+            content_box.add (autoclean_box);
 
             // Show name label option
-            show_name_label_label = new Gtk.Label(_("Show podcast names below cover art:"));
+            show_name_label_label = new Gtk.Label (_ ("Show podcast names below cover art:"));
             show_name_label_label.justify = Gtk.Justification.LEFT;
-            show_name_label_label.set_property("xalign", 0);
+            show_name_label_label.set_property ("xalign", 0);
 
-            show_name_label_switch = new Gtk.Switch();
-            show_name_label_switch.set_active(settings.show_name_label);
+            show_name_label_switch = new Gtk.Switch ();
+            show_name_label_switch.set_active (settings.show_name_label);
             show_name_label_switch.notify["active"].connect (() => {
                 settings.show_name_label = show_name_label_switch.active;
-                show_name_label_toggled();
+                show_name_label_toggled ();
             });
 
             var show_label_box = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 0);
             show_label_box.spacing = 5;
-            show_label_box.pack_start(show_name_label_label, true, true, 0);
-            show_label_box.pack_start(show_name_label_switch, false, false, 0);
-            content_box.add(show_label_box);
-            
-            
-		    Gtk.Separator check_spacer = new Gtk.Separator(Gtk.Orientation.HORIZONTAL);
+            show_label_box.pack_start (show_name_label_label, true, true, 0);
+            show_label_box.pack_start (show_name_label_switch, false, false, 0);
+            content_box.add (show_label_box);
+
+
+            Gtk.Separator check_spacer = new Gtk.Separator (Gtk.Orientation.HORIZONTAL);
             check_spacer.expand = false;
             check_spacer.margin_top = 12;
             check_spacer.margin_bottom = 12;
-            content_box.add(check_spacer);
-            
-            // Skip options
-		    var backward_interval_box = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 0);
-		  
-		    backward_interval_label = new Gtk.Label(_("Seconds to skip back:"));
-		    backward_interval_label.justify = Gtk.Justification.LEFT;
-		    backward_interval_label.halign = Gtk.Align.START;
-		    
-		    backward_spinner = new Gtk.SpinButton.with_range (0, 240, 15);
-		    backward_spinner.value = (double)settings.rewind_seconds;
-		    backward_spinner.value_changed.connect(() => {
-		        settings.rewind_seconds = (int) backward_spinner.value;
-		    });
-            backward_spinner.halign = Gtk.Align.END;
-		    
-		    backward_interval_box.pack_start(backward_interval_label, true, true, 0);
-		    backward_interval_box.pack_start(backward_spinner, false, false, 0);
-		    
-		    content_box.add(backward_interval_box);
-		    
-		    var forward_interval_box = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 0);
-		    
-		    forward_interval_label = new Gtk.Label(_("Seconds to skip forward:"));
-		    forward_interval_label.justify = Gtk.Justification.LEFT;
-		    forward_interval_label.halign = Gtk.Align.START;
-		    
-		    forward_spinner = new Gtk.SpinButton.with_range(0, 240, 15);
-		    forward_spinner.value = (double)settings.fast_forward_seconds;
-		    forward_spinner.value_changed.connect(() => {
-		        settings.fast_forward_seconds = (int) forward_spinner.value;
-		    });
-		    forward_spinner.halign = Gtk.Align.END;
+            content_box.add (check_spacer);
 
-		    forward_interval_box.pack_start(forward_interval_label, true, true, 0);
-		    forward_interval_box.pack_start(forward_spinner, false, false, 0);
-		    content_box.add(forward_interval_box);
-		    
+            // Skip options
+            var backward_interval_box = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 0);
+
+            backward_interval_label = new Gtk.Label (_ ("Seconds to skip back:"));
+            backward_interval_label.justify = Gtk.Justification.LEFT;
+            backward_interval_label.halign = Gtk.Align.START;
+
+            backward_spinner = new Gtk.SpinButton.with_range (0, 240, 15);
+            backward_spinner.value = (double)settings.rewind_seconds;
+            backward_spinner.value_changed.connect (() => {
+                settings.rewind_seconds = (int) backward_spinner.value;
+            });
+            backward_spinner.halign = Gtk.Align.END;
+
+            backward_interval_box.pack_start (backward_interval_label, true, true, 0);
+            backward_interval_box.pack_start (backward_spinner, false, false, 0);
+
+            content_box.add (backward_interval_box);
+
+            var forward_interval_box = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 0);
+
+            forward_interval_label = new Gtk.Label (_ ("Seconds to skip forward:"));
+            forward_interval_label.justify = Gtk.Justification.LEFT;
+            forward_interval_label.halign = Gtk.Align.START;
+
+            forward_spinner = new Gtk.SpinButton.with_range (0, 240, 15);
+            forward_spinner.value = (double)settings.fast_forward_seconds;
+            forward_spinner.value_changed.connect (() => {
+                settings.fast_forward_seconds = (int) forward_spinner.value;
+            });
+            forward_spinner.halign = Gtk.Align.END;
+
+            forward_interval_box.pack_start (forward_interval_label, true, true, 0);
+            forward_interval_box.pack_start (forward_spinner, false, false, 0);
+            content_box.add (forward_interval_box);
+
             // iTunes County Codes
-            Gtk.ListStore list_store = new Gtk.ListStore (1, typeof(string));
+            Gtk.ListStore list_store = new Gtk.ListStore (1, typeof (string));
             Gtk.TreeIter iter;
             int active_pos = 0, i = 0;
 
-            var cc = Utils.get_itunes_country_codes();
-            GLib.List<string> list = new GLib.List<string>();
-            foreach(string s in cc.values) {
-                list.append(s);
-            }     
-            list.sort((a,b) => {
+            var cc = Utils.get_itunes_country_codes ();
+            GLib.List<string> list = new GLib.List<string> ();
+            foreach (string s in cc.values) {
+                list.append (s);
+            }
+            list.sort ((a,b) => {
                 int pos;
                 if (a < b) { pos = 0; } else { pos = 1; }
                 return pos;
             });
 
             // Find the matching value in the list for the current setting
-            string current_store_id = cc.get(this.settings.itunes_store_country);
+            string current_store_id = cc.get (this.settings.itunes_store_country);
 
-            foreach(string s in list) {
+            foreach (string s in list) {
                 list_store.append (out iter);
                 list_store.set (iter, 0, s);
-                if(s == current_store_id) {
+                if (s == current_store_id) {
                     active_pos = i;
                 }
                 i++;
             }
 
-            var itunes_country_label = new Gtk.Label(_("Show iTunes Store results from:"));
+            var itunes_country_label = new Gtk.Label (_ ("Show iTunes Store results from:"));
             itunes_country_label.justify = Gtk.Justification.LEFT;
-            itunes_country_label.set_property("xalign", 0);
+            itunes_country_label.set_property ("xalign", 0);
 
-            var combo_box = new Gtk.ComboBox.with_model(list_store);
+            var combo_box = new Gtk.ComboBox.with_model (list_store);
             Gtk.CellRendererText renderer = new Gtk.CellRendererText ();
             combo_box.pack_start (renderer, true);
             combo_box.add_attribute (renderer, "text", 0);
             combo_box.active = active_pos;
 
             // When the combo box changes, save the setting
-            combo_box.changed.connect(() => {
+            combo_box.changed.connect (() => {
                 int active = combo_box.active;
-                string new_setting = list.nth(active).data;
+                string new_setting = list.nth (active).data;
 
-                foreach(string st in cc.keys) {
-                    if(cc.get(st) == new_setting) {
+                foreach (string st in cc.keys) {
+                    if (cc.get (st) == new_setting) {
                         this.settings.itunes_store_country = st;
                         break;
                     }
                 }
             });
 
-            Gtk.Separator store_spacer = new Gtk.Separator(Gtk.Orientation.HORIZONTAL);
+            Gtk.Separator store_spacer = new Gtk.Separator (Gtk.Orientation.HORIZONTAL);
             store_spacer.expand = false;
             store_spacer.margin_top = 12;
             store_spacer.margin_bottom = 12;
-            content_box.add(store_spacer);
+            content_box.add (store_spacer);
 
-            content_box.add(itunes_country_label);
-            content_box.add(combo_box);
-            
+            content_box.add (itunes_country_label);
+            content_box.add (combo_box);
+
             Gtk.Separator archive_spacer = new Gtk.Separator (Gtk.Orientation.HORIZONTAL);
             archive_spacer.expand = false;
             archive_spacer.margin_top = 12;
             content_box.add (archive_spacer);
-            
-            
+
+
             var archive_api_key_linkbutton = new Gtk.LinkButton.with_label ("https://archive.org/account/s3.php", "See your archive.org API keys");
-            
-            archive_access_key_label = new Gtk.Label (_("Archive.org S3 Access Key"));
+
+            archive_access_key_label = new Gtk.Label (_ ("Archive.org S3 Access Key"));
             archive_access_key_label.justify = Gtk.Justification.LEFT;
-		    archive_access_key_label.halign = Gtk.Align.START;
+            archive_access_key_label.halign = Gtk.Align.START;
             archive_access_key_entry = new Gtk.Entry ();
             archive_access_key_entry.set_text (settings.archive_access_key);
-            archive_access_key_entry.changed.connect ( () => {
+            archive_access_key_entry.changed.connect (() => {
                 settings.archive_access_key = archive_access_key_entry.text;
             });
-            
-            archive_secret_key_label = new Gtk.Label (_("Archive.org S3 Secret Key"));
+
+            archive_secret_key_label = new Gtk.Label (_ ("Archive.org S3 Secret Key"));
             archive_secret_key_label.justify = Gtk.Justification.LEFT;
-		    archive_secret_key_label.halign = Gtk.Align.START;
+            archive_secret_key_label.halign = Gtk.Align.START;
             archive_secret_key_entry = new Gtk.Entry ();
             archive_secret_key_entry.set_text (settings.archive_secret_key);
-            archive_secret_key_entry.changed.connect ( () => {
+            archive_secret_key_entry.changed.connect (() => {
                 settings.archive_secret_key = archive_secret_key_entry.text;
             });
-            
+
             content_box.add (archive_api_key_linkbutton);
             content_box.add (archive_access_key_label);
             content_box.add (archive_access_key_entry);
             content_box.add (archive_secret_key_label);
             content_box.add (archive_secret_key_entry);
-            
-            var close_button = new Gtk.Button.with_label (_("Close"));
-            close_button.clicked.connect(() => {
-                destroy();
+
+            var close_button = new Gtk.Button.with_label (_ ("Close"));
+            close_button.clicked.connect (() => {
+                destroy ();
             });
 
             var button_box = new Gtk.ButtonBox (Gtk.Orientation.HORIZONTAL);
@@ -290,7 +290,7 @@ namespace Vocal {
             button_box.pack_end (close_button);
 
             content_box.pack_end (button_box);
-            
+
             this.set_size_request (50, 50);
         }
     }

--- a/src/Widgets/ShowNotesPopover.vala
+++ b/src/Widgets/ShowNotesPopover.vala
@@ -18,34 +18,34 @@
 ***/
 
 namespace Vocal {
-	public class ShowNotesPopover : Gtk.Popover {
+    public class ShowNotesPopover : Gtk.Popover {
 
-		private Gtk.Label show_notes;
+        private Gtk.Label show_notes;
 
-		/*
-		 * Constructor for the shownotes popover relative to a given parent
-		 */
-		public ShowNotesPopover(Gtk.Widget parent) {
-			this.set_relative_to(parent);
+        /*
+         * Constructor for the shownotes popover relative to a given parent
+         */
+        public ShowNotesPopover (Gtk.Widget parent) {
+            this.set_relative_to (parent);
 
-			// Set up the scrolled window
-		  	var scrolled = new Gtk.ScrolledWindow(null, null);
-		  	show_notes = new Gtk.Label("");
-		  	show_notes.label = "";
-		  	show_notes.wrap = true;
-		  	show_notes.wrap_mode = Pango.WrapMode.WORD;
-		  	show_notes.use_markup = true;
-		  	show_notes.margin = 10;
-		  	scrolled.set_size_request(400, 200);
-		  	scrolled.add(show_notes);
-		  	this.add(scrolled);
-		}
-	
-		/*
-		 * Sets the text in the popover
-		 */
-		public void set_notes_text(string text) {
-			this.show_notes.label = Utils.html_to_markup(text);
-		}
-  	}
+            // Set up the scrolled window
+              var scrolled = new Gtk.ScrolledWindow (null, null);
+              show_notes = new Gtk.Label ("");
+              show_notes.label = "";
+              show_notes.wrap = true;
+              show_notes.wrap_mode = Pango.WrapMode.WORD;
+              show_notes.use_markup = true;
+              show_notes.margin = 10;
+              scrolled.set_size_request (400, 200);
+              scrolled.add (show_notes);
+              this.add (scrolled);
+        }
+
+        /*
+         * Sets the text in the popover
+         */
+        public void set_notes_text (string text) {
+            this.show_notes.label = Utils.html_to_markup (text);
+        }
+      }
 }

--- a/src/Widgets/Shownotes.vala
+++ b/src/Widgets/Shownotes.vala
@@ -20,194 +20,194 @@
 using Gtk;
 using Gee;
 using Granite;
-	namespace Vocal {
+    namespace Vocal {
 
-	    public class Shownotes : Gtk.ScrolledWindow {
+        public class Shownotes : Gtk.ScrolledWindow {
 
-    	public signal void copy_shareable_link();
-    	public signal void send_tweet();
-    	public signal void copy_direct_link();
-    	public signal void internet_archive_upload_requested ();
+        public signal void copy_shareable_link ();
+        public signal void send_tweet ();
+        public signal void copy_direct_link ();
+        public signal void internet_archive_upload_requested ();
 
-		public Gtk.Button play_button;
-		public Gtk.Button queue_button;
-		public Gtk.Button download_button;
-		public Gtk.Button share_button;
-		public Gtk.Button internet_archive_button;
-		public Gtk.Button mark_as_played_button;
-		public Gtk.Button mark_as_new_button;
-		public Gtk.Button delete_button;
-		public Episode episode = null;
+        public Gtk.Button play_button;
+        public Gtk.Button queue_button;
+        public Gtk.Button download_button;
+        public Gtk.Button share_button;
+        public Gtk.Button internet_archive_button;
+        public Gtk.Button mark_as_played_button;
+        public Gtk.Button mark_as_new_button;
+        public Gtk.Button delete_button;
+        public Episode episode = null;
 
-		public Gtk.MenuItem shareable_link;
-		public Gtk.MenuItem tweet;
-		public Gtk.MenuItem link_to_file;
+        public Gtk.MenuItem shareable_link;
+        public Gtk.MenuItem tweet;
+        public Gtk.MenuItem link_to_file;
 
-		private Gtk.Label title_label;
-		private Gtk.Label date_label;
-		private Gtk.Box controls_box;
-		private Gtk.Label shownotes_label;
+        private Gtk.Label title_label;
+        private Gtk.Label date_label;
+        private Gtk.Box controls_box;
+        private Gtk.Label shownotes_label;
 
-		public Shownotes () {
+        public Shownotes () {
 
-			var content_box = new Gtk.Box(Gtk.Orientation.VERTICAL, 0);
+            var content_box = new Gtk.Box (Gtk.Orientation.VERTICAL, 0);
 
-			shownotes_label = new Gtk.Label ("");
-			shownotes_label.margin = 12;
-			shownotes_label.halign = Gtk.Align.START;
-			shownotes_label.valign = Gtk.Align.START;
-			shownotes_label.xalign = 0;
-			shownotes_label.wrap = true;
+            shownotes_label = new Gtk.Label ("");
+            shownotes_label.margin = 12;
+            shownotes_label.halign = Gtk.Align.START;
+            shownotes_label.valign = Gtk.Align.START;
+            shownotes_label.xalign = 0;
+            shownotes_label.wrap = true;
 
-			controls_box = new Gtk.Box(Gtk.Orientation.HORIZONTAL, 0);
-			controls_box.get_style_context().add_class("toolbar");
-			controls_box.get_style_context().add_class("podcast-view-toolbar");
-			controls_box.height_request = 30;
+            controls_box = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 0);
+            controls_box.get_style_context ().add_class ("toolbar");
+            controls_box.get_style_context ().add_class ("podcast-view-toolbar");
+            controls_box.height_request = 30;
 
-			mark_as_played_button = new Gtk.Button.from_icon_name("object-select-symbolic", Gtk.IconSize.SMALL_TOOLBAR);
-			mark_as_played_button.has_tooltip = true;
-			mark_as_played_button.relief = Gtk.ReliefStyle.NONE;
-			mark_as_played_button.tooltip_text = _("Mark this episode as played");
+            mark_as_played_button = new Gtk.Button.from_icon_name ("object-select-symbolic", Gtk.IconSize.SMALL_TOOLBAR);
+            mark_as_played_button.has_tooltip = true;
+            mark_as_played_button.relief = Gtk.ReliefStyle.NONE;
+            mark_as_played_button.tooltip_text = _ ("Mark this episode as played");
 
-			mark_as_new_button = new Gtk.Button.from_icon_name("non-starred-symbolic", Gtk.IconSize.SMALL_TOOLBAR);
-			mark_as_new_button.has_tooltip = true;
-			mark_as_new_button.relief = Gtk.ReliefStyle.NONE;
-			mark_as_new_button.tooltip_text = _("Mark this episode as new");
+            mark_as_new_button = new Gtk.Button.from_icon_name ("non-starred-symbolic", Gtk.IconSize.SMALL_TOOLBAR);
+            mark_as_new_button.has_tooltip = true;
+            mark_as_new_button.relief = Gtk.ReliefStyle.NONE;
+            mark_as_new_button.tooltip_text = _ ("Mark this episode as new");
 
-			download_button = new Gtk.Button.from_icon_name(Utils.check_elementary() ? "browser-download-symbolic" : "document-save-symbolic", Gtk.IconSize.SMALL_TOOLBAR);
-			download_button.has_tooltip = true;
-			download_button.relief = Gtk.ReliefStyle.NONE;
-			download_button.tooltip_text = _("Download episode");
+            download_button = new Gtk.Button.from_icon_name (Utils.check_elementary () ? "browser-download-symbolic" : "document-save-symbolic", Gtk.IconSize.SMALL_TOOLBAR);
+            download_button.has_tooltip = true;
+            download_button.relief = Gtk.ReliefStyle.NONE;
+            download_button.tooltip_text = _ ("Download episode");
 
-			share_button = new Gtk.Button.from_icon_name(Utils.check_elementary() ? "send-to-symbolic" : "emblem-shared-symbolic", Gtk.IconSize.SMALL_TOOLBAR);
-			share_button.has_tooltip = true;
-			share_button.relief = Gtk.ReliefStyle.NONE;
-			share_button.tooltip_text = _("Share this episode");
-			share_button.button_press_event.connect((e) => {
-                var share_menu = new Gtk.Menu();
-                shareable_link = new Gtk.MenuItem.with_label(_("Copy shareable link"));
-                tweet = new Gtk.MenuItem.with_label(_("Send a Tweet…"));
-                link_to_file = new Gtk.MenuItem.with_label(_("Copy the direct episode link"));
+            share_button = new Gtk.Button.from_icon_name (Utils.check_elementary () ? "send-to-symbolic" : "emblem-shared-symbolic", Gtk.IconSize.SMALL_TOOLBAR);
+            share_button.has_tooltip = true;
+            share_button.relief = Gtk.ReliefStyle.NONE;
+            share_button.tooltip_text = _ ("Share this episode");
+            share_button.button_press_event.connect ((e) => {
+                var share_menu = new Gtk.Menu ();
+                shareable_link = new Gtk.MenuItem.with_label (_ ("Copy shareable link"));
+                tweet = new Gtk.MenuItem.with_label (_ ("Send a Tweet…"));
+                link_to_file = new Gtk.MenuItem.with_label (_ ("Copy the direct episode link"));
 
-                shareable_link.activate.connect(() => { copy_shareable_link(); });
-           		tweet.activate.connect(() => { send_tweet(); });
-            	link_to_file.activate.connect(() => { copy_direct_link(); });
+                shareable_link.activate.connect (() => { copy_shareable_link (); });
+                   tweet.activate.connect (() => { send_tweet (); });
+                link_to_file.activate.connect (() => { copy_direct_link (); });
 
-                share_menu.add(shareable_link);
-                share_menu.add(tweet);
-                share_menu.add(new Gtk.SeparatorMenuItem());
-                share_menu.add(link_to_file);
-                share_menu.attach_to_widget(share_button, null);
-                share_menu.show_all();
-                share_menu.popup(null, null, null, e.button, e.time);
+                share_menu.add (shareable_link);
+                share_menu.add (tweet);
+                share_menu.add (new Gtk.SeparatorMenuItem ());
+                share_menu.add (link_to_file);
+                share_menu.attach_to_widget (share_button, null);
+                share_menu.show_all ();
+                share_menu.popup (null, null, null, e.button, e.time);
                 return true;
             });
-            
+
             internet_archive_button = new Gtk.Button.from_icon_name ("document-send-symbolic", Gtk.IconSize.SMALL_TOOLBAR);
             internet_archive_button.relief = Gtk.ReliefStyle.NONE;
-            internet_archive_button.tooltip_text = _("Upload to the Internet Archive");
+            internet_archive_button.tooltip_text = _ ("Upload to the Internet Archive");
             internet_archive_button.button_press_event.connect ((e) => {
-            	internet_archive_upload_requested ();
-            	return true;
+                internet_archive_upload_requested ();
+                return true;
             });
 
-			controls_box.pack_start(mark_as_played_button, false, false, 0);
-			controls_box.pack_start(mark_as_new_button, false, false, 0);
-			controls_box.pack_start(download_button, false, false, 0);
-			controls_box.pack_end(share_button, false, false, 0);
-			controls_box.pack_end (internet_archive_button, false, false, 0);
+            controls_box.pack_start (mark_as_played_button, false, false, 0);
+            controls_box.pack_start (mark_as_new_button, false, false, 0);
+            controls_box.pack_start (download_button, false, false, 0);
+            controls_box.pack_end (share_button, false, false, 0);
+            controls_box.pack_end (internet_archive_button, false, false, 0);
 
-			title_label = new Gtk.Label("");
-			title_label.get_style_context().add_class("h3");
-			title_label.wrap = true;
-			title_label.wrap_mode = Pango.WrapMode.WORD;
-			title_label.margin_top = 20;
-			title_label.margin_bottom = 6;
-			title_label.margin_left = 12;
-			title_label.halign = Gtk.Align.START;
-			title_label.set_property("xalign", 0);
+            title_label = new Gtk.Label ("");
+            title_label.get_style_context ().add_class ("h3");
+            title_label.wrap = true;
+            title_label.wrap_mode = Pango.WrapMode.WORD;
+            title_label.margin_top = 20;
+            title_label.margin_bottom = 6;
+            title_label.margin_left = 12;
+            title_label.halign = Gtk.Align.START;
+            title_label.set_property ("xalign", 0);
 
-			date_label = new Gtk.Label("");
-			date_label.margin_bottom = 12;
-			date_label.margin_left = 12;
-			date_label.halign = Gtk.Align.START;
-			title_label.set_property("xalign", 0);
+            date_label = new Gtk.Label ("");
+            date_label.margin_bottom = 12;
+            date_label.margin_left = 12;
+            date_label.halign = Gtk.Align.START;
+            title_label.set_property ("xalign", 0);
 
-			play_button = new Gtk.Button.with_label("Play this episode");
-			queue_button = new Gtk.Button.from_icon_name("list-add-symbolic", Gtk.IconSize.SMALL_TOOLBAR);
-			queue_button.has_tooltip = true;
-			queue_button.tooltip_text = _("Add this episode to the up next list");
+            play_button = new Gtk.Button.with_label ("Play this episode");
+            queue_button = new Gtk.Button.from_icon_name ("list-add-symbolic", Gtk.IconSize.SMALL_TOOLBAR);
+            queue_button.has_tooltip = true;
+            queue_button.tooltip_text = _ ("Add this episode to the up next list");
 
-			var button_box = new Gtk.Box(Gtk.Orientation.HORIZONTAL, 5);
-			button_box.pack_start(play_button, false, false, 0);
-			button_box.pack_start(queue_button, false, false, 0);
-			button_box.margin_bottom = 20;
-			button_box.margin_left = 12;
+            var button_box = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 5);
+            button_box.pack_start (play_button, false, false, 0);
+            button_box.pack_start (queue_button, false, false, 0);
+            button_box.margin_bottom = 20;
+            button_box.margin_left = 12;
 
-			var summary_label = new Gtk.Label(_("<b>Summary</b>"));
-			summary_label.use_markup = true;
-			summary_label.margin_left = 12;
-			summary_label.margin_bottom = 6;
-			summary_label.halign = Gtk.Align.START;
+            var summary_label = new Gtk.Label (_ ("<b>Summary</b>"));
+            summary_label.use_markup = true;
+            summary_label.margin_left = 12;
+            summary_label.margin_bottom = 6;
+            summary_label.halign = Gtk.Align.START;
 
-			content_box.pack_start(controls_box, false, false, 0);
-			content_box.pack_start(title_label, false, false, 0);
-			content_box.pack_start(date_label, false, false, 0);
-			content_box.pack_start(button_box, false, false, 0);
-			content_box.pack_start(summary_label, false, false, 0);
-			content_box.pack_start(shownotes_label, true, true, 0);
+            content_box.pack_start (controls_box, false, false, 0);
+            content_box.pack_start (title_label, false, false, 0);
+            content_box.pack_start (date_label, false, false, 0);
+            content_box.pack_start (button_box, false, false, 0);
+            content_box.pack_start (summary_label, false, false, 0);
+            content_box.pack_start (shownotes_label, true, true, 0);
 
-			this.add (content_box);
-		}
+            this.add (content_box);
+        }
 
-		public void set_html(string html) {
-			this.shownotes_label.label = html;
-			shownotes_label.use_markup = true;
-			show_all();
-		}
+        public void set_html (string html) {
+            this.shownotes_label.label = html;
+            shownotes_label.use_markup = true;
+            show_all ();
+        }
 
-		public void show_download_button() {
-			this.download_button.set_no_show_all(false);
-			download_button.show();
-		}
+        public void show_download_button () {
+            this.download_button.set_no_show_all (false);
+            download_button.show ();
+        }
 
-		public void hide_download_button() {
-			this.download_button.set_no_show_all(true);
-			download_button.hide();
-		}
+        public void hide_download_button () {
+            this.download_button.set_no_show_all (true);
+            download_button.hide ();
+        }
 
-		public void set_title(string title) {
-			title_label.set_text(title.replace("%27", "'"));
-		}
+        public void set_title (string title) {
+            title_label.set_text (title.replace ("%27", "'"));
+        }
 
-		public void set_date(GLib.DateTime date) {
-			date_label.set_text(date.format("%x"));
-		}
+        public void set_date (GLib.DateTime date) {
+            date_label.set_text (date.format ("%x"));
+        }
 
-	    public void show_mark_as_new_button () {
-	        mark_as_played_button.no_show_all = true;
-	        mark_as_played_button.hide ();
+        public void show_mark_as_new_button () {
+            mark_as_played_button.no_show_all = true;
+            mark_as_played_button.hide ();
 
-	        mark_as_new_button.no_show_all = false;
-	        mark_as_new_button.show ();
-	    }
+            mark_as_new_button.no_show_all = false;
+            mark_as_new_button.show ();
+        }
 
-	    public void show_mark_as_played_button () {
-	        mark_as_played_button.no_show_all = false;
-	        mark_as_played_button.show ();
+        public void show_mark_as_played_button () {
+            mark_as_played_button.no_show_all = false;
+            mark_as_played_button.show ();
 
-	        mark_as_new_button.no_show_all = true;
-	        mark_as_new_button.hide ();
-	    }
-	    
-	    public void show_internet_archive_button () {
-	    	internet_archive_button.set_no_show_all (false);
-	    	internet_archive_button. show();
-	    }
-	    
-	    public void hide_internet_archive_button () {
-	    	internet_archive_button.set_no_show_all (true);
-	    	internet_archive_button. hide();
-	    }
-	}
+            mark_as_new_button.no_show_all = true;
+            mark_as_new_button.hide ();
+        }
+
+        public void show_internet_archive_button () {
+            internet_archive_button.set_no_show_all (false);
+            internet_archive_button. show ();
+        }
+
+        public void hide_internet_archive_button () {
+            internet_archive_button.set_no_show_all (true);
+            internet_archive_button. hide ();
+        }
+    }
 }

--- a/src/Widgets/Shownotes.vala
+++ b/src/Widgets/Shownotes.vala
@@ -64,7 +64,10 @@ using Granite;
             controls_box.get_style_context ().add_class ("podcast-view-toolbar");
             controls_box.height_request = 30;
 
-            mark_as_played_button = new Gtk.Button.from_icon_name ("object-select-symbolic", Gtk.IconSize.SMALL_TOOLBAR);
+            mark_as_played_button = new Gtk.Button.from_icon_name (
+                "object-select-symbolic",
+                Gtk.IconSize.SMALL_TOOLBAR
+            );
             mark_as_played_button.has_tooltip = true;
             mark_as_played_button.relief = Gtk.ReliefStyle.NONE;
             mark_as_played_button.tooltip_text = _ ("Mark this episode as played");
@@ -74,12 +77,18 @@ using Granite;
             mark_as_new_button.relief = Gtk.ReliefStyle.NONE;
             mark_as_new_button.tooltip_text = _ ("Mark this episode as new");
 
-            download_button = new Gtk.Button.from_icon_name (Utils.check_elementary () ? "browser-download-symbolic" : "document-save-symbolic", Gtk.IconSize.SMALL_TOOLBAR);
+            download_button = new Gtk.Button.from_icon_name (
+                Utils.check_elementary () ? "browser-download-symbolic" : "document-save-symbolic",
+                Gtk.IconSize.SMALL_TOOLBAR
+            );
             download_button.has_tooltip = true;
             download_button.relief = Gtk.ReliefStyle.NONE;
             download_button.tooltip_text = _ ("Download episode");
 
-            share_button = new Gtk.Button.from_icon_name (Utils.check_elementary () ? "send-to-symbolic" : "emblem-shared-symbolic", Gtk.IconSize.SMALL_TOOLBAR);
+            share_button = new Gtk.Button.from_icon_name (
+                Utils.check_elementary () ? "send-to-symbolic" : "emblem-shared-symbolic",
+                Gtk.IconSize.SMALL_TOOLBAR
+            );
             share_button.has_tooltip = true;
             share_button.relief = Gtk.ReliefStyle.NONE;
             share_button.tooltip_text = _ ("Share this episode");
@@ -103,7 +112,10 @@ using Granite;
                 return true;
             });
 
-            internet_archive_button = new Gtk.Button.from_icon_name ("document-send-symbolic", Gtk.IconSize.SMALL_TOOLBAR);
+            internet_archive_button = new Gtk.Button.from_icon_name (
+                "document-send-symbolic",
+                Gtk.IconSize.SMALL_TOOLBAR
+            );
             internet_archive_button.relief = Gtk.ReliefStyle.NONE;
             internet_archive_button.tooltip_text = _ ("Upload to the Internet Archive");
             internet_archive_button.button_press_event.connect ((e) => {

--- a/src/Widgets/Sidepane.vala
+++ b/src/Widgets/Sidepane.vala
@@ -23,30 +23,30 @@ using Granite;
 
 namespace Vocal {
     class Sidepane : Gtk.Box {
-    
-    	/* Signals */
-    
-    	public signal void play_episode_requested();
-    	public signal void download_episode_requested(Episode episode);
-        public signal void delete_local_episode_requested(Episode episode);
-        public signal void delete_multiple_episodes_requested(Gee.ArrayList<int> indexes);
-        public signal void mark_all_episodes_as_played_requested();
-        public signal void mark_episode_as_played_requested(Episode episode);
-        public signal void mark_multiple_episodes_as_played_requested(Gee.ArrayList<int> indexes);
-        public signal void mark_episode_as_unplayed_requested(Episode episode);
-        public signal void mark_multiple_episodes_as_unplayed_requested(Gee.ArrayList<int> indexes);
-    	public signal void pane_should_hide();
-        public signal void download_all_requested();
-        public signal void delete_podcast_requested();
-        public signal void unplayed_count_changed(int n);
 
-    
-        public Podcast 			podcast;				// The parent podcast
-        public MainWindow 		parent;					// The parent window
-        private VocalSettings 	settings;				// Vocal's current settings
-        public int 				current_episode_index;  // The index of the episode currently being used
-        private int 			boxes_index;        	// Refers to an index in the list of boxes
-        
+        /* Signals */
+
+        public signal void play_episode_requested ();
+        public signal void download_episode_requested (Episode episode);
+        public signal void delete_local_episode_requested (Episode episode);
+        public signal void delete_multiple_episodes_requested (Gee.ArrayList<int> indexes);
+        public signal void mark_all_episodes_as_played_requested ();
+        public signal void mark_episode_as_played_requested (Episode episode);
+        public signal void mark_multiple_episodes_as_played_requested (Gee.ArrayList<int> indexes);
+        public signal void mark_episode_as_unplayed_requested (Episode episode);
+        public signal void mark_multiple_episodes_as_unplayed_requested (Gee.ArrayList<int> indexes);
+        public signal void pane_should_hide ();
+        public signal void download_all_requested ();
+        public signal void delete_podcast_requested ();
+        public signal void unplayed_count_changed (int n);
+
+
+        public Podcast podcast;            // The parent podcast
+        public MainWindow parent;          // The parent window
+        private VocalSettings settings;    // Vocal's current settings
+        public int current_episode_index;  // The index of the episode currently being used
+        private int boxes_index;           // Refers to an index in the list of boxes
+
         private Gtk.ListBox listbox;
         private Gtk.Toolbar toolbar;
         private Gtk.Box toolbar_box;
@@ -54,164 +54,164 @@ namespace Vocal {
         private string count_string;
 
         private Gtk.Menu right_click_menu;
-		
-		public Gee.ArrayList<EpisodeDetailBox> boxes;
-		private EpisodeDetailBox previously_selected_box;
-        private EpisodeDetailBox previously_activated_box;
-		private Gtk.ScrolledWindow scrolled;
-		private int largest_box_size;
-		public int  unplayed_count;
-		private int limit;
 
-		/*
-		 * Constructor for a Sidepane given a parent window and pocast
-		 */
-        public Sidepane (MainWindow parent, Podcast podcast, bool? on_elementary = Utils.check_elementary()) {
-            assert(podcast!= null);
+        public Gee.ArrayList<EpisodeDetailBox> boxes;
+        private EpisodeDetailBox previously_selected_box;
+        private EpisodeDetailBox previously_activated_box;
+        private Gtk.ScrolledWindow scrolled;
+        private int largest_box_size;
+        public int unplayed_count;
+        private int limit;
+
+        /*
+         * Constructor for a Sidepane given a parent window and pocast
+         */
+        public Sidepane (MainWindow parent, Podcast podcast, bool? on_elementary = Utils.check_elementary ()) {
+            assert (podcast!= null);
             this.podcast = podcast;
             this.parent = parent;
-            this.settings = new VocalSettings();
-            
+            this.settings = new VocalSettings ();
+
             largest_box_size = 500;
-            
-			this.current_episode_index = 0;
+
+            this.current_episode_index = 0;
             this.boxes_index = 0;
-			this.orientation = Gtk.Orientation.VERTICAL;
-			
-			count_string = null;
-			
-            toolbar = new Gtk.Toolbar();
+            this.orientation = Gtk.Orientation.VERTICAL;
+
+            count_string = null;
+
+            toolbar = new Gtk.Toolbar ();
             toolbar.icon_size = Gtk.IconSize.MENU;
 
 
-            var mark_as_played_image = new Gtk.Image.from_icon_name("object-select-symbolic", Gtk.IconSize.MENU);
-            Gtk.ToolButton mark_as_played = new Gtk.ToolButton(mark_as_played_image, null);
-            mark_as_played.tooltip_text = _("Mark all episodes as played");
-            mark_as_played.clicked.connect(() => {
-                mark_all_episodes_as_played_requested();
+            var mark_as_played_image = new Gtk.Image.from_icon_name ("object-select-symbolic", Gtk.IconSize.MENU);
+            Gtk.ToolButton mark_as_played = new Gtk.ToolButton (mark_as_played_image, null);
+            mark_as_played.tooltip_text = _ ("Mark all episodes as played");
+            mark_as_played.clicked.connect (() => {
+                mark_all_episodes_as_played_requested ();
             });
-            toolbar.insert(mark_as_played, 0);
+            toolbar.insert (mark_as_played, 0);
 
-	        Gtk.Image download_image;	
-            download_image = new Gtk.Image.from_icon_name(check_elementary() ? "browser-download-symbolic" : "document-save-symbolic", Gtk.IconSize.MENU);
-            Gtk.ToolButton download_all = new Gtk.ToolButton(download_image, null);
-            download_all.tooltip_text = _("Download all episodes");
-            download_all.clicked.connect(() => {
-                download_all_requested();
-            });  
-            toolbar.insert(download_all, 1);
+            Gtk.Image download_image;
+            download_image = new Gtk.Image.from_icon_name (check_elementary () ? "browser-download-symbolic" : "document-save-symbolic", Gtk.IconSize.MENU);
+            Gtk.ToolButton download_all = new Gtk.ToolButton (download_image, null);
+            download_all.tooltip_text = _ ("Download all episodes");
+            download_all.clicked.connect (() => {
+                download_all_requested ();
+            });
+            toolbar.insert (download_all, 1);
 
-            var hide_played_image = new Gtk.Image.from_icon_name("view-list-symbolic", Gtk.IconSize.MENU);
-            Gtk.ToolButton hide_played = new Gtk.ToolButton(hide_played_image, null);
-            hide_played.tooltip_text = _("Hide episodes that have already been played");
-            hide_played.clicked.connect(() => {
+            var hide_played_image = new Gtk.Image.from_icon_name ("view-list-symbolic", Gtk.IconSize.MENU);
+            Gtk.ToolButton hide_played = new Gtk.ToolButton (hide_played_image, null);
+            hide_played.tooltip_text = _ ("Hide episodes that have already been played");
+            hide_played.clicked.connect (() => {
 
-                if(settings.hide_played) {
+                if (settings.hide_played) {
                     settings.hide_played = false;
                 } else {
                     settings.hide_played = true;
                 }
 
-                populate_episodes();
-                show_all();
+                populate_episodes ();
+                show_all ();
             });
 
-            toolbar.insert(hide_played, 2);
+            toolbar.insert (hide_played, 2);
 
-            Gtk.ToolItem spacer = new Gtk.ToolItem();
-            spacer.set_expand(true);
-            toolbar.insert(spacer, 3);
+            Gtk.ToolItem spacer = new Gtk.ToolItem ();
+            spacer.set_expand (true);
+            toolbar.insert (spacer, 3);
 
             var more_menu = new Gtk.Menu ();
-            var remove = new Gtk.MenuItem.with_label (_("Remove podcast from library"));
+            var remove = new Gtk.MenuItem.with_label (_ ("Remove podcast from library"));
             remove.activate.connect (() => {
-               delete_podcast_requested();
+               delete_podcast_requested ();
             });
-            remove.set_no_show_all(false);
-            remove.show();
-            more_menu.add(remove);
+            remove.set_no_show_all (false);
+            remove.show ();
+            more_menu.add (remove);
 
 
-            var menu_image = new Gtk.Image.from_icon_name("open-menu-symbolic", Gtk.IconSize.MENU);
-            Gtk.ToolButton menu = new Gtk.ToolButton(menu_image, null);
-            menu.tooltip_text = _("More options");
+            var menu_image = new Gtk.Image.from_icon_name ("open-menu-symbolic", Gtk.IconSize.MENU);
+            Gtk.ToolButton menu = new Gtk.ToolButton (menu_image, null);
+            menu.tooltip_text = _ ("More options");
 
-            menu.clicked.connect(() => {
-                more_menu.popup(null, null, null, 1,Gdk.CURRENT_TIME );
+            menu.clicked.connect (() => {
+                more_menu.popup (null, null, null, 1,Gdk.CURRENT_TIME );
             });
 
 
-            toolbar.insert(menu, 4);
+            toolbar.insert (menu, 4);
 
-            toolbar_box = new Gtk.Box(Gtk.Orientation.VERTICAL, 0);
-            toolbar_box.pack_start(new Gtk.Separator(Gtk.Orientation.HORIZONTAL), true, true, 0);
-            toolbar_box.pack_start(toolbar, true, true, 0);
+            toolbar_box = new Gtk.Box (Gtk.Orientation.VERTICAL, 0);
+            toolbar_box.pack_start (new Gtk.Separator (Gtk.Orientation.HORIZONTAL), true, true, 0);
+            toolbar_box.pack_start (toolbar, true, true, 0);
 
 
 
-			// Create the header box and set it up
-			var headerbox = new Gtk.Box(Gtk.Orientation.VERTICAL, 5);
-			var horizontal_box = new Gtk.Box(Gtk.Orientation.HORIZONTAL, 5);
-			var labelbox = new Gtk.Box(Gtk.Orientation.VERTICAL, 5);
-			labelbox.hexpand = true;
-				
-			try {
-			    GLib.File cover = GLib.File.new_for_uri(podcast.coverart_uri);
-                InputStream input_stream = cover.read();
-                var pixbuf = new Gdk.Pixbuf.from_stream_at_scale(input_stream, 64, 64, true);
-                var image = new Gtk.Image.from_pixbuf(pixbuf);
+            // Create the header box and set it up
+            var headerbox = new Gtk.Box (Gtk.Orientation.VERTICAL, 5);
+            var horizontal_box = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 5);
+            var labelbox = new Gtk.Box (Gtk.Orientation.VERTICAL, 5);
+            labelbox.hexpand = true;
+
+            try {
+                GLib.File cover = GLib.File.new_for_uri (podcast.coverart_uri);
+                InputStream input_stream = cover.read ();
+                var pixbuf = new Gdk.Pixbuf.from_stream_at_scale (input_stream, 64, 64, true);
+                var image = new Gtk.Image.from_pixbuf (pixbuf);
                 image.margin = 5;
                 image.margin_bottom = 0;
 
-                horizontal_box.pack_start(image, false, false, 0);
+                horizontal_box.pack_start (image, false, false, 0);
             } catch (Error e) {}
-            
-            
-			var name_label = new Gtk.Label(podcast.name.replace("%27", "'"));
-			count_label = new Gtk.Label(count_string);
-			name_label.max_width_chars = 15;
-			name_label.wrap = true;
-			name_label.justify = Gtk.Justification.CENTER;
-			
-			Granite.Widgets.Utils.apply_text_style_to_label (TextStyle.H2, name_label);
+
+
+            var name_label = new Gtk.Label (podcast.name.replace ("%27", "'"));
+            count_label = new Gtk.Label (count_string);
+            name_label.max_width_chars = 15;
+            name_label.wrap = true;
+            name_label.justify = Gtk.Justification.CENTER;
+
+            Granite.Widgets.Utils.apply_text_style_to_label (TextStyle.H2, name_label);
             Granite.Widgets.Utils.apply_text_style_to_label (TextStyle.H3, count_label);
-            
-            
-			labelbox.pack_start(name_label, true, true, 0);
-			labelbox.pack_start(count_label, true, true, 0);
-			horizontal_box.pack_start(labelbox, true, true, 0);
-			
-			// Set up the hide panel button
+
+
+            labelbox.pack_start (name_label, true, true, 0);
+            labelbox.pack_start (count_label, true, true, 0);
+            horizontal_box.pack_start (labelbox, true, true, 0);
+
+            // Set up the hide panel button
              Gtk.Button hide_pane;
-            if(parent.on_elementary)
-			     hide_pane = new Gtk.Button.from_icon_name("pane-hide-symbolic", Gtk.IconSize.BUTTON);
+            if (parent.on_elementary)
+                 hide_pane = new Gtk.Button.from_icon_name ("pane-hide-symbolic", Gtk.IconSize.BUTTON);
             else
-                hide_pane = new Gtk.Button.from_icon_name("go-last-symbolic", Gtk.IconSize.BUTTON);
-			hide_pane.relief = Gtk.ReliefStyle.NONE;
-            hide_pane.tooltip_text = _("Hide the episode side pane");
-			hide_pane.clicked.connect(() => {
-			    pane_should_hide();
-			});
-			horizontal_box.pack_start(hide_pane, false, false, 0);
-			
-			headerbox.pack_start(horizontal_box, false, false, 0);
-            headerbox.add(new Gtk.Separator(Gtk.Orientation.HORIZONTAL));
-			
-			this.add(headerbox);
+                hide_pane = new Gtk.Button.from_icon_name ("go-last-symbolic", Gtk.IconSize.BUTTON);
+            hide_pane.relief = Gtk.ReliefStyle.NONE;
+            hide_pane.tooltip_text = _ ("Hide the episode side pane");
+            hide_pane.clicked.connect (() => {
+                pane_should_hide ();
+            });
+            horizontal_box.pack_start (hide_pane, false, false, 0);
+
+            headerbox.pack_start (horizontal_box, false, false, 0);
+            headerbox.add (new Gtk.Separator (Gtk.Orientation.HORIZONTAL));
+
+            this.add (headerbox);
 
             // Populate the list box
-            populate_episodes();          
-              
+            populate_episodes ();
+
         }
-        
-        /* 
+
+        /*
          * Gets an episode's corresponding box index in the list of EpisodeDetailBoxes
          */
-        public int get_box_index_from_episode(Episode e) {
+        public int get_box_index_from_episode (Episode e) {
 
             int index = 0;
-            foreach(EpisodeDetailBox b in boxes) {
-                if(b.episode == e) {
+            foreach (EpisodeDetailBox b in boxes) {
+                if (b.episode == e) {
                     return index;
                 } else {
                     index++;
@@ -220,133 +220,133 @@ namespace Vocal {
 
             return -1;
         }
-        
+
         /*
          * Marks each episode detail box in the list as played
          */
-        public void mark_all_played() {
-            foreach(EpisodeDetailBox b in boxes) {
-                b.mark_as_played();
+        public void mark_all_played () {
+            foreach (EpisodeDetailBox b in boxes) {
+                b.mark_as_played ();
             }
         }
 
-		/*
-		 * Handler for when a box has a button press event
-		 */
-        private bool on_button_press_event(Gdk.EventButton e) {
+        /*
+         * Handler for when a box has a button press event
+         */
+        private bool on_button_press_event (Gdk.EventButton e) {
 
-            if(e.button == 3 && podcast.episodes.size > 0) {
+            if (e.button == 3 && podcast.episodes.size > 0) {
 
-                GLib.List<weak ListBoxRow> rows = listbox.get_selected_rows();
-                if(rows.length() > 1) {
+                GLib.List<weak ListBoxRow> rows = listbox.get_selected_rows ();
+                if (rows.length () > 1) {
 
 
                     // Multiple rows selected
 
-                    right_click_menu = new Gtk.Menu();
-             
-                    var mark_played_menuitem = new Gtk.MenuItem.with_label(_("Mark selected episodes as played"));
+                    right_click_menu = new Gtk.Menu ();
 
-                    mark_played_menuitem.activate.connect(() => {
+                    var mark_played_menuitem = new Gtk.MenuItem.with_label (_ ("Mark selected episodes as played"));
 
-                            GLib.List<weak ListBoxRow> rows1 = listbox.get_selected_rows();
-                            Gee.ArrayList<int> indexes = new Gee.ArrayList<int>();
+                    mark_played_menuitem.activate.connect (() => {
+
+                            GLib.List<weak ListBoxRow> rows1 = listbox.get_selected_rows ();
+                            Gee.ArrayList<int> indexes = new Gee.ArrayList<int> ();
 
 
-                            foreach(ListBoxRow r in rows1) {
-                                current_episode_index = (podcast.episodes.size - r.get_index() - 1);
-                                indexes.add(current_episode_index);
+                            foreach (ListBoxRow r in rows1) {
+                                current_episode_index = (podcast.episodes.size - r.get_index () - 1);
+                                indexes.add (current_episode_index);
                             }
 
 
                             // Set all the boxes to hide the played image
-                            foreach(int i in indexes) {
+                            foreach (int i in indexes) {
                                 int floor = podcast.episodes.size - limit -1;
                                 int num;
 
                                 (floor >= 0) ? num = i - floor : num = i;
 
-                                boxes[num].mark_as_played();
+                                boxes[num].mark_as_played ();
                             }
 
-                            mark_multiple_episodes_as_played_requested(indexes);
-                            reset_unplayed_count();
+                            mark_multiple_episodes_as_played_requested (indexes);
+                            reset_unplayed_count ();
 
                     });
-                    right_click_menu.add(mark_played_menuitem);
+                    right_click_menu.add (mark_played_menuitem);
 
-                    var mark_unplayed_menuitem = new Gtk.MenuItem.with_label(_("Mark selected episodes as unplayed"));
-                    mark_unplayed_menuitem.activate.connect(() => {
+                    var mark_unplayed_menuitem = new Gtk.MenuItem.with_label (_ ("Mark selected episodes as unplayed"));
+                    mark_unplayed_menuitem.activate.connect (() => {
 
-                        GLib.List<weak ListBoxRow> rows2 = listbox.get_selected_rows();
-                        Gee.ArrayList<int> indexes = new Gee.ArrayList<int>();
+                        GLib.List<weak ListBoxRow> rows2 = listbox.get_selected_rows ();
+                        Gee.ArrayList<int> indexes = new Gee.ArrayList<int> ();
 
-                        foreach(ListBoxRow r in rows2) {
-                            current_episode_index = (podcast.episodes.size - r.get_index() - 1);
-                            indexes.add(current_episode_index);
+                        foreach (ListBoxRow r in rows2) {
+                            current_episode_index = (podcast.episodes.size - r.get_index () - 1);
+                            indexes.add (current_episode_index);
                         }
 
-                        
+
 
                         // Set all the boxes to show the played image
-                        foreach(int i in indexes) {
+                        foreach (int i in indexes) {
                             int floor = podcast.episodes.size - limit -1;
                             int num;
 
                             (floor >= 0) ? num = i - floor : num = i;
-       
-                            boxes[num].mark_as_unplayed();
+
+                            boxes[num].mark_as_unplayed ();
                         }
 
-                        mark_multiple_episodes_as_unplayed_requested(indexes);  
+                        mark_multiple_episodes_as_unplayed_requested (indexes);
 
-                        reset_unplayed_count();
+                        reset_unplayed_count ();
 
 
                     });
-                    right_click_menu.add(mark_unplayed_menuitem);
+                    right_click_menu.add (mark_unplayed_menuitem);
 
 
-                    var delete_menuitem = new Gtk.MenuItem.with_label(_("Delete local files for selected episodes"));
-                    delete_menuitem.activate.connect(() => {
+                    var delete_menuitem = new Gtk.MenuItem.with_label (_ ("Delete local files for selected episodes"));
+                    delete_menuitem.activate.connect (() => {
 
                         Gtk.MessageDialog msg = new Gtk.MessageDialog (parent, Gtk.DialogFlags.MODAL, Gtk.MessageType.WARNING, Gtk.ButtonsType.NONE,
-                             _("Are you sure you want to delete the downloaded files for the selected episodes?"));
-                             
-                             
+                             _ ("Are you sure you want to delete the downloaded files for the selected episodes?"));
+
+
                         msg.add_button ("_No", Gtk.ResponseType.CANCEL);
-                        Gtk.Button delete_button = (Gtk.Button) msg.add_button("_Yes", Gtk.ResponseType.YES);
-                        delete_button.get_style_context().add_class("destructive-action");
-                    
-                        var image = new Gtk.Image.from_icon_name("dialog-question", Gtk.IconSize.DIALOG);     
+                        Gtk.Button delete_button = (Gtk.Button) msg.add_button ("_Yes", Gtk.ResponseType.YES);
+                        delete_button.get_style_context ().add_class ("destructive-action");
+
+                        var image = new Gtk.Image.from_icon_name ("dialog-question", Gtk.IconSize.DIALOG);
                         msg.image = image;
-                        msg.image.show_all();
-                        
+                        msg.image.show_all ();
+
                         msg.response.connect ((response_id) => {
                             switch (response_id) {
                                 case Gtk.ResponseType.YES:
 
-                                    GLib.List<weak ListBoxRow> rows3 = listbox.get_selected_rows();
-                                    Gee.ArrayList<int> indexes = new Gee.ArrayList<int>();
+                                    GLib.List<weak ListBoxRow> rows3 = listbox.get_selected_rows ();
+                                    Gee.ArrayList<int> indexes = new Gee.ArrayList<int> ();
 
 
-                                    foreach(ListBoxRow r in rows3) {
-                                        current_episode_index = (podcast.episodes.size - r.get_index() - 1);
-                                        indexes.add(current_episode_index);
+                                    foreach (ListBoxRow r in rows3) {
+                                        current_episode_index = (podcast.episodes.size - r.get_index () - 1);
+                                        indexes.add (current_episode_index);
                                     }
 
-                                    delete_multiple_episodes_requested(indexes);
+                                    delete_multiple_episodes_requested (indexes);
                                     break;
                                 case Gtk.ResponseType.NO:
                                     break;
                             }
-                            msg.destroy();
+                            msg.destroy ();
                         });
 
                         msg.show ();
 
                     });
-                    right_click_menu.add(delete_menuitem);
+                    right_click_menu.add (delete_menuitem);
 
 
 
@@ -354,93 +354,93 @@ namespace Vocal {
 
                     // Only a single row selected
 
-                    ListBoxRow new_row = listbox.get_row_at_y((int)e.y);
-                    current_episode_index = (podcast.episodes.size - new_row.get_index() - 1);
-                    
-                    if(current_episode_index >= 0 && current_episode_index < boxes.size) {
+                    ListBoxRow new_row = listbox.get_row_at_y ((int)e.y);
+                    current_episode_index = (podcast.episodes.size - new_row.get_index () - 1);
+
+                    if (current_episode_index >= 0 && current_episode_index < boxes.size) {
                         previously_selected_box = boxes[current_episode_index];
                     }
 
                     // Populate the right click menu based on the current conditions
-                    right_click_menu = new Gtk.Menu();
+                    right_click_menu = new Gtk.Menu ();
 
                     // Mark as played
-                    if(podcast.episodes[current_episode_index].status != EpisodeStatus.PLAYED) {
-                        var mark_played_menuitem = new Gtk.MenuItem.with_label(_("Mark as Played"));
-                        mark_played_menuitem.activate.connect(() => {
+                    if (podcast.episodes[current_episode_index].status != EpisodeStatus.PLAYED) {
+                        var mark_played_menuitem = new Gtk.MenuItem.with_label (_ ("Mark as Played"));
+                        mark_played_menuitem.activate.connect (() => {
                             unplayed_count--;
-                            set_unplayed_text();
+                            set_unplayed_text ();
 
                             // Remove the unplayed image from the episode's box
                             int floor = podcast.episodes.size - limit -1;
                             int num;
 
                             (floor >= 0) ? num = current_episode_index - floor : num = current_episode_index;
-       
-                            boxes[num].mark_as_played();
 
-                            mark_episode_as_played_requested(podcast.episodes[current_episode_index]);
+                            boxes[num].mark_as_played ();
+
+                            mark_episode_as_played_requested (podcast.episodes[current_episode_index]);
                         });
-                        right_click_menu.add(mark_played_menuitem);
+                        right_click_menu.add (mark_played_menuitem);
 
                     // Mark as unplayed
                     } else {
-                        var mark_unplayed_menuitem = new Gtk.MenuItem.with_label(_("Mark as Unplayed"));
-                        mark_unplayed_menuitem.activate.connect(() => {
+                        var mark_unplayed_menuitem = new Gtk.MenuItem.with_label (_ ("Mark as Unplayed"));
+                        mark_unplayed_menuitem.activate.connect (() => {
                             unplayed_count++;
-                            set_unplayed_text();
+                            set_unplayed_text ();
 
                             // Remove the unplayed image from the episode's box
                             int floor = podcast.episodes.size - limit -1;
                             int num;
 
                             (floor >= 0) ? num = current_episode_index - floor : num = current_episode_index;
-       
-                            boxes[num].mark_as_unplayed();
 
-                            mark_episode_as_unplayed_requested(podcast.episodes[current_episode_index]);
+                            boxes[num].mark_as_unplayed ();
+
+                            mark_episode_as_unplayed_requested (podcast.episodes[current_episode_index]);
                         });
-                        right_click_menu.add(mark_unplayed_menuitem);
+                        right_click_menu.add (mark_unplayed_menuitem);
                     }
 
-                    if(podcast.episodes[current_episode_index].current_download_status == DownloadStatus.DOWNLOADED) {
+                    if (podcast.episodes[current_episode_index].current_download_status == DownloadStatus.DOWNLOADED) {
 
-                        var delete_menuitem = new Gtk.MenuItem.with_label(_("Delete Local File"));
+                        var delete_menuitem = new Gtk.MenuItem.with_label (_ ("Delete Local File"));
 
-                        delete_menuitem.activate.connect(() => {
+                        delete_menuitem.activate.connect (() => {
                             Gtk.MessageDialog msg = new Gtk.MessageDialog (parent, Gtk.DialogFlags.MODAL, Gtk.MessageType.WARNING, Gtk.ButtonsType.NONE,
-                                 "Are you sure you want to delete the downloaded episode '%s'?".printf(podcast.episodes[current_episode_index].title.replace("%27", "'")));
-                                 
-                                 
+                                 "Are you sure you want to delete the downloaded episode '%s'?".printf (podcast.episodes[current_episode_index].title.replace ("%27", "'")));
+
+
                             msg.add_button ("_No", Gtk.ResponseType.CANCEL);
-                            Gtk.Button delete_button = (Gtk.Button) msg.add_button("_Yes", Gtk.ResponseType.YES);
-                            delete_button.get_style_context().add_class("destructive-action");
-                        
-                            var image = new Gtk.Image.from_icon_name("dialog-question", Gtk.IconSize.DIALOG);     
+                            Gtk.Button delete_button = (Gtk.Button) msg.add_button ("_Yes", Gtk.ResponseType.YES);
+                            delete_button.get_style_context ().add_class ("destructive-action");
+
+                            var image = new Gtk.Image.from_icon_name ("dialog-question", Gtk.IconSize.DIALOG);
                             msg.image = image;
-                            msg.image.show_all();
-                            
+                            msg.image.show_all ();
+
                             msg.response.connect ((response_id) => {
                                 switch (response_id) {
                                     case Gtk.ResponseType.YES:
-                                        delete_local_episode_requested(podcast.episodes[current_episode_index]);
+                                        delete_local_episode_requested (podcast.episodes[current_episode_index]);
                                         break;
                                     case Gtk.ResponseType.NO:
                                         break;
                                 }
 
-                                msg.destroy();
+                                msg.destroy ();
                             });
                             msg.show ();
-                                        
+
                         });
 
-                        right_click_menu.add(delete_menuitem);
+                        right_click_menu.add (delete_menuitem);
                     }
                 }
 
-                right_click_menu.show_all();
-                right_click_menu.popup(null, null, null, e.button, e.time);
+                right_click_menu.show_all ();
+                right_click_menu.popup (null, null, null, e.button, e.time);
             }
 
             return false;
@@ -450,69 +450,69 @@ namespace Vocal {
          * When a row is activated, clear the unplayed icon if there is one and request
          * the corresponding episode be played
          */
-        private void on_row_activated(ListBoxRow? row) {
+        private void on_row_activated (ListBoxRow? row) {
 
-            if(previously_activated_box != null) {
-                previously_activated_box.clear_now_playing();
+            if (previously_activated_box != null) {
+                previously_activated_box.clear_now_playing ();
             }
-            if(boxes_index >= 0 && boxes_index < boxes.size) {
+            if (boxes_index >= 0 && boxes_index < boxes.size) {
                 previously_activated_box = boxes[boxes_index];
             }
-        
-            
+
+
             // Clear the unplayed icon
-            if(podcast.episodes[current_episode_index].status == EpisodeStatus.UNPLAYED) {
+            if (podcast.episodes[current_episode_index].status == EpisodeStatus.UNPLAYED) {
 
                 // Mark the box as played
-                previously_activated_box.mark_as_played();
+                previously_activated_box.mark_as_played ();
 
                 // Set the new unplayed count in the top area
                 unplayed_count--;
-                set_unplayed_text();
+                set_unplayed_text ();
 
                 // Re-mark the box so it doesn't show if hide played is enabled
-                if(settings.hide_played && unplayed_count > 0) {
-                    previously_activated_box.set_no_show_all(true);
-                    previously_activated_box.hide();
-                } 
+                if (settings.hide_played && unplayed_count > 0) {
+                    previously_activated_box.set_no_show_all (true);
+                    previously_activated_box.hide ();
+                }
             }
-            
+
 
             // No matter what, mark this box as now playing
-            previously_activated_box.mark_as_now_playing();
-            show_all();
+            previously_activated_box.mark_as_now_playing ();
+            show_all ();
 
-            play_episode_requested();
+            play_episode_requested ();
         }
-        
-        
+
+
         /*
          * When a row is selected, highlight it and show the details
          */
-        private void on_row_selected() {
+        private void on_row_selected () {
 
-            GLib.List<weak ListBoxRow> rows = listbox.get_selected_rows();
-            if(rows.length() > 1)
+            GLib.List<weak ListBoxRow> rows = listbox.get_selected_rows ();
+            if (rows.length () > 1)
                 return;
-            
 
-            ListBoxRow new_row = listbox.get_selected_row();
-            current_episode_index = (podcast.episodes.size - new_row.get_index() - 1);
-            boxes_index = boxes.size - new_row.get_index() - 1;
-            
-            if(current_episode_index >= 0 && current_episode_index < boxes.size) {
+
+            ListBoxRow new_row = listbox.get_selected_row ();
+            current_episode_index = (podcast.episodes.size - new_row.get_index () - 1);
+            boxes_index = boxes.size - new_row.get_index () - 1;
+
+            if (current_episode_index >= 0 && current_episode_index < boxes.size) {
                 previously_selected_box = boxes[current_episode_index];
-            }           
+            }
         }
-        
+
         /*
          * Handler for when a single episode needs to be marked as remote (needs downloading)
          */
-        public void on_single_delete(Episode e) {
-            int index = get_box_index_from_episode(e);
-            if(index != -1) {
-                boxes[index].show_playback_button();
-                boxes[index].show_download_button();
+        public void on_single_delete (Episode e) {
+            int index = get_box_index_from_episode (e);
+            if (index != -1) {
+                boxes[index].show_playback_button ();
+                boxes[index].show_download_button ();
             }
         }
 
@@ -520,32 +520,32 @@ namespace Vocal {
          * When a streaming button gets clicked set the current episode and treat
          * it like a row has been activated
          */
-        private void on_streaming_button_clicked(int index, int box_index) {
+        private void on_streaming_button_clicked (int index, int box_index) {
 
             current_episode_index = index;
             boxes_index = box_index;
-            on_row_activated(null);  
+            on_row_activated (null);
         }
-        
+
         /*
          * Creates an EpisodeDetailBox for each episode and adds it to the window
          */
-        public void populate_episodes(int? limit = 25) {
+        public void populate_episodes (int? limit = 25) {
 
-        	this.limit = limit;
+            this.limit = limit;
 
-        	// The count is used for finding the right episodes in the exact right order
-        	int count = (limit < podcast.episodes.size) ? limit : (podcast.episodes.size - 1);
-        	
-            
-            var children = this.get_children();
-            if(children.index(toolbar_box) > 0) {
-                remove(toolbar_box);
-                remove(scrolled);
+            // The count is used for finding the right episodes in the exact right order
+            int count = (limit < podcast.episodes.size) ? limit : (podcast.episodes.size - 1);
+
+
+            var children = this.get_children ();
+            if (children.index (toolbar_box) > 0) {
+                remove (toolbar_box);
+                remove (scrolled);
             }
 
             scrolled = new Gtk.ScrolledWindow (null, null);
-            listbox = new Gtk.ListBox();
+            listbox = new Gtk.ListBox ();
             listbox.activate_on_single_click = false;
             listbox.selection_mode = Gtk.SelectionMode.MULTIPLE;
             listbox.expand = true;
@@ -553,44 +553,44 @@ namespace Vocal {
 
             // If there are episodes, create an episode detail box for each of them
 
-            if(this.podcast.episodes.size > 0) {
-            
-                boxes = new Gee.ArrayList<EpisodeDetailBox>();
-                listbox.row_selected.connect(on_row_selected);
-                listbox.row_activated.connect(on_row_activated);
-                
+            if (this.podcast.episodes.size > 0) {
+
+                boxes = new Gee.ArrayList<EpisodeDetailBox> ();
+                listbox.row_selected.connect (on_row_selected);
+                listbox.row_activated.connect (on_row_activated);
+
                 unplayed_count = 0;
-                int i = 0;		// An index for the episodes array
+                int i = 0;        // An index for the episodes array
 
                 while (count >= 0 && ((podcast.episodes.size - 1) - count) >= 0) {
-                	Episode current_episode = podcast.episodes[(podcast.episodes.size - 1) - count];
-                    EpisodeDetailBox current_episode_box = new EpisodeDetailBox(current_episode, ((podcast.episodes.size - 1) - count), boxes.size, parent.on_elementary);
-                    current_episode_box.streaming_button_clicked.connect(on_streaming_button_clicked);
-                    if(current_episode_box.top_box_width > this.largest_box_size) {
+                    Episode current_episode = podcast.episodes[ (podcast.episodes.size - 1) - count];
+                    EpisodeDetailBox current_episode_box = new EpisodeDetailBox (current_episode, ((podcast.episodes.size - 1) - count), boxes.size, parent.on_elementary);
+                    current_episode_box.streaming_button_clicked.connect (on_streaming_button_clicked);
+                    if (current_episode_box.top_box_width > this.largest_box_size) {
                         this.largest_box_size = current_episode_box.top_box_width;
                     }
-                    current_episode_box.download_button.clicked.connect(() => {
-                        current_episode_box.hide_download_button();
-                        download_episode_requested(current_episode);
+                    current_episode_box.download_button.clicked.connect (() => {
+                        current_episode_box.hide_download_button ();
+                        download_episode_requested (current_episode);
                     });
 
 
-                    boxes.add(current_episode_box);
-                    listbox.prepend(current_episode_box);                    
-                    
+                    boxes.add (current_episode_box);
+                    listbox.prepend (current_episode_box);
+
                     // Determine whether or not the episode has been played
-                    if(current_episode.status == EpisodeStatus.UNPLAYED) {
+                    if (current_episode.status == EpisodeStatus.UNPLAYED) {
                         unplayed_count++;
-                    } else if(current_episode == parent.current_episode) {
-                        current_episode_box.mark_as_now_playing();
-                        if(settings.hide_played) {
-                            current_episode_box.set_no_show_all(true);
-                            current_episode_box.hide();
+                    } else if (current_episode == parent.current_episode) {
+                        current_episode_box.mark_as_now_playing ();
+                        if (settings.hide_played) {
+                            current_episode_box.set_no_show_all (true);
+                            current_episode_box.hide ();
                         }
                     } else {
-                        if(settings.hide_played) {
-                            current_episode_box.set_no_show_all(true);
-                            current_episode_box.hide();
+                        if (settings.hide_played) {
+                            current_episode_box.set_no_show_all (true);
+                            current_episode_box.hide ();
                         }
                     }
                     i++;
@@ -598,78 +598,77 @@ namespace Vocal {
                 }
 
                 // Check to see if there are more episodes left
-                if(this.limit < podcast.episodes.size && !settings.hide_played)
-                {
+                if (this.limit < podcast.episodes.size && !settings.hide_played) {
 
-                	// If so, add a button that will increase the limit
-                	var increase_button = new Gtk.Button.with_label("Show more episodes");
-                	increase_button.clicked.connect(() => {
-                		populate_episodes(this.limit += 25);
-                		this.show_all();
-            		});
+                    // If so, add a button that will increase the limit
+                    var increase_button = new Gtk.Button.with_label ("Show more episodes");
+                    increase_button.clicked.connect (() => {
+                        populate_episodes (this.limit += 25);
+                        this.show_all ();
+                    });
 
-            		listbox.insert(increase_button, -1);
+                    listbox.insert (increase_button, -1);
                 }
 
-                if(settings.hide_played && unplayed_count == 0) {
-                    var no_new_label = new Gtk.Label(_("No new episodes."));
+                if (settings.hide_played && unplayed_count == 0) {
+                    var no_new_label = new Gtk.Label (_ ("No new episodes."));
                     no_new_label.margin_top = 25;
                     Granite.Widgets.Utils.apply_text_style_to_label (TextStyle.H3, no_new_label);
-                    listbox.prepend(no_new_label);
+                    listbox.prepend (no_new_label);
                 }
 
 
-            // Otherwise, simply create a new label to tell user that the feed is empty    
+            // Otherwise, simply create a new label to tell user that the feed is empty
             } else {
-                var empty_label = new Gtk.Label(_("No episodes available."));
+                var empty_label = new Gtk.Label (_ ("No episodes available."));
                 empty_label.justify = Gtk.Justification.CENTER;
                 empty_label.margin = 10;
-            
+
                 Granite.Widgets.Utils.apply_text_style_to_label (TextStyle.H3, empty_label);
-                listbox.prepend(empty_label);
+                listbox.prepend (empty_label);
             }
 
-            listbox.button_press_event.connect(on_button_press_event);
+            listbox.button_press_event.connect (on_button_press_event);
 
-            scrolled.add(listbox);
+            scrolled.add (listbox);
 
-            add(scrolled);
-            add(toolbar_box);
-            set_unplayed_text();
+            add (scrolled);
+            add (toolbar_box);
+            set_unplayed_text ();
         }
-        
+
         /*
          * Resets the unplayed count and iterates through the boxes to obtain a new one
          */
-        public void reset_unplayed_count() {
+        public void reset_unplayed_count () {
 
             int previous_count = unplayed_count;
 
             unplayed_count = 0;
 
-            foreach(Episode e in podcast.episodes) {
-                if(e.status == EpisodeStatus.UNPLAYED)
+            foreach (Episode e in podcast.episodes) {
+                if (e.status == EpisodeStatus.UNPLAYED)
                     unplayed_count++;
             }
 
-            set_unplayed_text();
+            set_unplayed_text ();
 
             // Is the number of unplayed episodes now different?
-            if(previous_count != unplayed_count)
-                unplayed_count_changed(unplayed_count);
+            if (previous_count != unplayed_count)
+                unplayed_count_changed (unplayed_count);
         }
 
-		/*
- 		 * Sets the unplayed text (assumes the unplayed count has already been set)
- 		 */
-        public void set_unplayed_text() {
+        /*
+          * Sets the unplayed text (assumes the unplayed count has already been set)
+          */
+        public void set_unplayed_text () {
             string count_string = null;
-            if(unplayed_count > 0) {
-                count_string = _("%d episodes, %d unplayed".printf(podcast.episodes.size, unplayed_count));
+            if (unplayed_count > 0) {
+                count_string = _ ("%d episodes, %d unplayed".printf (podcast.episodes.size, unplayed_count));
             } else {
-                count_string = _("%d episodes".printf(podcast.episodes.size));
+                count_string = _ ("%d episodes".printf (podcast.episodes.size));
             }
-            count_label.set_text(count_string);
+            count_label.set_text (count_string);
         }
-    }  
+    }
 }

--- a/src/Widgets/Sidepane.vala
+++ b/src/Widgets/Sidepane.vala
@@ -67,7 +67,7 @@ namespace Vocal {
          * Constructor for a Sidepane given a parent window and pocast
          */
         public Sidepane (MainWindow parent, Podcast podcast, bool? on_elementary = Utils.check_elementary ()) {
-            assert (podcast!= null);
+            assert (podcast != null);
             this.podcast = podcast;
             this.parent = parent;
             this.settings = new VocalSettings ();
@@ -93,7 +93,10 @@ namespace Vocal {
             toolbar.insert (mark_as_played, 0);
 
             Gtk.Image download_image;
-            download_image = new Gtk.Image.from_icon_name (check_elementary () ? "browser-download-symbolic" : "document-save-symbolic", Gtk.IconSize.MENU);
+            download_image = new Gtk.Image.from_icon_name (
+                check_elementary () ? "browser-download-symbolic" : "document-save-symbolic",
+                Gtk.IconSize.MENU
+            );
             Gtk.ToolButton download_all = new Gtk.ToolButton (download_image, null);
             download_all.tooltip_text = _ ("Download all episodes");
             download_all.clicked.connect (() => {
@@ -137,7 +140,7 @@ namespace Vocal {
             menu.tooltip_text = _ ("More options");
 
             menu.clicked.connect (() => {
-                more_menu.popup (null, null, null, 1,Gdk.CURRENT_TIME );
+                more_menu.popup (null, null, null, 1, Gdk.CURRENT_TIME );
             });
 
 
@@ -261,7 +264,7 @@ namespace Vocal {
 
                             // Set all the boxes to hide the played image
                             foreach (int i in indexes) {
-                                int floor = podcast.episodes.size - limit -1;
+                                int floor = podcast.episodes.size - limit - 1;
                                 int num;
 
                                 (floor >= 0) ? num = i - floor : num = i;
@@ -290,7 +293,7 @@ namespace Vocal {
 
                         // Set all the boxes to show the played image
                         foreach (int i in indexes) {
-                            int floor = podcast.episodes.size - limit -1;
+                            int floor = podcast.episodes.size - limit - 1;
                             int num;
 
                             (floor >= 0) ? num = i - floor : num = i;
@@ -310,8 +313,13 @@ namespace Vocal {
                     var delete_menuitem = new Gtk.MenuItem.with_label (_ ("Delete local files for selected episodes"));
                     delete_menuitem.activate.connect (() => {
 
-                        Gtk.MessageDialog msg = new Gtk.MessageDialog (parent, Gtk.DialogFlags.MODAL, Gtk.MessageType.WARNING, Gtk.ButtonsType.NONE,
-                             _ ("Are you sure you want to delete the downloaded files for the selected episodes?"));
+                        Gtk.MessageDialog msg = new Gtk.MessageDialog (
+                            parent,
+                            Gtk.DialogFlags.MODAL,
+                            Gtk.MessageType.WARNING,
+                            Gtk.ButtonsType.NONE,
+                            _ ("Are you sure you want to delete the downloaded files for the selected episodes?")
+                        );
 
 
                         msg.add_button ("_No", Gtk.ResponseType.CANCEL);
@@ -372,7 +380,7 @@ namespace Vocal {
                             set_unplayed_text ();
 
                             // Remove the unplayed image from the episode's box
-                            int floor = podcast.episodes.size - limit -1;
+                            int floor = podcast.episodes.size - limit - 1;
                             int num;
 
                             (floor >= 0) ? num = current_episode_index - floor : num = current_episode_index;
@@ -391,7 +399,7 @@ namespace Vocal {
                             set_unplayed_text ();
 
                             // Remove the unplayed image from the episode's box
-                            int floor = podcast.episodes.size - limit -1;
+                            int floor = podcast.episodes.size - limit - 1;
                             int num;
 
                             (floor >= 0) ? num = current_episode_index - floor : num = current_episode_index;
@@ -408,8 +416,15 @@ namespace Vocal {
                         var delete_menuitem = new Gtk.MenuItem.with_label (_ ("Delete Local File"));
 
                         delete_menuitem.activate.connect (() => {
-                            Gtk.MessageDialog msg = new Gtk.MessageDialog (parent, Gtk.DialogFlags.MODAL, Gtk.MessageType.WARNING, Gtk.ButtonsType.NONE,
-                                 "Are you sure you want to delete the downloaded episode '%s'?".printf (podcast.episodes[current_episode_index].title.replace ("%27", "'")));
+                            Gtk.MessageDialog msg = new Gtk.MessageDialog (
+                                parent,
+                                Gtk.DialogFlags.MODAL,
+                                Gtk.MessageType.WARNING,
+                                Gtk.ButtonsType.NONE,
+                                "Are you sure you want to delete the downloaded episode '%s'?".printf (
+                                    podcast.episodes[current_episode_index].title.replace ("%27", "'")
+                                )
+                            );
 
 
                             msg.add_button ("_No", Gtk.ResponseType.CANCEL);
@@ -564,7 +579,12 @@ namespace Vocal {
 
                 while (count >= 0 && ((podcast.episodes.size - 1) - count) >= 0) {
                     Episode current_episode = podcast.episodes[ (podcast.episodes.size - 1) - count];
-                    EpisodeDetailBox current_episode_box = new EpisodeDetailBox (current_episode, ((podcast.episodes.size - 1) - count), boxes.size, parent.on_elementary);
+                    EpisodeDetailBox current_episode_box = new EpisodeDetailBox (
+                        current_episode,
+                        ((podcast.episodes.size - 1) - count),
+                        boxes.size,
+                        parent.on_elementary
+                    );
                     current_episode_box.streaming_button_clicked.connect (on_streaming_button_clicked);
                     if (current_episode_box.top_box_width > this.largest_box_size) {
                         this.largest_box_size = current_episode_box.top_box_width;

--- a/src/Widgets/Toolbar.vala
+++ b/src/Widgets/Toolbar.vala
@@ -62,7 +62,7 @@ namespace Vocal {
 
         private VocalSettings settings;
 
-        public Toolbar (VocalSettings settings, bool? first_run = false, bool? on_elementary = Utils.check_elementary ()) {
+        public Toolbar (VocalSettings settings, bool? first_run = false, bool? on_elementary = Utils.check_elementary ()) {  // vala-lint=line-length
 
             this.settings = settings;
 
@@ -77,9 +77,15 @@ namespace Vocal {
 
             // Create the show notes button
             if (on_elementary) {
-                shownotes_button = new Gtk.Button.from_icon_name ("help-info-symbolic", Gtk.IconSize.SMALL_TOOLBAR);
+                shownotes_button = new Gtk.Button.from_icon_name (
+                    "help-info-symbolic",
+                    Gtk.IconSize.SMALL_TOOLBAR
+                );
             } else {
-                shownotes_button = new Gtk.Button.from_icon_name ("dialog-information-symbolic", Gtk.IconSize.SMALL_TOOLBAR);
+                shownotes_button = new Gtk.Button.from_icon_name (
+                    "dialog-information-symbolic",
+                    Gtk.IconSize.SMALL_TOOLBAR
+                );
             }
             shownotes_button.tooltip_text = _ ("View show notes");
             shownotes_button.valign = Gtk.Align.CENTER;
@@ -178,18 +184,6 @@ namespace Vocal {
             preferences_item.activate.connect (() => {
                 preferences_selected ();
             });
-            menu.add (check_for_updates);
-            menu.add (new Gtk.SeparatorMenuItem ());
-            menu.add (add_feed_item);
-            menu.add (import_item);
-            menu.add (export_item);
-            menu.add (new Gtk.SeparatorMenuItem ());
-
-
-            var preferences_item = new Gtk.MenuItem.with_label (_ ("Preferences"));
-            preferences_item.activate.connect (() => {
-                preferences_selected ();
-            });
             menu.add (preferences_item);
             menu.add (new Gtk.SeparatorMenuItem ());
 
@@ -218,7 +212,7 @@ namespace Vocal {
 
             // Create the AppMenu
             app_menu = new Gtk.MenuButton ();
-             app_menu.set_image (new Gtk.Image.from_icon_name ("open-menu-symbolic", on_elementary ? on_elementary ? Gtk.IconSize.LARGE_TOOLBAR : Gtk.IconSize.SMALL_TOOLBAR : Gtk.IconSize.SMALL_TOOLBAR));
+             app_menu.set_image (new Gtk.Image.from_icon_name ("open-menu-symbolic", on_elementary ? on_elementary ? Gtk.IconSize.LARGE_TOOLBAR : Gtk.IconSize.SMALL_TOOLBAR : Gtk.IconSize.SMALL_TOOLBAR));  // vala-lint=line-length
             app_menu.popup = menu;
             app_menu.relief = Gtk.ReliefStyle.NONE;
             app_menu.valign = Gtk.Align.CENTER;
@@ -234,7 +228,10 @@ namespace Vocal {
             this.show_close_button = true;
 
             // Create new icons for placback functions and downloads
-            var playpause_image = new Gtk.Image.from_icon_name ("media-playback-start-symbolic", on_elementary ? Gtk.IconSize.LARGE_TOOLBAR : Gtk.IconSize.SMALL_TOOLBAR);
+            var playpause_image = new Gtk.Image.from_icon_name (
+                "media-playback-start-symbolic",
+                on_elementary ? Gtk.IconSize.LARGE_TOOLBAR : Gtk.IconSize.SMALL_TOOLBAR
+            );
             play_pause = new Gtk.Button ();
             play_pause.image = playpause_image;
             play_pause.image = playpause_image;
@@ -243,7 +240,10 @@ namespace Vocal {
             play_pause.relief = Gtk.ReliefStyle.NONE;
             play_pause.valign = Gtk.Align.CENTER;
 
-            var forward_image = new Gtk.Image.from_icon_name ("media-seek-forward-symbolic", on_elementary ? Gtk.IconSize.LARGE_TOOLBAR : Gtk.IconSize.SMALL_TOOLBAR);
+            var forward_image = new Gtk.Image.from_icon_name (
+                "media-seek-forward-symbolic",
+                on_elementary ? Gtk.IconSize.LARGE_TOOLBAR : Gtk.IconSize.SMALL_TOOLBAR
+            );
             forward = new Gtk.Button ();
             forward.image = forward_image;
             forward.has_tooltip = true;
@@ -253,7 +253,10 @@ namespace Vocal {
             forward.tooltip_text = _ ("Fast forward %d seconds".printf (this.settings.fast_forward_seconds));
             forward.valign = Gtk.Align.CENTER;
 
-            var backward_image = new Gtk.Image.from_icon_name ("media-seek-backward-symbolic", on_elementary ? Gtk.IconSize.LARGE_TOOLBAR : Gtk.IconSize.SMALL_TOOLBAR);
+            var backward_image = new Gtk.Image.from_icon_name (
+                "media-seek-backward-symbolic",
+                on_elementary ? Gtk.IconSize.LARGE_TOOLBAR : Gtk.IconSize.SMALL_TOOLBAR
+            );
             backward = new Gtk.Button ();
             backward.image = backward_image;
             backward.has_tooltip = true;
@@ -269,7 +272,10 @@ namespace Vocal {
                 backward.tooltip_text = _ ("Rewind %d seconds".printf (this.settings.rewind_seconds));
             });
 
-            refresh = new Gtk.Button.from_icon_name ("view-refresh-symbolic", on_elementary ? Gtk.IconSize.LARGE_TOOLBAR : Gtk.IconSize.SMALL_TOOLBAR);
+            refresh = new Gtk.Button.from_icon_name (
+                "view-refresh-symbolic",
+                on_elementary ? Gtk.IconSize.LARGE_TOOLBAR : Gtk.IconSize.SMALL_TOOLBAR
+            );
             refresh.has_tooltip = true;
             refresh.tooltip_text = _ ("Check for new episodes");
 
@@ -279,16 +285,25 @@ namespace Vocal {
             rate_button.relief = Gtk.ReliefStyle.NONE;
             rate_button.valign = Gtk.Align.CENTER;
 
-            search_button = new Gtk.Button.from_icon_name ("edit-find-symbolic", on_elementary ? Gtk.IconSize.LARGE_TOOLBAR : Gtk.IconSize.SMALL_TOOLBAR);
+            search_button = new Gtk.Button.from_icon_name (
+                "edit-find-symbolic",
+                on_elementary ? Gtk.IconSize.LARGE_TOOLBAR : Gtk.IconSize.SMALL_TOOLBAR
+            );
             search_button.tooltip_text = _ ("Search your library or online");
             search_button.relief = Gtk.ReliefStyle.NONE;
             search_button.valign = Gtk.Align.CENTER;
 
 
             if (on_elementary) {
-                podcast_store_button = new Gtk.Button.from_icon_name ("system-software-install-symbolic", on_elementary ? Gtk.IconSize.LARGE_TOOLBAR : Gtk.IconSize.SMALL_TOOLBAR);
+                podcast_store_button = new Gtk.Button.from_icon_name (
+                    "system-software-install-symbolic",
+                    on_elementary ? Gtk.IconSize.LARGE_TOOLBAR : Gtk.IconSize.SMALL_TOOLBAR
+                );
             } else {
-                podcast_store_button = new Gtk.Button.from_icon_name ("application-rss+xml-symbolic", Gtk.IconSize.SMALL_TOOLBAR);
+                podcast_store_button = new Gtk.Button.from_icon_name (
+                    "application-rss+xml-symbolic",
+                    Gtk.IconSize.SMALL_TOOLBAR
+                );
             }
             podcast_store_button.tooltip_text = _ ("View the top podcasts in the iTunes Store");
             podcast_store_button.relief = Gtk.ReliefStyle.NONE;
@@ -318,9 +333,15 @@ namespace Vocal {
 
             Gtk.Image download_image;
             if (on_elementary) {
-                download_image = new Gtk.Image.from_icon_name ("browser-download-symbolic", on_elementary ? Gtk.IconSize.LARGE_TOOLBAR : Gtk.IconSize.SMALL_TOOLBAR);
+                download_image = new Gtk.Image.from_icon_name (
+                    "browser-download-symbolic",
+                    on_elementary ? Gtk.IconSize.LARGE_TOOLBAR : Gtk.IconSize.SMALL_TOOLBAR
+                );
             } else {
-                download_image = new Gtk.Image.from_icon_name ("document-save-symbolic", on_elementary ? Gtk.IconSize.LARGE_TOOLBAR : Gtk.IconSize.SMALL_TOOLBAR);
+                download_image = new Gtk.Image.from_icon_name (
+                    "document-save-symbolic",
+                    on_elementary ? Gtk.IconSize.LARGE_TOOLBAR : Gtk.IconSize.SMALL_TOOLBAR
+                );
             }
             download = new Gtk.Button ();
             download.image = download_image;

--- a/src/Widgets/Toolbar.vala
+++ b/src/Widgets/Toolbar.vala
@@ -21,94 +21,98 @@ using Gtk;
 using Gee;
 using Granite;
 namespace Vocal {
-	public class Toolbar : Gtk.HeaderBar {
+    public class Toolbar : Gtk.HeaderBar {
 
-		public signal void add_podcast_selected();
-		public signal void import_podcasts_selected();
-		public signal void export_selected();
-		public signal void shownotes_selected();
-		public signal void playlist_selected();
-		public signal void preferences_selected();
-		public signal void donate_selected();
-		public signal void refresh_selected();
-		public signal void rate_button_selected();
-		public signal void store_selected();
-		public signal void play_pause_selected();
-		public signal void seek_forward_selected();
-		public signal void seek_backward_selected();
-		public signal void downloads_selected();
-        public signal void check_for_updates_selected();
+        public signal void add_podcast_selected ();
+        public signal void import_podcasts_selected ();
+        public signal void export_selected ();
+        public signal void shownotes_selected ();
+        public signal void playlist_selected ();
+        public signal void preferences_selected ();
+        public signal void donate_selected ();
+        public signal void refresh_selected ();
+        public signal void rate_button_selected ();
+        public signal void store_selected ();
+        public signal void play_pause_selected ();
+        public signal void seek_forward_selected ();
+        public signal void seek_backward_selected ();
+        public signal void downloads_selected ();
+        public signal void check_for_updates_selected ();
         public signal void about_selected ();
         public signal void theme_toggled ();
 
-        public Gtk.Menu             menu;
-        public Gtk.MenuButton       app_menu;
+        public Gtk.Menu menu;
+        public Gtk.MenuButton app_menu;
 
-		private Gtk.Button          play_pause;
-        private Gtk.Button          forward;
-        private Gtk.Button          backward;
-        private Gtk.Button          refresh;
-        public  Gtk.Button          download;
-        public  Gtk.Button 			shownotes_button;
-        public  Gtk.Button          volume_button;
-        public  Gtk.Button          search_button;
-        private Gtk.Button          podcast_store_button;
-		public Gtk.Button 			playlist_button;
-		public Gtk.Button new_episodes_button;
+        private Gtk.Button play_pause;
+        private Gtk.Button forward;
+        private Gtk.Button backward;
+        private Gtk.Button refresh;
+        public Gtk.Button download;
+        public Gtk.Button shownotes_button;
+        public Gtk.Button volume_button;
+        public Gtk.Button search_button;
+        private Gtk.Button podcast_store_button;
+        public Gtk.Button playlist_button;
+        public Gtk.Button new_episodes_button;
 
-        public  Gtk.MenuItem        export_item;
-        private Gtk.Box             headerbar_box;
-        public  PlaybackBox         playback_box;
+        public Gtk.MenuItem export_item;
+        private Gtk.Box headerbar_box;
+        public PlaybackBox playback_box;
 
-        private VocalSettings 		settings;
+        private VocalSettings settings;
 
-		public Toolbar(VocalSettings settings, bool? first_run = false, bool? on_elementary = Utils.check_elementary()) {
+        public Toolbar (VocalSettings settings, bool? first_run = false, bool? on_elementary = Utils.check_elementary ()) {
 
-			this.settings = settings;
+            this.settings = settings;
 
-			// Create the box that will be used for the title in the headerbar
-            headerbar_box = new Gtk.Box(Gtk.Orientation.HORIZONTAL, 10);
+            // Create the box that will be used for the title in the headerbar
+            headerbar_box = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 10);
 
             // Create the box to be shown during playback
-            playback_box = new PlaybackBox();
+            playback_box = new PlaybackBox ();
 
             // Set the playback box in the middle of the HeaderBar
-	        playback_box.hexpand = true;
+            playback_box.hexpand = true;
 
             // Create the show notes button
-		    if(on_elementary)
-	            shownotes_button = new Gtk.Button.from_icon_name("help-info-symbolic", Gtk.IconSize.SMALL_TOOLBAR);
-		    else
-	     		shownotes_button = new Gtk.Button.from_icon_name("dialog-information-symbolic", Gtk.IconSize.SMALL_TOOLBAR);
-            shownotes_button.tooltip_text = _("View show notes");
+            if (on_elementary) {
+                shownotes_button = new Gtk.Button.from_icon_name ("help-info-symbolic", Gtk.IconSize.SMALL_TOOLBAR);
+            } else {
+                shownotes_button = new Gtk.Button.from_icon_name ("dialog-information-symbolic", Gtk.IconSize.SMALL_TOOLBAR);
+            }
+            shownotes_button.tooltip_text = _ ("View show notes");
             shownotes_button.valign = Gtk.Align.CENTER;
-            shownotes_button.clicked.connect(() => {
-                shownotes_selected();
+            shownotes_button.clicked.connect (() => {
+                shownotes_selected ();
             });
             shownotes_button.relief = Gtk.ReliefStyle.NONE;
-            
-            volume_button = new Gtk.Button.from_icon_name("audio-volume-high-symbolic", Gtk.IconSize.SMALL_TOOLBAR);
+
+            volume_button = new Gtk.Button.from_icon_name ("audio-volume-high-symbolic", Gtk.IconSize.SMALL_TOOLBAR);
             volume_button.relief = Gtk.ReliefStyle.NONE;
 
-            playlist_button = new Gtk.Button.from_icon_name("media-playlist-consecutive-symbolic");
-            playlist_button.tooltip_text = _("Coming up next");
-            playlist_button.clicked.connect(() => {
-                playlist_selected();
+            volume_button = new Gtk.Button.from_icon_name ("audio-volume-high-symbolic", Gtk.IconSize.SMALL_TOOLBAR);
+
+            playlist_button = new Gtk.Button.from_icon_name ("media-playlist-consecutive-symbolic");
+            playlist_button.tooltip_text = _ ("Coming up next");
+            playlist_button.clicked.connect (() => {
+                playlist_selected ();
             });
             playlist_button.relief = Gtk.ReliefStyle.NONE;
             playlist_button.valign = Gtk.Align.CENTER;
-            
-            if(on_elementary)
+
+            if (on_elementary) {
                 new_episodes_button = new Gtk.Button.from_icon_name ("help-about-symbolic", Gtk.IconSize.LARGE_TOOLBAR);
-            else
+            } else {
                 new_episodes_button = new Gtk.Button.from_icon_name ("starred-symbolic", Gtk.IconSize.SMALL_TOOLBAR);
-            new_episodes_button.tooltip_text = _("New Episodes");
+            }
+            new_episodes_button.tooltip_text = _ ("New Episodes");
             new_episodes_button.relief = Gtk.ReliefStyle.NONE;
 
-            headerbar_box.add(shownotes_button);
+            headerbar_box.add (shownotes_button);
             headerbar_box.add (volume_button);
-            headerbar_box.add(playback_box);
-            headerbar_box.add(playlist_button);
+            headerbar_box.add (playback_box);
+            headerbar_box.add (playlist_button);
             headerbar_box.halign = Gtk.Align.CENTER;
             headerbar_box.margin_left = 50;
             headerbar_box.margin_right = 50;
@@ -117,31 +121,31 @@ namespace Vocal {
             // Create the menus and menuitems
             menu = new Gtk.Menu ();
 
-            var check_for_updates = new Gtk.MenuItem.with_label(_("Check for Updates"));
-            check_for_updates.activate.connect(() => {
-                check_for_updates_selected();
+            var check_for_updates = new Gtk.MenuItem.with_label (_ ("Check for Updates"));
+            check_for_updates.activate.connect (() => {
+                check_for_updates_selected ();
             });
 
-            var add_feed_item = new Gtk.MenuItem.with_label(_("Add Podcast Feed…"));
-            add_feed_item.activate.connect(() => {
-                add_podcast_selected();
+            var add_feed_item = new Gtk.MenuItem.with_label (_ ("Add Podcast Feed…"));
+            add_feed_item.activate.connect (() => {
+                add_podcast_selected ();
             });
 
-            var import_item = new Gtk.MenuItem.with_label(_("Import Subcriptions…"));
-            import_item.activate.connect(() => {
-                import_podcasts_selected();
+            var import_item = new Gtk.MenuItem.with_label (_ ("Import Subcriptions…"));
+            import_item.activate.connect (() => {
+                import_podcasts_selected ();
             });
 
-            export_item = new Gtk.MenuItem.with_label(_("Export Subscriptions…"));
-            
+            export_item = new Gtk.MenuItem.with_label ( _("Export Subscriptions…"));
+
             var dark_mode_item = new Gtk.MenuItem ();
-            
+
             if (settings.dark_mode_enabled) {
                 dark_mode_item.label = _("Use Light Theme");
             } else {
                 dark_mode_item.label = _("Use Dark Theme");
             }
-            
+
             dark_mode_item.activate.connect (() => {
                 if (settings.dark_mode_enabled) {
                     settings.dark_mode_enabled = false;
@@ -154,55 +158,67 @@ namespace Vocal {
             });
 
             // Set refresh and export insensitive if there isn't a library to export
-            if(first_run) {
+            if (first_run) {
                 //refresh_item.sensitive = false;
                 export_item.sensitive = false;
             }
-            export_item.activate.connect(() => {
-            	export_selected();
-        	});
-            menu.add(check_for_updates);
-            menu.add(new Gtk.SeparatorMenuItem());
-            menu.add(add_feed_item);
-            menu.add(import_item);
-            menu.add(export_item);
-            menu.add(new Gtk.SeparatorMenuItem());
+            export_item.activate.connect (() => {
+                export_selected ();
+            });
+            menu.add (check_for_updates);
+            menu.add (new Gtk.SeparatorMenuItem ());
+            menu.add (add_feed_item);
+            menu.add (import_item);
+            menu.add (export_item);
+            menu.add (new Gtk.SeparatorMenuItem ());
             menu.add (dark_mode_item);
 
 
-            var preferences_item = new Gtk.MenuItem.with_label(_("Preferences"));
-            preferences_item.activate.connect(() => {
-                preferences_selected();
+            var preferences_item = new Gtk.MenuItem.with_label ( _("Preferences"));
+            preferences_item.activate.connect (() => {
+                preferences_selected ();
             });
-            menu.add(preferences_item);
-            menu.add(new Gtk.SeparatorMenuItem());
+            menu.add (check_for_updates);
+            menu.add (new Gtk.SeparatorMenuItem ());
+            menu.add (add_feed_item);
+            menu.add (import_item);
+            menu.add (export_item);
+            menu.add (new Gtk.SeparatorMenuItem ());
 
-            var report_problem = new Gtk.MenuItem.with_label (_("Report a Problem…"));
+
+            var preferences_item = new Gtk.MenuItem.with_label (_ ("Preferences"));
+            preferences_item.activate.connect (() => {
+                preferences_selected ();
+            });
+            menu.add (preferences_item);
+            menu.add (new Gtk.SeparatorMenuItem ());
+
+            var report_problem = new Gtk.MenuItem.with_label (_ ("Report a Problem…"));
             report_problem.activate.connect (() => {
                 try {
                     Gtk.show_uri (null, "https://github.com/needle-and-thread/vocal/issues", 0);
                 } catch (Error error) {}
             });
-            menu.add(report_problem);
+            menu.add (report_problem);
 
-            var donate = new Gtk.MenuItem.with_label (_("Donate…"));
+            var donate = new Gtk.MenuItem.with_label (_ ("Donate…"));
             donate.activate.connect (() => {
                 try {
                     Gtk.show_uri (null, "http://needleandthread.co/apps/vocal", 0);
                 } catch (Error error) {}
             });
-            //menu.add(donate);
+            //menu.add (donate);
 
-            var about = new Gtk.MenuItem.with_label (_("About"));
+            var about = new Gtk.MenuItem.with_label (_ ("About"));
             about.activate.connect (() => {
                 about_selected ();
             });
             menu.add (about);
-            menu.show_all();
+            menu.show_all ();
 
             // Create the AppMenu
-            app_menu = new Gtk.MenuButton();
-	     	app_menu.set_image (new Gtk.Image.from_icon_name ("open-menu-symbolic", on_elementary ? on_elementary ? Gtk.IconSize.LARGE_TOOLBAR : Gtk.IconSize.SMALL_TOOLBAR : Gtk.IconSize.SMALL_TOOLBAR));
+            app_menu = new Gtk.MenuButton ();
+             app_menu.set_image (new Gtk.Image.from_icon_name ("open-menu-symbolic", on_elementary ? on_elementary ? Gtk.IconSize.LARGE_TOOLBAR : Gtk.IconSize.SMALL_TOOLBAR : Gtk.IconSize.SMALL_TOOLBAR));
             app_menu.popup = menu;
             app_menu.relief = Gtk.ReliefStyle.NONE;
             app_menu.valign = Gtk.Align.CENTER;
@@ -210,213 +226,213 @@ namespace Vocal {
 
             // Populate the toolbar
             pack_end (app_menu);
-            set_custom_title(headerbar_box);
+            set_custom_title (headerbar_box);
 
             // Initially hide the headearbar_box
-            hide_playback_box();
+            hide_playback_box ();
 
             this.show_close_button = true;
 
             // Create new icons for placback functions and downloads
-            var playpause_image = new Gtk.Image.from_icon_name("media-playback-start-symbolic", on_elementary ? Gtk.IconSize.LARGE_TOOLBAR : Gtk.IconSize.SMALL_TOOLBAR);
-            play_pause = new Gtk.Button();
+            var playpause_image = new Gtk.Image.from_icon_name ("media-playback-start-symbolic", on_elementary ? Gtk.IconSize.LARGE_TOOLBAR : Gtk.IconSize.SMALL_TOOLBAR);
+            play_pause = new Gtk.Button ();
             play_pause.image = playpause_image;
             play_pause.image = playpause_image;
             play_pause.has_tooltip = true;
-            play_pause.tooltip_text = _("Play");
+            play_pause.tooltip_text = _ ("Play");
             play_pause.relief = Gtk.ReliefStyle.NONE;
             play_pause.valign = Gtk.Align.CENTER;
 
-            var forward_image = new Gtk.Image.from_icon_name("media-seek-forward-symbolic", on_elementary ? Gtk.IconSize.LARGE_TOOLBAR : Gtk.IconSize.SMALL_TOOLBAR);
-            forward = new Gtk.Button();
+            var forward_image = new Gtk.Image.from_icon_name ("media-seek-forward-symbolic", on_elementary ? Gtk.IconSize.LARGE_TOOLBAR : Gtk.IconSize.SMALL_TOOLBAR);
+            forward = new Gtk.Button ();
             forward.image = forward_image;
             forward.has_tooltip = true;
             forward.relief = Gtk.ReliefStyle.NONE;
             forward.hexpand = true;
             forward.halign = Gtk.Align.START;
-            forward.tooltip_text = _("Fast forward %d seconds".printf(this.settings.fast_forward_seconds));
+            forward.tooltip_text = _ ("Fast forward %d seconds".printf (this.settings.fast_forward_seconds));
             forward.valign = Gtk.Align.CENTER;
 
-            var backward_image = new Gtk.Image.from_icon_name("media-seek-backward-symbolic", on_elementary ? Gtk.IconSize.LARGE_TOOLBAR : Gtk.IconSize.SMALL_TOOLBAR);
-            backward = new Gtk.Button();
+            var backward_image = new Gtk.Image.from_icon_name ("media-seek-backward-symbolic", on_elementary ? Gtk.IconSize.LARGE_TOOLBAR : Gtk.IconSize.SMALL_TOOLBAR);
+            backward = new Gtk.Button ();
             backward.image = backward_image;
             backward.has_tooltip = true;
             backward.relief = Gtk.ReliefStyle.NONE;
-            backward.tooltip_text = _("Rewind %d seconds".printf(this.settings.rewind_seconds));
+            backward.tooltip_text = _ ("Rewind %d seconds".printf (this.settings.rewind_seconds));
             backward.valign = Gtk.Align.CENTER;
 
-			play_pause.get_style_context().add_class("vocal-headerbar-button");
+            play_pause.get_style_context ().add_class ("vocal-headerbar-button");
 
             // Connect the changed signal for settings to update the tooltips
-            this.settings.changed.connect(() => {
-                forward.tooltip_text = _("Fast forward %d seconds".printf(this.settings.fast_forward_seconds));
-                backward.tooltip_text = _("Rewind %d seconds".printf(this.settings.rewind_seconds));
+            this.settings.changed.connect (() => {
+                forward.tooltip_text = _ ("Fast forward %d seconds".printf (this.settings.fast_forward_seconds));
+                backward.tooltip_text = _ ("Rewind %d seconds".printf (this.settings.rewind_seconds));
             });
 
-            refresh = new Gtk.Button.from_icon_name("view-refresh-symbolic", on_elementary ? Gtk.IconSize.LARGE_TOOLBAR : Gtk.IconSize.SMALL_TOOLBAR);
+            refresh = new Gtk.Button.from_icon_name ("view-refresh-symbolic", on_elementary ? Gtk.IconSize.LARGE_TOOLBAR : Gtk.IconSize.SMALL_TOOLBAR);
             refresh.has_tooltip = true;
-            refresh.tooltip_text = _("Check for new episodes");
+            refresh.tooltip_text = _ ("Check for new episodes");
 
-            var rate_button = new Gtk.Button.with_label("");
-			rate_button.get_style_context().add_class("rate-button");
-			rate_button.get_style_context().add_class("h3");
+            var rate_button = new Gtk.Button.with_label ("");
+            rate_button.get_style_context ().add_class ("rate-button");
+            rate_button.get_style_context ().add_class ("h3");
             rate_button.relief = Gtk.ReliefStyle.NONE;
             rate_button.valign = Gtk.Align.CENTER;
 
-            search_button = new Gtk.Button.from_icon_name("edit-find-symbolic", on_elementary ? Gtk.IconSize.LARGE_TOOLBAR : Gtk.IconSize.SMALL_TOOLBAR);
-            search_button.tooltip_text = _("Search your library or online");
+            search_button = new Gtk.Button.from_icon_name ("edit-find-symbolic", on_elementary ? Gtk.IconSize.LARGE_TOOLBAR : Gtk.IconSize.SMALL_TOOLBAR);
+            search_button.tooltip_text = _ ("Search your library or online");
             search_button.relief = Gtk.ReliefStyle.NONE;
             search_button.valign = Gtk.Align.CENTER;
 
 
-            if(on_elementary) {
-                podcast_store_button = new Gtk.Button.from_icon_name("system-software-install-symbolic", on_elementary ? Gtk.IconSize.LARGE_TOOLBAR : Gtk.IconSize.SMALL_TOOLBAR);
+            if (on_elementary) {
+                podcast_store_button = new Gtk.Button.from_icon_name ("system-software-install-symbolic", on_elementary ? Gtk.IconSize.LARGE_TOOLBAR : Gtk.IconSize.SMALL_TOOLBAR);
             } else {
-                podcast_store_button = new Gtk.Button.from_icon_name("application-rss+xml-symbolic", Gtk.IconSize.SMALL_TOOLBAR);
+                podcast_store_button = new Gtk.Button.from_icon_name ("application-rss+xml-symbolic", Gtk.IconSize.SMALL_TOOLBAR);
             }
-            podcast_store_button.tooltip_text = _("View the top podcasts in the iTunes Store");
+            podcast_store_button.tooltip_text = _ ("View the top podcasts in the iTunes Store");
             podcast_store_button.relief = Gtk.ReliefStyle.NONE;
             podcast_store_button.valign = Gtk.Align.CENTER;
 
             // Connect signals to appropriate handlers
-            refresh.clicked.connect(() => {
-        		refresh_selected();
+            refresh.clicked.connect (() => {
+                refresh_selected ();
             });
 
-            play_pause.clicked.connect(() => {
-            	play_pause_selected();
+            play_pause.clicked.connect (() => {
+                play_pause_selected ();
             });
-            forward.clicked.connect(() => {
-            	seek_forward_selected();
-        	});
-            backward.clicked.connect(() => {
-            	seek_backward_selected();
+            forward.clicked.connect (() => {
+                seek_forward_selected ();
             });
-            rate_button.clicked.connect(() => {
-                rate_button_selected();
+            backward.clicked.connect (() => {
+                seek_backward_selected ();
             });
-            podcast_store_button.clicked.connect(() => {
-                store_selected();
+            rate_button.clicked.connect (() => {
+                rate_button_selected ();
+            });
+            podcast_store_button.clicked.connect (() => {
+                store_selected ();
             });
 
 
             Gtk.Image download_image;
-            if(on_elementary)
-                download_image = new Gtk.Image.from_icon_name("browser-download-symbolic", on_elementary ? Gtk.IconSize.LARGE_TOOLBAR : Gtk.IconSize.SMALL_TOOLBAR);
-            else {
-                download_image = new Gtk.Image.from_icon_name("document-save-symbolic", on_elementary ? Gtk.IconSize.LARGE_TOOLBAR : Gtk.IconSize.SMALL_TOOLBAR);
+            if (on_elementary) {
+                download_image = new Gtk.Image.from_icon_name ("browser-download-symbolic", on_elementary ? Gtk.IconSize.LARGE_TOOLBAR : Gtk.IconSize.SMALL_TOOLBAR);
+            } else {
+                download_image = new Gtk.Image.from_icon_name ("document-save-symbolic", on_elementary ? Gtk.IconSize.LARGE_TOOLBAR : Gtk.IconSize.SMALL_TOOLBAR);
             }
-            download = new Gtk.Button();
+            download = new Gtk.Button ();
             download.image = download_image;
             download.has_tooltip = true;
-            download.tooltip_text = _("Downloads");
+            download.tooltip_text = _ ("Downloads");
             download.relief = Gtk.ReliefStyle.NONE;
             download.valign = Gtk.Align.CENTER;
 
-            download.clicked.connect(() => {
-            	downloads_selected();
-        	});
-            download.set_no_show_all(true);
-            download.hide();
+            download.clicked.connect (() => {
+                downloads_selected ();
+            });
+            download.set_no_show_all (true);
+            download.hide ();
 
             // Add the buttons
             pack_start (backward);
-	        pack_start (play_pause);
-	        pack_start (forward);
+            pack_start (play_pause);
+            pack_start (forward);
 
             pack_end (search_button);
-			pack_end (podcast_store_button);
-	        pack_end (download);
-	        pack_end (new_episodes_button);
-		}
+            pack_end (podcast_store_button);
+            pack_end (download);
+            pack_end (new_episodes_button);
+        }
 
 
-        public void hide_downloads_menuitem() {
-            if(download != null) {
+        public void hide_downloads_menuitem () {
+            if (download != null) {
                 download.no_show_all = true;
-                download.hide();
+                download.hide ();
             }
-            show_all();
+            show_all ();
         }
 
-        public void hide_playback_box() {
-            if(headerbar_box != null) {
+        public void hide_playback_box () {
+            if (headerbar_box != null) {
                 this.headerbar_box.no_show_all = true;
-                this.headerbar_box.hide();
+                this.headerbar_box.hide ();
             }
         }
 
 
-        public void show_playback_box() {
-            if(headerbar_box != null) {
+        public void show_playback_box () {
+            if (headerbar_box != null) {
                 this.headerbar_box.no_show_all = false;
-                this.headerbar_box.show();
-                show_all();
+                this.headerbar_box.show ();
+                show_all ();
             }
         }
 
-        public void show_shownotes_button() {
-            if(shownotes_button != null) {
-            	shownotes_button.set_no_show_all(false);
-                shownotes_button.show();
+        public void show_shownotes_button () {
+            if (shownotes_button != null) {
+                shownotes_button.set_no_show_all (false);
+                shownotes_button.show ();
             }
         }
 
-        public void hide_shownotes_button() {
-            if(shownotes_button != null) {
-            	shownotes_button.set_no_show_all(true);
-                shownotes_button.hide();
-            }
-        }
-        
-        public void show_volume_button() {
-            if(volume_button != null) {
-            	volume_button.set_no_show_all(false);
-                volume_button.show();
+        public void hide_shownotes_button () {
+            if (shownotes_button != null) {
+                shownotes_button.set_no_show_all (true);
+                shownotes_button.hide ();
             }
         }
 
-        public void hide_volume_button() {
-            if(volume_button != null) {
-            	volume_button.set_no_show_all(true);
-                volume_button.hide();
+        public void show_volume_button () {
+            if (volume_button != null) {
+                volume_button.set_no_show_all (false);
+                volume_button.show ();
             }
         }
 
-		public void show_playlist_button() {
-		    if(playlist_button != null) {
-			    playlist_button.set_no_show_all(false);
-			    playlist_button.show();
-		    }
-		}
-
-		public void hide_playlist_button() {
-		    if(playlist_button != null) {
-			    playlist_button.set_no_show_all(true);
-			    playlist_button.hide();
-		    }
-		}
-
-        public void hide_download_button() {
-            if(download != null) {
-            	this.download.set_no_show_all(true);
-                this.download.hide();
+        public void hide_volume_button () {
+            if (volume_button != null) {
+                volume_button.set_no_show_all (true);
+                volume_button.hide ();
             }
         }
 
-        public void show_download_button() {
-            if(download != null) {
-            	this.download.set_no_show_all(false);
-                this.download.show();
+        public void show_playlist_button () {
+            if (playlist_button != null) {
+                playlist_button.set_no_show_all (false);
+                playlist_button.show ();
             }
         }
 
-        public void set_play_pause_image(Gtk.Image new_img) {
-        	play_pause.image = new_img;
+        public void hide_playlist_button () {
+            if (playlist_button != null) {
+                playlist_button.set_no_show_all (true);
+                playlist_button.hide ();
+            }
         }
 
-        public void set_play_pause_text(string new_text) {
-        	play_pause.tooltip_text = new_text;
+        public void hide_download_button () {
+            if (download != null) {
+                this.download.set_no_show_all (true);
+                this.download.hide ();
+            }
         }
-	}
+
+        public void show_download_button () {
+            if (download != null) {
+                this.download.set_no_show_all (false);
+                this.download.show ();
+            }
+        }
+
+        public void set_play_pause_image (Gtk.Image new_img) {
+            play_pause.image = new_img;
+        }
+
+        public void set_play_pause_text (string new_text) {
+            play_pause.tooltip_text = new_text;
+        }
+    }
 }

--- a/src/Widgets/VideoControls.vala
+++ b/src/Widgets/VideoControls.vala
@@ -21,11 +21,15 @@ namespace Vocal {
 
     public class VideoControls : Gtk.Revealer {
 
-        public signal void play_toggled ();                    // Fired when the play button gets clicked
-        public signal void unfullscreen ();                    // Fired when the unfullscreen button gets clicked
-        public signal void progress_bar_scale_changed ();    // Fired when the progress bar scale changes (user seeks position)
+        // Fired when the play button gets clicked
+        public signal void play_toggled ();
+        // Fired when the unfullscreen button gets clicked
+        public signal void unfullscreen ();
+        // Fired when the progress bar scale changes (user seeks position)
+        public signal void progress_bar_scale_changed ();
 
-        public double progress_bar_fill;                    // The value currently set in the progress bar
+        // The value currently set in the progress bar
+        public double progress_bar_fill;
 
         public Gtk.Button play_button;
         private Gtk.Button unfullscreen_button;
@@ -70,9 +74,14 @@ namespace Vocal {
         /*
          * Sets the progress
          */
-        public void set_progress (double percentage, int mins_remaining, int secs_remaining, int mins_elapsed, int secs_elapsed) {
+        public void set_progress (
+            double percentage,
+            int mins_remaining,
+            int secs_remaining,
+            int mins_elapsed,
+            int secs_elapsed
+        ) {
             playback_box.set_progress (percentage, mins_remaining, secs_remaining, mins_elapsed, secs_elapsed);
-
         }
 
         /*

--- a/src/Widgets/VideoControls.vala
+++ b/src/Widgets/VideoControls.vala
@@ -20,12 +20,12 @@
 namespace Vocal {
 
     public class VideoControls : Gtk.Revealer {
-    
-        public signal void play_toggled ();					// Fired when the play button gets clicked
-        public signal void unfullscreen ();					// Fired when the unfullscreen button gets clicked
-        public signal void progress_bar_scale_changed();	// Fired when the progress bar scale changes (user seeks position)			
 
-        public double progress_bar_fill;					// The value currently set in the progress bar
+        public signal void play_toggled ();                    // Fired when the play button gets clicked
+        public signal void unfullscreen ();                    // Fired when the unfullscreen button gets clicked
+        public signal void progress_bar_scale_changed ();    // Fired when the progress bar scale changes (user seeks position)
+
+        public double progress_bar_fill;                    // The value currently set in the progress bar
 
         public Gtk.Button play_button;
         private Gtk.Button unfullscreen_button;
@@ -37,16 +37,16 @@ namespace Vocal {
             var main_actionbar = new Gtk.ActionBar ();
 
             play_button = new Gtk.Button.from_icon_name ("media-playback-start-symbolic", Gtk.IconSize.DIALOG);
-            play_button.tooltip_text = _("Play");
+            play_button.tooltip_text = _ ("Play");
             play_button.clicked.connect (() => {play_toggled ();});
             play_button.relief = Gtk.ReliefStyle.NONE;
 
             main_actionbar.pack_start (play_button);
 
-            playback_box = new PlaybackBox();
-            playback_box.scale_changed.connect(() => {
-                progress_bar_fill = playback_box.get_progress_bar_fill();
-                progress_bar_scale_changed();
+            playback_box = new PlaybackBox ();
+            playback_box.scale_changed.connect (() => {
+                progress_bar_fill = playback_box.get_progress_bar_fill ();
+                progress_bar_scale_changed ();
             });
             this.halign = Gtk.Align.CENTER;
 
@@ -55,31 +55,31 @@ namespace Vocal {
             playback_box.margin_left = 20;
             playback_box.margin_right = 20;
 
-            unfullscreen_button = new Gtk.Button.from_icon_name("window-restore-symbolic", Gtk.IconSize.DIALOG);
-            unfullscreen_button.clicked.connect(() => { unfullscreen(); });
-            unfullscreen_button.tooltip_text = _("Exit Fullscreen");
+            unfullscreen_button = new Gtk.Button.from_icon_name ("window-restore-symbolic", Gtk.IconSize.DIALOG);
+            unfullscreen_button.clicked.connect (() => { unfullscreen (); });
+            unfullscreen_button.tooltip_text = _ ("Exit Fullscreen");
             unfullscreen_button.relief = Gtk.ReliefStyle.NONE;
 
-            main_actionbar.pack_start(playback_box);
-            main_actionbar.pack_start(unfullscreen_button);
+            main_actionbar.pack_start (playback_box);
+            main_actionbar.pack_start (unfullscreen_button);
             add (main_actionbar);
 
             show_all ();
         }
 
-		/*
-		 * Sets the progress
-		 */
-        public void set_progress(double percentage, int mins_remaining, int secs_remaining, int mins_elapsed, int secs_elapsed) {
-            playback_box.set_progress(percentage, mins_remaining, secs_remaining, mins_elapsed, secs_elapsed);
+        /*
+         * Sets the progress
+         */
+        public void set_progress (double percentage, int mins_remaining, int secs_remaining, int mins_elapsed, int secs_elapsed) {
+            playback_box.set_progress (percentage, mins_remaining, secs_remaining, mins_elapsed, secs_elapsed);
 
         }
-	
-		/*
-		 * Sets the info title
-		 */
-        public void set_info_title(string title, string podcast_name) {
-            playback_box.set_info_title(title, podcast_name);
+
+        /*
+         * Sets the info title
+         */
+        public void set_info_title (string title, string podcast_name) {
+            playback_box.set_info_title (title, podcast_name);
         }
     }
 }


### PR DESCRIPTION
This change uses vala-lint in CI to enforce code styles. Having seen a number of pull request reviews to the effect of "please follow the elementary code style", I thought this may make things a bit easier on reviewers. I don't necessarily expect this change to be accepted at this time due largely to the size of the change set, but it's food for thought. Some notes:

- I've included a *large* commit here to address most of the existing errors reported by the linter. This was done primarily in bulk using `sed` but included a handful of manual changes, as well. These changes were primarily whitespace-related.
- There are 182 remaining errors reported by the linter in the "naming-convention" and "line-length" categories. These changes would require a more manual touch and are more likely to actually break something, so I've skipped them for now. If the maintainers are interested in a change like this one, I'd be happy to work through those errors, as well.
- A less blunt approach would be to enforce the linter only on new changes. vala-lint doesn't appear to have a diff mode, so some additional custom code would be necessary if that route was desired.
- I'm not sure if enforcing this should be done within Travis, Houston, or somewhere else. I'm not very familiar with elementary development, and I haven't found where other projects enforce this linter.

If this is something that would be helpful to the project, I'm happy to continue development here to get a mergeable version complete.