### PR TITLE
Fix crash on missing remote podcast artwork

### DIFF
--- a/src/Library.vala
+++ b/src/Library.vala
@@ -237,20 +237,21 @@ namespace Vocal {
             try {
                 // Don't use the default coverart_path getter, we want to make sure we are using the remote URI
                 GLib.File remote_art = GLib.File.new_for_uri(podcast.remote_art_uri);
-                
-                // Set the path of the new file and create another object for the local file
-                string art_path = podcast_path + "/" + remote_art.get_basename().replace("%", "_");
-                GLib.File local_art = GLib.File.new_for_path(art_path);
+                if(remote_art.query_exists()) {
+                    // If the remote art exists, set the path of the new file and create another object for the local file
+                    string art_path = podcast_path + "/" + remote_art.get_basename().replace("%", "_");
+                    GLib.File local_art = GLib.File.new_for_path(art_path);
 
-                // If the local album art doesn't exist
-                if(!local_art.query_exists()) {
-                    // Cache the art
-                    remote_art.copy(local_art, FileCopyFlags.NONE);
-                    // Mark the local path on the podcast
-                    podcast.local_art_uri = "file://" + art_path;
-                } else {
-                    // it already exists so don't download again.
-                    podcast.local_art_uri = "file://" + art_path;
+                    // If the local album art doesn't exist
+                    if(!local_art.query_exists()) {
+                        // Cache the art
+                        remote_art.copy(local_art, FileCopyFlags.NONE);
+                        // Mark the local path on the podcast
+                        podcast.local_art_uri = "file://" + art_path;
+                    } else {
+                        // it already exists so don't download again.
+                        podcast.local_art_uri = "file://" + art_path;
+                    }
                 }
             } catch(Error e) {
                 error("Unable to save a local copy of the album art. %s", e.message);


### PR DESCRIPTION
Vocal currently crashes if the remote art request fails with a
non-success HTTP status code. This change fixes that and allows the
application to fall back to the missing artwork icon.

Fixes #406.