### PR TITLE
Update database schema & primary keys.

### DIFF
--- a/src/Controller.vala
+++ b/src/Controller.vala
@@ -300,7 +300,10 @@ namespace Vocal {
             if (first_run || library.empty ()) {
                 window.show_all ();
                 window.switch_visible_page (window.welcome);
-
+                if (library.pending_import != null) {
+                    info ("Starting subscription migration as import: %s", library.pending_import);
+                    window.import_podcasts (library.pending_import);
+                }
             } else {
                 // Populate the IconViews from the library
                 window.populate_views ();

--- a/src/Library.vala
+++ b/src/Library.vala
@@ -1095,6 +1095,8 @@ namespace Vocal {
                     episode.podcast_uri = val;
                 } else if (col_name == "guid") {
                     episode.guid = val;
+                } else if (col_name == "link") {
+                    episode.link = val;
                 }
             }
 
@@ -1273,10 +1275,11 @@ namespace Vocal {
                 latest_position     TEXT,
                 download_status     TEXT,
                 play_status         TEXT,
-                guid                TEXT
+                guid                TEXT,
+                link                TEXT
               );
 
-              CREATE UNIQUE INDEX episode_guid ON Episode (guid, podcast_uri);
+              CREATE UNIQUE INDEX episode_guid ON Episode (guid, link, podcast_uri);
               CREATE INDEX episode_title ON Episode (title);
               CREATE INDEX episode_released ON Episode (released);
 
@@ -1361,12 +1364,11 @@ namespace Vocal {
          */
         public bool write_episode_to_database (Episode episode) {
 
-            assert (episode.guid != null && episode.guid != "");
             assert (episode.podcast_uri != null && episode.podcast_uri != "");
 
             string query = "INSERT OR REPLACE INTO Episode " +
-                           " (title, podcast_uri, uri, local_uri, released, description, latest_position, download_status, play_status, guid) " +
-                           " VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10);";
+                           " (title, podcast_uri, uri, local_uri, released, description, latest_position, download_status, play_status, guid, link) " +
+                           " VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11);";
 
             Sqlite.Statement stmt;
             int ec = db.prepare_v2 (query, query.length, out stmt);
@@ -1396,6 +1398,7 @@ namespace Vocal {
             stmt.bind_text (8, download_text);
             stmt.bind_text (9, played_text);
             stmt.bind_text (10, episode.guid);
+            stmt.bind_text (11, episode.link);
 
             ec = stmt.step ();
 

--- a/src/Library.vala
+++ b/src/Library.vala
@@ -79,6 +79,7 @@ namespace Vocal {
         private GLib.List<string> podcasts_being_added = new GLib.List<string> ();
 
         private Controller controller;
+        public string pending_import = null;
 
         /*
          * Constructor for the library
@@ -168,6 +169,8 @@ namespace Vocal {
                 export_to_OPML (export_path);
 
                 podcasts.clear ();
+
+                this.pending_import = export_path; // save location for later import.
 
                 // Create backup of existing db tables.
                 query = """

--- a/src/Library.vala
+++ b/src/Library.vala
@@ -114,36 +114,21 @@ namespace Vocal {
          */
         public void run_database_update_check () {
 
-            if (!check_database_exists ()) {
+            if ( ! check_database_exists ()) {
                 return;
             }
 
-            info ("Performing database update check.");
+            prepare_database ();
 
-            // Open the database
-            int ec = Sqlite.Database.open (db_location, out db);
-            if (ec != Sqlite.OK) {
-                error ("Can't open database: %d: %s\n", db.errcode (), db.errmsg ());
-                return;
-            }
+            int current_db_version = get_db_version ();
 
-            // Temporarily add a dummy podcast
-            string query = """INSERT OR REPLACE INTO Podcast (name, feed_uri, album_art_url, album_art_local_uri, description, content_type)
-                VALUES ('%s','%s','%s','%s', '%s', '%s');""".printf ("dummy", "dummy", "dummy", "dummy", "dummy", "dummy");
-
-            string errmsg;
-
-            ec = db.exec (query, null, out errmsg);
-            if (ec != Sqlite.OK) {
-                warning ("Error: %s\n", errmsg);
-                return;
-            }
+            info ("Performing database update check. Current version: %d", current_db_version);
 
             // Check that license is in the database (added 2018-05-06)
-            query = """SELECT license FROM Podcast WHERE name = "dummy";""";
-            errmsg = null;
+            string query = """SELECT license FROM Podcast WHERE name = "dummy";""";
+            string errmsg = null;
 
-            ec = db.exec (query, null, out errmsg);
+            int ec = db.exec (query, null, out errmsg);
 
             if (ec != Sqlite.OK) {
                 info ("License column does not exist in podcast table. Altering table to update.");
@@ -161,9 +146,52 @@ namespace Vocal {
                 }
             }
 
-            // Clean up by removing the dummy podcast
-            query = """DELETE FROM Podcast WHERE name = "dummy";""";
-            ec = db.exec (query, null, out errmsg);
+            if (current_db_version < 1) {
+                info ("Updating DB schema to v1 ...");
+
+                // Backup existing data before creating schema at current level.
+                // Load podcasts here since the export expects the library to be loaded.
+                Sqlite.Statement stmt;
+                query = "SELECT * FROM Podcast ORDER BY name";
+                ec = db.prepare_v2 (query, query.length, out stmt);
+
+                while (stmt.step () == Sqlite.ROW) {
+                    Podcast current = podcast_from_row (stmt);
+                    podcasts.add (current);
+                }
+
+                stmt.reset ();
+
+                string export_name = "vocal_export-%s.xml".printf (new GLib.DateTime.now_utc ().format ("%FT%TZ"));
+                string export_path = Path.build_filename(db_directory, export_name);
+                info ("exporting existing subscriptions to <%s>.", export_path);
+                export_to_OPML (export_path);
+
+                podcasts.clear ();
+
+                // Create backup of existing db tables.
+                query = """
+                  BEGIN TRANSACTION;
+
+                  ALTER TABLE Podcast RENAME TO Podcast_V0;
+                  ALTER TABLE Episode RENAME TO Episode_V0;
+
+                  END TRANSACTION;
+                """;
+
+                ec = db.exec (query, null);
+                if (ec != Sqlite.OK) {
+                    error ("Rename of existing tables failed! (%d) %s", db.errcode (), db.errmsg ());
+                }
+
+                create_db_schema ();
+
+                info ("DB update finished.");
+
+                current_db_version = get_db_version ();
+            }
+
+            assert (current_db_version == 1);
         }
 
 
@@ -263,6 +291,7 @@ namespace Vocal {
                 podcasts.add (podcast);
 
                 foreach (Episode episode in podcast.episodes) {
+                    episode.podcast_uri = podcast.feed_uri;
                     write_episode_to_database (episode);
                 }
             } else {
@@ -774,6 +803,8 @@ namespace Vocal {
                 downloaded_episode = null;
                 bool found = false;
 
+                // TODO: the following can be very slow for large podcasts/databases, should be done in sql.
+
                 foreach (Podcast podcast in podcasts) {
                     if (!found) {
                         if (parent_podcast_name == podcast.name) {
@@ -863,13 +894,18 @@ namespace Vocal {
 
 
             // Repeat the process with the episodes
-
+            // TODO: instead of running a separate sql query for each podcast all episodes
+            //       can be loaded in single statement.
             foreach (Podcast podcast in podcasts) {
 
-                prepared_query_str = "SELECT * FROM Episode WHERE parent_podcast_name = '%s' ORDER BY rowid ASC".printf (podcast.name);
+                prepared_query_str = "SELECT e.*, p.name as parent_podcast_name
+                                      FROM Episode e
+                                      LEFT JOIN Podcast p on p.feed_uri = e.podcast_uri
+                                      WHERE podcast_uri = '%s'
+                                      ORDER BY e.rowid ASC".printf (podcast.feed_uri);
                 ec = db.prepare_v2 (prepared_query_str, prepared_query_str.length, out stmt);
                 if (ec != Sqlite.OK) {
-                    stderr.printf ("Error: %d: %s\n", db.errcode (), db.errmsg ());
+                    warning ("Error: %d: %s\n", db.errcode (), db.errmsg ());
                     return;
                 }
 
@@ -958,21 +994,21 @@ namespace Vocal {
             int ec;
 
             // Delete the podcast's episodes from the database
-            query = "DELETE FROM Episode WHERE parent_podcast_name = '%s';".printf (podcast.name.replace ("'", "%27"));
+            query = "DELETE FROM Episode WHERE podcast_uri = '%s';".printf (podcast.feed_uri.replace ("'", "%27"));
 
 
             ec = db.exec (query, null, out errmsg);
             if (ec != Sqlite.OK) {
-                stderr.printf ("Error: %d: %s\n", db.errcode (), db.errmsg ());
+                warning ("Error: %d: %s\n", db.errcode (), db.errmsg ());
                 return;
             }
 
             // Delete the podcast from the database
-            query = "DELETE FROM Podcast WHERE name = '%s';".printf (podcast.name.replace ("'", "%27"));
+            query = "DELETE FROM Podcast WHERE feed_uri = '%s';".printf (podcast.feed_uri);
             ec = db.exec (query, null, out errmsg);
 
             if (ec != Sqlite.OK) {
-                stderr.printf ("Error: %s\n", errmsg);
+                warning ("Error: %d: %s\n", db.errcode (), db.errmsg ());
             }
 
             // Remove the local object as well
@@ -1026,10 +1062,8 @@ namespace Vocal {
                 else if (col_name == "local_uri") {
                     if (val != " (null)")
                         episode.local_uri = val;
-                }
-                else if (col_name == "release_date") {
-                    episode.date_released = val;
-                    episode.set_datetime_from_pubdate ();
+                } else if (col_name == "released") {
+                    episode.datetime_released = new GLib.DateTime.from_unix_local (val.to_int64 ());
                 }
                 else if (col_name == "download_status") {
                     if (val == "downloaded") {
@@ -1054,6 +1088,10 @@ namespace Vocal {
                 }
                 else if (col_name == "parent_podcast_name") {
                     episode.parent = new Podcast.with_name (val);
+                } else if (col_name == "podcast_uri") {
+                    episode.podcast_uri = val;
+                } else if (col_name == "guid") {
+                    episode.guid = val;
                 }
             }
 
@@ -1197,13 +1235,22 @@ namespace Vocal {
             // Create the vocal folder if it doesn't exist
             GLib.DirUtils.create_with_parents (db_directory, 0775);
 
+            create_db_schema ();
+
+            return true;
+
+        }
+
+        public void create_db_schema () {
+
             prepare_database ();
 
             string query = """
+              BEGIN TRANSACTION;
+
               CREATE TABLE Podcast (
-                id                  INT,
-                name                TEXT    PRIMARY KEY     NOT NULL,
-                feed_uri            TEXT                    NOT NULL,
+                name                TEXT                    NOT NULL,
+                feed_uri            TEXT    PRIMARY KEY     NOT NULL,
                 album_art_url       TEXT,
                 album_art_local_uri TEXT,
                 description         TEXT                    NOT NULL,
@@ -1211,26 +1258,36 @@ namespace Vocal {
                 license             TEXT
               );
 
+              CREATE INDEX podcast_name ON Podcast (name);
+
               CREATE TABLE Episode (
-                title               TEXT    PRIMARY KEY     NOT NULL,
-                parent_podcast_name TEXT                    NOT NULL,
-                parent_podcast_id   INT,
+                title               TEXT                    NOT NULL,
+                podcast_uri         TEXT                    NOT NULL,
                 uri                 TEXT                    NOT NULL,
                 local_uri           TEXT,
-                release_date        TEXT,
+                released            INT,
                 description         TEXT,
                 latest_position     TEXT,
                 download_status     TEXT,
-                play_status         TEXT
+                play_status         TEXT,
+                guid                TEXT
               );
+
+              CREATE UNIQUE INDEX episode_guid ON Episode (guid, podcast_uri);
+              CREATE INDEX episode_title ON Episode (title);
+              CREATE INDEX episode_released ON Episode (released);
+
+              PRAGMA user_version = 1;
+
+              END TRANSACTION;
             """;
 
             int ec = db.exec (query, null);
             if (ec != Sqlite.OK) {
-                error ("unable to create database %d: %s", db.errcode (), db.errmsg ());
+                error ("unable to create database schema %d: %s", db.errcode (), db.errmsg ());
             }
-            return true;
 
+            return;
         }
 
 
@@ -1301,9 +1358,12 @@ namespace Vocal {
          */
         public bool write_episode_to_database (Episode episode) {
 
+            assert (episode.guid != null && episode.guid != "");
+            assert (episode.podcast_uri != null && episode.podcast_uri != "");
+
             string query = "INSERT OR REPLACE INTO Episode " +
-                           " (title, parent_podcast_name, uri, local_uri, description, release_date, download_status, play_status, latest_position) " +
-                           " VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9);";
+                           " (title, podcast_uri, uri, local_uri, released, description, latest_position, download_status, play_status, guid) " +
+                           " VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10);";
 
             Sqlite.Statement stmt;
             int ec = db.prepare_v2 (query, query.length, out stmt);
@@ -1324,14 +1384,15 @@ namespace Vocal {
             string download_text = (episode.current_download_status == DownloadStatus.DOWNLOADED) ? "downloaded" : "not_downloaded";
 
             stmt.bind_text (1, title);
-            stmt.bind_text (2, parent_podcast_name);
+            stmt.bind_text (2, episode.podcast_uri);
             stmt.bind_text (3, episode.uri);
             stmt.bind_text (4, episode.local_uri);
-            stmt.bind_text (5, episode.description);
-            stmt.bind_text (6, episode.date_released);
-            stmt.bind_text (7, download_text);
-            stmt.bind_text (8, played_text);
-            stmt.bind_text (9, episode.last_played_position.to_string ());
+            stmt.bind_int64 (5, episode.datetime_released.to_unix ());
+            stmt.bind_text (6, episode.description);
+            stmt.bind_text (7, episode.last_played_position.to_string ());
+            stmt.bind_text (8, download_text);
+            stmt.bind_text (9, played_text);
+            stmt.bind_text (10, episode.guid);
 
             ec = stmt.step ();
 
@@ -1342,5 +1403,30 @@ namespace Vocal {
 
             return true;
         }
+
+
+        /*
+         * Returns the Sqlite user_version pragma used for checking current db schema version.
+         * https://www.sqlite.org/pragma.html#pragma_user_version
+         */
+        private int get_db_version () {
+            if (db == null) {
+                prepare_database ();
+            }
+
+            int version = 0;
+            int ec = db.exec ("PRAGMA user_version", (n_cols, values, col_names) => {
+                    version = values[0].to_int ();
+                    return 0;
+                }, null);
+
+            if (ec != Sqlite.OK) {
+                error ("Unable to determine database schema version! (%d) %s.",
+                       db.errcode (), db.errmsg ());
+            }
+
+            return version;
+        }
+
     }
 }

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -892,36 +892,46 @@ namespace Vocal {
         /*
          * Choose a file to import to the controller.library
          */
-        public void import_podcasts () {
+        public void import_podcasts (string? import_file = null) {
 
             controller.currently_importing = true;
+            int decision = Gtk.ResponseType.NONE;
+            bool run_pending_import = false;
+            Gtk.FileChooserDialog file_chooser = null;
+            string file_name;
 
-            var file_chooser = new Gtk.FileChooserDialog (_ ("Select Subscription File"),
-                 this,
-                 Gtk.FileChooserAction.OPEN,
-                 _ ("Cancel"), Gtk.ResponseType.CANCEL,
-                 _ ("Open"), Gtk.ResponseType.ACCEPT);
+            if (import_file == null) {
 
-            var all_files_filter = new Gtk.FileFilter ();
-            all_files_filter.set_filter_name (_ ("All files"));
-            all_files_filter.add_pattern ("*");
+                file_chooser = new Gtk.FileChooserDialog ("Save Subscriptions to XML File",
+                          this,
+                          Gtk.FileChooserAction.SAVE,
+                          _ ("Cancel"), Gtk.ResponseType.CANCEL,
+                          _ ("Save"), Gtk.ResponseType.ACCEPT);
 
-            var opml_filter = new Gtk.FileFilter ();
-            opml_filter.set_filter_name (_ ("OPML files"));
-            opml_filter.add_mime_type ("text/x-opml+xml");
+                var all_files_filter = new Gtk.FileFilter ();
+                all_files_filter.set_filter_name (_ ("All files"));
+                all_files_filter.add_pattern ("*");
 
-            file_chooser.add_filter (opml_filter);
-            file_chooser.add_filter (all_files_filter);
+                var opml_filter = new Gtk.FileFilter ();
+                opml_filter.set_filter_name (_ ("OPML files"));
+                opml_filter.add_mime_type ("text/x-opml+xml");
 
-            file_chooser.modal = true;
+                file_chooser.add_filter (opml_filter);
+                file_chooser.add_filter (all_files_filter);
 
-            int decision = file_chooser.run ();
-            string file_name = file_chooser.get_filename ();
+                file_chooser.modal = true;
 
-            file_chooser.destroy ();
+                decision = file_chooser.run ();
+                file_name = file_chooser.get_filename ();
+
+                file_chooser.destroy ();
+            } else {
+                run_pending_import = true;
+                file_name = import_file;
+            }
 
             //If the user selects a file, get the name and parse it
-            if (decision == Gtk.ResponseType.ACCEPT) {
+            if (decision == Gtk.ResponseType.ACCEPT || run_pending_import == true) {
 
                 toolbar.show_playback_box ();
 

--- a/src/Objects/Episode.vala
+++ b/src/Objects/Episode.vala
@@ -24,6 +24,7 @@ namespace Vocal {
     public class Episode : GLib.Object {
 
         public string guid = null;
+        public string link = "";
         public string podcast_uri = null;
         public string title = "";                       // the title of the episode
         public string description = "";                 // the description/shownotes

--- a/src/Objects/Episode.vala
+++ b/src/Objects/Episode.vala
@@ -23,12 +23,15 @@ namespace Vocal {
 
     public class Episode : GLib.Object {
 
+        public string guid = null;
+        public string podcast_uri = null;
         public string title = "";                       // the title of the episode
         public string description = "";                 // the description/shownotes
         public string uri = "";                         // the remote location for the media file
         public string local_uri = "";                   // the local location for the media file, if any
         public double last_played_position;             // the latest position that has been played
         public string date_released;                    // when the episode was released, in string form
+
         public EpisodeStatus status;                    // whether the episode is played or unplayed
         public DownloadStatus current_download_status;  // whether the episode is downloaded or not downloaded
 

--- a/src/Objects/Podcast.vala
+++ b/src/Objects/Podcast.vala
@@ -84,6 +84,7 @@ namespace Vocal {
          * Add a new episode to the library
          */
         public void add_episode (Episode new_episode) {
+            new_episode.podcast_uri = this.feed_uri;
             episodes.insert (0, new_episode);
         }
 

--- a/src/Utils/FeedParser.vala
+++ b/src/Utils/FeedParser.vala
@@ -196,6 +196,9 @@ namespace Vocal {
                         else if (next_item_in_queue == "description") {
                             i++;
                             episode.description = queue[i];
+                        } else if (next_item_in_queue == "guid") {
+                            i++;
+                            episode.guid = queue[i];
                         }
                     }
 
@@ -578,10 +581,15 @@ namespace Vocal {
                             else if (next_item_in_queue == "description") {
                                 i++;
                                 episode.description = queue[i];
+                            } else if (next_item_in_queue == "guid") {
+                                i++;
+                                episode.guid = queue[i];
                             }
+
                         }
 
                         episode.parent = podcast;
+                        episode.podcast_uri = podcast.feed_uri;
 
                         if (previous_newest_episode != null) {
                             if (episode.title == previous_newest_episode.title.replace ("%27", "'")) {
@@ -670,12 +678,17 @@ namespace Vocal {
                             }
                         }
                         break;
+                    case "id":
+                        entry.guid = iterEntry->get_content ();
+                        break;
                     default:
                         break;
                 }
             }
 
             entry.parent=podcast;
+            entry.podcast_uri = podcast.feed_uri;
+
             episodes.add (entry);
         }
 

--- a/src/Utils/FeedParser.vala
+++ b/src/Utils/FeedParser.vala
@@ -199,6 +199,9 @@ namespace Vocal {
                         } else if (next_item_in_queue == "guid") {
                             i++;
                             episode.guid = queue[i];
+                        } else if (next_item_in_queue == "link") {
+                            i++;
+                            episode.link = queue[i];
                         }
                     }
 
@@ -584,6 +587,9 @@ namespace Vocal {
                             } else if (next_item_in_queue == "guid") {
                                 i++;
                                 episode.guid = queue[i];
+                            } else if (next_item_in_queue == "link") {
+                                i++;
+                                episode.link = queue[i];
                             }
 
                         }
@@ -667,6 +673,7 @@ namespace Vocal {
                             string attr_name = propEntry->name;
                             if (attr_name == "href") {
                                 entry.uri=propEntry->children->content;
+                                entry.link = entry.uri;
                             } else if (attr_name == "type" && podcast != null) {
                                 podcast.content_type = MediaType.UNKNOWN;
 

--- a/src/Widgets/SearchResultsView.vala
+++ b/src/Widgets/SearchResultsView.vala
@@ -313,7 +313,7 @@ namespace Vocal {
             foreach (Episode e in e_matches) {
                 Podcast parent = null;
                 foreach (Podcast p in library.podcasts) {
-                    if (e.parent.name == p.name) {
+                    if (e.podcast_uri == p.feed_uri) {
                         parent = p;
                     }
                 }


### PR DESCRIPTION
This is a simplified version of #379 as a result of the discussion on that PR thread.

This PR primarily updates the database schema to use the podcast uri to uniquely identify podcasts and the podcast uri and episode guid to uniquely identify episodes, addressing the problem identified in #320 

This change also uses the existing export/import methods to migrate existing subscriptions. Note that this does not copy episode data directly, which could appear to result in loss of episodes no longer shown in their feeds . Note that the actual episode data is retained so technically recovery is possible though complex (as in the #379 example).

This is a minimized changeset, and should be a work in progress.


