### PR TITLE
Add gvfs to dependency list

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -7,6 +7,7 @@ libxml-2.0
 granite
 gtk+-3.0
 gstreamer-1.0
+gvfs
 sqlite3
 
 


### PR DESCRIPTION
Vocal will crash when trying to add a Podcast if gvfs isn't installed, because it fails when downloading the Podcast image. This affects mostly Arch users, because on most other distros gvfs is preinstalled.
I've already reported this in the Arch Linux bug tracker, so they'll hopefully add the dependency as well.
Fixes [#388 ](https://github.com/needle-and-thread/vocal/issues/388)