### PR TITLE
Read response body data as text rather than stream in request_as_string.

### DIFF
--- a/src/Utils/SoupClient.vala
+++ b/src/Utils/SoupClient.vala
@@ -8,14 +8,13 @@ public class SoupClient {
     }
 
     public string request_as_string(HttpMethod method, string url) throws Error {
-        var data_stream = new DataInputStream(request(method, url));
-        var builder = new StringBuilder ();
+        var message = new Soup.Message (method.to_string (), url);
 
-        for (string line = data_stream.read_line_utf8(); line != null; line = data_stream.read_line_utf8()) {
-            builder.append(line);
-        }
+        soup_session.send_message (message);
+        check_response_headers (message);
 
-        return builder.str;
+        return (string) message.response_body.data;
+
     }
 
     public InputStream request (HttpMethod method, string url) throws Error {


### PR DESCRIPTION
Fix for #405

Reading the response stream line by line resulted in responses being built incorrectly. For instance the following
```
    xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd"
xmlns:rawvoice="http://www.rawvoice.com/rawvoiceRssModule/"
```
resulted in `xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd"xmlns:rawvoice="http:/` because there is no space added between the two attributes.