### PR TITLE
Strip out weekday from Episode pubDate

### DIFF
--- a/src/Objects/Episode.vala
+++ b/src/Objects/Episode.vala
@@ -116,7 +116,8 @@ namespace Vocal {
 
             if (date_released != null) {
                 GLib.Time tm = GLib.Time ();
-                tm.strptime (date_released, "%a, %d %b %Y %H:%M:%S %Z");
+                date_released = date_released[5:date_released.length];
+                tm.strptime (date_released, "%d %b %Y %H:%M:%S %Z");
                 datetime_released = new DateTime.local (
                     1900 + tm.year,
                     1 + tm.month,


### PR DESCRIPTION
For some reason GLib.Time.strptime doesn't accept strings that contain the weekday(it returns just null if there is a weekday). This commit strips out the first 5 characters of the pubDate, so strptime actually works now. This was also the cause for a lot of crashes in the git-version.
Fixes [#436](https://github.com/needle-and-thread/vocal/issues/436).