### PR TITLE
Fix minor errors with null download button and invalid GVariant format string.

### DIFF
--- a/src/Utils/MPRIS.vala
+++ b/src/Utils/MPRIS.vala
@@ -213,7 +213,7 @@ namespace Vocal {
                                   "/org/mpris/MediaPlayer2",
                                   "org.freedesktop.DBus.Properties",
                                   "PropertiesChanged",
-                                  new Variant (" (sa{sv}as)",
+                                  new Variant ("(sa{sv}as)",
                                              INTERFACE_NAME,
                                              builder,
                                              invalidated_builder)

--- a/src/Widgets/EpisodeDetailBox.vala
+++ b/src/Widgets/EpisodeDetailBox.vala
@@ -223,8 +223,10 @@ namespace Vocal {
          * Removes the download button from the box
          */
         public void hide_download_button () {
-            download_button.set_no_show_all (true);
-            download_button.hide ();
+            if (download_button != null) {
+                download_button.set_no_show_all (true);
+                download_button.hide ();
+            }
             show_all ();
         }
 


### PR DESCRIPTION
Though minor, these errors cause gdb to break when running with `G_DEBUG=fatal-criticals` which is very annoying when debugging other issues.

This commit fixes the following errors:

* Fix fatal `[Gtk] gtk_widget_set_no_show_all: assertion 'GTK_IS_WIDGET
  (widget)' failed`  message, don't call `set_no_show_all()` on
  null `download_button`.
* `[GLib] ' (sa{sv}as)' is not a valid GVariant format string`