### PR TITLE
Use iTunes image if available

### DIFF
--- a/src/Utils/FeedParser.vala
+++ b/src/Utils/FeedParser.vala
@@ -97,13 +97,15 @@ namespace Vocal {
                     found_main_description = true;
                     i++;
                 }
-                else if (current == "image" && found_cover_art == false) {
+                else if (current == "image") {
 
                     if (queue[i + 2] == "href") {
-                        i += 3;
-                        podcast.remote_art_uri = queue[i];
-                    }
-                    else {
+                        // When there is an iTunes image, queue[i + 1] is empty
+                        if (queue[i + 1] == "" || found_cover_art == false) {
+                            i += 3;
+                            podcast.remote_art_uri = queue[i];
+                        }
+                    } else if (found_cover_art == false) {
                         while (queue[i] != "url") {
                             i++;
                         }


### PR DESCRIPTION
Currently Vocal uses the first image it can find as the thumbnail. I've seen some Podcasts where the first image is just a low resolution image, while the iTunes image has a much higher resolution(e.g. [Destination Linux Podcast](https://destinationlinux.org/feed/mp3/)). With this commit Vocal will use the iTunes image - if there is one - otherwise it will still use the first image of the feed.