### PR TITLE
Respect global dark theme preference

### DIFF
--- a/src/Controller.vala
+++ b/src/Controller.vala
@@ -92,6 +92,14 @@ namespace Vocal {
             
             info ("Initiating the gpodder API");
             gpodder_client = gpodderClient.get_default_instance (this);
+
+            // Determine whether or not the local library exists
+            first_run = (!library.check_database_exists ());
+
+            // Use Dark theme by default if option is set globally
+            if (first_run && Gtk.Settings.get_default ().gtk_application_prefer_dark_theme) {
+                settings.dark_mode_enabled = true;
+            }
             
             // IMPORTANT NOTE: the player, library, and iTunes provider MUST exist before the MainWindow is created
 
@@ -241,9 +249,6 @@ namespace Vocal {
             // Connect the library's signals
             library.import_status_changed.connect (window.on_import_status_changed);
             library.download_finished.connect (window.on_download_finished);
-
-            // Determine whether or not the local library exists
-            first_run = (!library.check_database_exists ());
 
             if (!first_run) {
                 info ("Refilling library.");

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -216,6 +216,7 @@ namespace Vocal {
             if (controller.settings.dark_mode_enabled) {
                 Gtk.Settings.get_default ().set ("gtk-application-prefer-dark-theme", true);
             } else {
+                Gtk.Settings.get_default ().set ("gtk-application-prefer-dark-theme", false);
                 style_context.add_provider_for_screen (screen, headerbar_css_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
             }
 


### PR DESCRIPTION
This commit sets the setting `dark_mode_enabled` to true when launching Vocal for the first time, if the user has the setting `gtk-application-prefer-dark-theme` enabled globally. 
This also fixes two issues when the global dark theme setting is enabled, but the `dark_mode_enabled` setting from Vocal is set to false:
- Dark application + light headerbar (only when using Elementary theme)
- the application thinks it is light (at startup) even when it's not(it shows the "Use Dark Theme" entry in the dropdown menu, even though it's already dark)