### PR TITLE
Support multiple datetime formats for episode pubdate

### DIFF
--- a/src/Objects/Episode.vala
+++ b/src/Objects/Episode.vala
@@ -116,7 +116,23 @@ namespace Vocal {
 
             if (date_released != null) {
                 GLib.Time tm = GLib.Time ();
-                tm.strptime (date_released, "%a, %d %b %Y %H:%M:%S %Z");
+                // Set a default time of now in case a time cannot be parsed
+                // from the pubdate string.
+                tm.mktime ();
+                // Supported time formats.
+                // The specification (https://cyber.harvard.edu/rss/rss.html)
+                // states that datetimes should be in RFC 822 format,
+                // but date strings with different formats can cause a crash.
+                string[] time_formats = {
+                    "%a, %d %b %Y %H:%M:%S %Z",  // Sunday, 01 Jan 1970 00:00:00 GMT
+                    "%a, %b %d %Y %H:%M:%S %Z"  // Sunday, Jan 01 1970 00:00:00 GMT
+                };
+                foreach (string format in time_formats) {
+                    var last_parsed_char = tm.strptime (date_released, format);
+                    if (last_parsed_char != null) {
+                        break;
+                    }
+                }
                 datetime_released = new DateTime.local (
                     1900 + tm.year,
                     1 + tm.month,


### PR DESCRIPTION
The RSS spec states that pubdates should be formatted according to RFC
822, but podcast feeds don't always conform to that (see episode three
of [Conversations in Code] for an example). Currently, if Vocal
encounters a pubdate of any other format, it crashes. To prevent that,
this change does two things:

1. Adds support for parsing multiple datetime formats. Only two formats
   are supported initially. A more robust implementation would include
   many common formats seen across podcast feeds.

2. Sets the default pubdate to the current time. This is not an ideal
   solution, but it prevents the application from crashing.

[Conversations in Code]: https://conversationsincode.xyz/rss/podcast.xml