### PR TITLE
Show podcast description on info button (Search)

### DIFF
--- a/src/Utils/FeedParser.vala
+++ b/src/Utils/FeedParser.vala
@@ -229,8 +229,18 @@ namespace Vocal {
 
             string description = "";
 
-            // Call the Xml.Parser to parse the file, which returns an unowned reference
-            Xml.Doc* doc = Xml.Parser.parse_file (path);
+            Xml.Doc* doc;
+
+            if (SoupClient.valid_http_uri (path)) {
+                try {
+                    doc = XmlUtils.parse_string (soup_client.request_as_string (HttpMethod.GET, path));
+                } catch (GLib.Error e) {
+                    warning ("Failed to get podcast. %s", e.message);
+                    return null;
+                }
+            } else {
+                doc = Xml.Parser.parse_file (path);
+            }
 
             // Make sure that it didn't return a null reference
             if (doc == null) {

--- a/src/Widgets/DirectoryArt.vala
+++ b/src/Widgets/DirectoryArt.vala
@@ -88,7 +88,7 @@ namespace Vocal {
             details_button.clicked.connect (() => {
                 if (summary.length > 0) {
                     summary_label.set_text (summary);
-                } else if (url.contains ("itunes.apple")) {
+                } else if (url.contains ("podcasts.apple.com")) {
                     var itunes = new iTunesProvider ();
                     string rss_url = itunes.get_rss_from_itunes_url (url);
                     var feed_parser = new FeedParser ();


### PR DESCRIPTION
This fixes the non-existent Podcast description in the search results view when clicking on the Info button.

Fixes: #415 