### PR TITLE
Add launchable tag to appdata

### DIFF
--- a/data/com.github.needleandthread.vocal.appdata.xml
+++ b/data/com.github.needleandthread.vocal.appdata.xml
@@ -2,6 +2,7 @@
 <!-- Copyright 2018 Needle & Thread -->
 <component type="desktop">
   <id>com.github.needleandthread.vocal</id>
+  <launchable type="desktop-id">com.github.needleandthread.vocal.desktop</launchable>
   <metadata_license>CC0</metadata_license>
   <project_license>GPL-3.0+</project_license>
   <name>Vocal</name>


### PR DESCRIPTION
This is needed for appstream-generator to find the associated desktop file.

See also:
- https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-launchable
- https://github.com/ximion/appstream-generator/issues/88