### PR TITLE
Clean up a tag hrefs before returning markup.

### DIFF
--- a/src/Utils/Utils.vala
+++ b/src/Utils/Utils.vala
@@ -132,9 +132,16 @@ public class Utils {
             }
         }
 
-        // remaining < & > tags are translated
-        markup = markup.replace ("<", "&lt;");
-        markup = markup.replace (">", "&gt;");
+        Regex hrefs = new Regex("href='(.+?)'>");
+        markup = hrefs.replace_eval(markup, -1, 0, 0, (match_info, result) => {
+            var str = match_info.fetch(1);
+
+            str = str.replace("href='", "");
+            str = str.substring(0, -3);
+            
+            result.append("href='%s'>".printf(Markup.escape_text(str)));
+            return false;
+        });
 
         // Preserve hyperlinks
         markup = markup.replace ("?a?", "<a");


### PR DESCRIPTION
Resolves #494 by escaping the value of href before passing returning it. Compare screenshot below to the one in the Issue.

![vocal-no-conver-markup-fix](https://user-images.githubusercontent.com/8648705/126911091-df6eb1a9-e0c3-418d-bbb1-c8579014fb73.png)
