### PR TITLE
Fixed bug where the mark as played icon isn't cleared

### DIFF
--- a/src/Widgets/PodcastView.vala
+++ b/src/Widgets/PodcastView.vala
@@ -637,13 +637,9 @@ namespace Vocal {
             }
 
             ListBoxRow new_row = listbox.get_selected_row();
-            if (controller.settings.newest_episodes_first) {
-                current_episode = boxes[new_row.get_index()].episode;
-            } else {
-                int new_index = boxes.size - new_row.get_index() - 1;
-                current_episode = boxes[new_index].episode;
-            }
-            
+
+            current_episode = boxes[new_row.get_index()].episode;
+
             shownotes.episode = current_episode;
             shownotes.set_html(current_episode.description != "(null)" ? Utils.html_to_markup(current_episode.description) : _("No show notes available."));
             shownotes.set_title(current_episode.title);
@@ -712,26 +708,23 @@ namespace Vocal {
                 foreach (Episode current_episode in podcast.episodes) {
                                    
                     EpisodeDetailBox current_episode_box = new EpisodeDetailBox (current_episode, controller, false);
-                    boxes.add(current_episode_box);
+
+                    if(controller.settings.newest_episodes_first) {
+                        boxes.add(current_episode_box);
+                    } else {
+                        boxes.insert(0, current_episode_box);
+                    }
                     
                     // Determine whether or not the episode has been played
                     if(current_episode.status == EpisodeStatus.UNPLAYED) {
                         unplayed_count++;
                     }
                 }
-                
-                if (controller.settings.newest_episodes_first) {
-                    foreach (EpisodeDetailBox box in boxes) {
-                        listbox.add (box);
-                        box.show_all ();
-                    }
-                } else {
-                    foreach (EpisodeDetailBox box in boxes) {
-                        listbox.prepend (box);
-                        box.show_all ();
-                    }
+
+                foreach (EpisodeDetailBox box in boxes) {
+                    listbox.add (box);
+                    box.show_all ();
                 }
-                
                 
             } else {
                 // Otherwise, simply create a new label to tell user that the feed is empty


### PR DESCRIPTION
The bug mentioned in #399 only occurred when the episodes were sorted as new. The reason for that was because when the podcasts were populated, the `boxes` array always stored the episodes from older to newer, while `listbox` stored them based on `controller.settings.newest_episodes_first`, causing them to be inverted, meaning that when the episodes were sorted as new, if the first one was marked as played, the icon changed on the last item of the list.

My solution was to `insert` the episodes to `boxes` also using `controller.settings.newest_episodes_first`.

I'm not sure if this is the most efficient way of doing. Let me know if I did anything wrong!