### PR TITLE
Fix regex to properly ignore <a href tags

### DIFF
--- a/src/Utils/Utils.vala
+++ b/src/Utils/Utils.vala
@@ -98,7 +98,7 @@ public class Utils {
         markup = markup.replace ("&", "&amp;");
 
         // Simplify (keep only href attribute) & preserve anchor tags.
-        Regex simpleLinks = new Regex ("<a (.*? (href[\\s=]*?\".*?\").*?)> (.*?)<[\\s\\/]*?a[\\s>]*",
+        Regex simpleLinks = new Regex ("<a (.*?(href[\\s=]*?\".*?\").*?)>(.*?)<[\\s\\/]*?a[\\s>]*",
                                       RegexCompileFlags.CASELESS | RegexCompileFlags.DOTALL);
         markup = simpleLinks.replace (markup, -1, 0, "?a? \\2?a-end?\\3 ?/a?");
 


### PR DESCRIPTION
Currently get error messages like 
(com.github.needleandthread.vocal:68386): Gtk-WARNING **: 13:19:28.220: Failed to set text 'CNN Chief Medical Correspondent Dr. Sanjay Gupta talks to healthcare providers on the frontlines in New Rochelle, a New York suburb where a large cluster of cases prompted Governor Andrew Cuomo to set up a containment zone and deploy the National Guard. <a href="http://knit.audio/podcast-advertising"&gt;via Knit</a>' from markup due to error parsing markup: Error on line 1 char 318: “&gt;via” is not a valid name.

This fixes that. The first '>' does not get picked up and gets converted to &gt; currently.