### PR TITLE
Fix coverart property getter logic

### DIFF
--- a/src/Objects/Podcast.vala
+++ b/src/Objects/Podcast.vala
@@ -38,17 +38,15 @@ namespace Vocal {
          */
         public string coverart_uri {
 
-            //the album art is saved locally, return that path. Otherwise, return main album art URI
-            get {
-                if(local_art_uri != null && local_art_uri != "") {
-                    GLib.File local_art = GLib.File.new_for_path(local_art_uri);
-                    if(local_art.query_exists()) {
-                        return local_art_uri;
-                    }
-                } else if(remote_art_uri != null) {
-                    GLib.File remote_art = GLib.File.new_for_uri(remote_art_uri);
-                    if(remote_art.query_exists()) {
-                        return remote_art_uri;
+            // If the album art is saved locally, return that path. Otherwise, return main album art URI.
+            owned get {
+                string[] uris = { local_art_uri, remote_art_uri };
+                foreach (string uri in uris) {
+                    if (uri != null && uri != "") {
+                        GLib.File art = GLib.File.new_for_uri (uri);
+                        if (art.query_exists ()) {
+                            return uri;
+                        }
                     }
                 }
                 // In rare instances where album art is not available at all, provide a "missing art" image to use
@@ -63,7 +61,7 @@ namespace Vocal {
                 if(proto == "http" || proto == "https") {
                     remote_art_uri = value.replace("%27", "'");
                 } else {
-                    local_art_uri = """file://""" + value.replace("%27", "'");
+                    local_art_uri = "file://" + value.replace("%27", "'");
                 }
             }
         }


### PR DESCRIPTION
Since #375 was merged, podcast cover art does not display. This change
`GLib.File.new_for_uri` for both `remote_art_uri` and `local_art_uri`
and consolidates the getter logic to eliminate null and empty check
inconsistencies. The core of this issue appears to be the the use of
`new_for_path`, which expects an absolute or relative filepath rather
than a `file://` URI.