### PR TITLE
Infobar improvements when adding a podcast

### DIFF
--- a/src/Controller.vala
+++ b/src/Controller.vala
@@ -571,6 +571,7 @@ namespace Vocal {
 
             if (success) {
 
+                window.hide_infobar ();
                 window.toolbar.playback_box.show_artwork_image ();
                 window.toolbar.playback_box.show_volume_button ();
             

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -1867,6 +1867,7 @@ namespace Vocal {
             }
             var message_label = new Gtk.Label (message);
             message_label.margin_left = 12;
+            message_label.use_markup = true;
             content_area.add (message_label);
             
             infobar.revealed = true;


### PR DESCRIPTION
The first commit enables the use of markup in the infobar, so when adding a Podcast the URL will be bold(previously it just showed `<b>URL</b>`).

The second commit hides the infobar automatically after the Podcast has been added successfully. 